### PR TITLE
demo for dataSource with azure_blob storage

### DIFF
--- a/api/core/enums.py
+++ b/api/core/enums.py
@@ -39,8 +39,9 @@ class RepositoryType(Enum):
 
 class StorageDataTypes(Enum):
     DEFAULT = "default"
-    SMALL = "small"
     LARGE = "large"
+    VERY_LARGE = "veryLarge"
+    VIDEO = "video"
     BLOB = "blob"
 
 

--- a/api/home/blueprints/CarPackage/engine/EngineUncontainedFuelPump.json
+++ b/api/home/blueprints/CarPackage/engine/EngineUncontainedFuelPump.json
@@ -1,0 +1,112 @@
+{
+  "name": "EngineUncontainedFuelPump",
+  "type": "system/SIMOS/Blueprint",
+  "description": "This describes an engine",
+  "attributes": [
+    {
+      "type": "system/SIMOS/BlueprintAttribute",
+      "name": "name",
+      "attributeType": "string"
+    }, {
+      "type": "system/SIMOS/BlueprintAttribute",
+      "name": "type",
+      "attributeType": "string"
+    }, {
+      "type": "system/SIMOS/BlueprintAttribute",
+      "name": "description",
+      "attributeType": "string"
+    }, {
+      "type": "system/SIMOS/BlueprintAttribute",
+      "name": "power",
+      "attributeType": "string"
+    }, {
+      "type": "system/SIMOS/BlueprintAttribute",
+      "name": "value1",
+      "description": "data points.",
+      "attributeType": "number",
+      "dimensions": "*",
+      "default": "[2,3,4]",
+      "optional": false,
+      "contained": true
+    }, {
+      "type": "system/SIMOS/BlueprintAttribute",
+      "name": "value2",
+      "description": "more data points.",
+      "attributeType": "number",
+      "dimensions": "*",
+      "optional": false,
+      "contained": true
+    }, {
+      "type": "system/SIMOS/BlueprintAttribute",
+      "name": "fuelPump",
+      "attributeType": "SSR-DataSource/CarPackage/engine/FuelPump"
+    }
+  ],
+  "storageRecipes": [
+    {
+      "name": "default",
+      "type": "system/SIMOS/StorageRecipe",
+      "description": "",
+      "attributes": [
+        {
+          "type": "system/SIMOS/StorageAttribute",
+          "name": "fuelPump",
+          "contained": false,
+          "storageTypeAffinity": "blob",
+          "description": ""
+        }
+      ]
+    }
+  ],
+  "uiRecipes": [
+    {
+      "name": "EnginePlot",
+      "type": "system/SIMOS/UiRecipe",
+      "description": "",
+      "plugin": "PLOT",
+      "options": [],
+      "attributes": [
+        {
+          "name": "name",
+          "type": "system/SIMOS/UiAttribute",
+          "mapping": "title",
+          "options": []
+        }, {
+          "name": "value1",
+          "type": "system/SIMOS/UiAttribute",
+          "mapping": "line",
+          "options": []
+        }, {
+          "name": "value2",
+          "type": "system/SIMOS/UiAttribute",
+          "mapping": "line",
+          "options": []
+        }
+      ]
+    }, {
+      "name": "EngineTable",
+      "type": "system/SIMOS/UiRecipe",
+      "description": "",
+      "plugin": "TABLE",
+      "options": [],
+      "attributes": [
+        {
+          "name": "name",
+          "type": "system/SIMOS/UiAttribute",
+          "mapping": "title",
+          "options": []
+        }, {
+          "name": "value1",
+          "type": "system/SIMOS/UiAttribute",
+          "mapping": "column",
+          "options": []
+        }, {
+          "name": "value2",
+          "type": "system/SIMOS/UiAttribute",
+          "mapping": "column",
+          "options": []
+        }
+      ]
+    }
+  ]
+}

--- a/api/home/data_sources/local-entities.json
+++ b/api/home/data_sources/local-entities.json
@@ -12,17 +12,25 @@
       "database": "local",
       "collection": "entities"
     },
-    "blob_storage": {
-      "dataTypes": ["blob"],
+    "video_storage": {
+      "dataTypes": ["video"],
       "type": "mongo-db",
       "host": "db",
       "port": 27017,
       "username": "maf",
       "password": "maf",
       "tls": false,
-      "name": "blob_storage",
+      "name": "video_storage",
       "database": "local",
-      "collection": "blob_storage"
+      "collection": "videos"
+    },
+    "azure_blob": {
+      "dataTypes": ["blob"],
+      "type": "azure-blob-storage",
+      "account_name": "dmssfilestorage",
+      "account_key": "REPLACE_ME",
+      "name": "azure_blob",
+      "collection": "dmss"
     }
   }
 }


### PR DESCRIPTION
## What does this pull request change?
* Adds a AzureBlob repo in the demo "entitites" dataSource
* Adds a Engine Blueprint with a storageAttribute to store the fuelPump in Blob

## Why is this pull request needed?
* Showcase different storage backends

## Issues related to this change:
#41 