### PR TITLE
fix: Default is a string

### DIFF
--- a/api/home/core/SIMOS/UiRecipe.json
+++ b/api/home/core/SIMOS/UiRecipe.json
@@ -41,7 +41,7 @@
       "attributeType": "boolean",
       "type": "system/SIMOS/BlueprintAttribute",
       "optional": true,
-      "default": false
+      "default": "false"
     },
     {
       "type": "system/SIMOS/BlueprintAttribute",


### PR DESCRIPTION
## What does this pull request change?
The `default` attribute is defined to be a string.

## Why is this pull request needed?

## Issues related to this change:
