### PR TITLE
wipe ALL databases

### DIFF
--- a/src/controllers/package_controller.py
+++ b/src/controllers/package_controller.py
@@ -29,5 +29,5 @@ def find_by_name(data_source_id: str, name: str):
         {"type": "system/SIMOS/Package", "isRoot": True, "name": name}
     )
     if not package:
-        raise FileNotFoundException(data_source_id, name, is_root=True)
+        raise FileNotFoundException(data_source_id, name)
     return JSONResponse(package.to_dict()["data"])

--- a/src/services/document_service.py
+++ b/src/services/document_service.py
@@ -204,7 +204,7 @@ class DocumentService:
             {"type": "system/SIMOS/Package", "isRoot": True, "name": package_name}
         )
         if not package:
-            raise FileNotFoundException(data_source_id, package_name, is_root=True)
+            raise FileNotFoundException(data_source_id, package_name)
 
         complete_document = get_complete_document(
             package.uid, self.repository_provider(data_source_id), self.get_blueprint

--- a/src/tests/bdd/document/update.feature
+++ b/src/tests/bdd/document/update.feature
@@ -333,7 +333,6 @@ Feature: Document 2
 
   Scenario: Update document (attribute and not contained)
     Given i access the resource url "/api/v1/documents/data-source-name/6?attribute=itemNotContained"
-    And data modelling tool templates are imported
     When i make a "PUT" request
     """
     {

--- a/src/utils/exceptions.py
+++ b/src/utils/exceptions.py
@@ -8,8 +8,8 @@ class RepositoryException(Exception):
 
 
 class EntityAlreadyExistsException(RepositoryException):
-    def __init__(self, document_id):
-        super().__init__(message=f"The document, with id {document_id} already exists")
+    def __init__(self, document_id=None, message: str = None):
+        super().__init__(message=f"The document, with id {document_id} already exists" if not message else message)
 
 
 class EntityNotFoundException(RepositoryException):
@@ -47,22 +47,21 @@ class RootPackageNotFoundException(Exception):
 
     def __str__(self):
         if self.data_source_id and self.file:
-            return f"RootPackageNotFoundException, data_source: {self.data_source_id} file: {self.file}"
+            return f"No root package with name '{self.file}', in data source '{self.data_source_id}' could be found."
         else:
-            return "RootPackageNotFoundException has been raised"
+            return "The root package could not be found"
 
 
 class FileNotFoundException(Exception):
-    def __init__(self, data_source_id=None, file=None, is_root=False):
+    def __init__(self, data_source_id=None, file=None):
         self.data_source_id = data_source_id if data_source_id else None
         self.file = file if file else None
-        self.is_root = is_root
 
     def __str__(self):
         if self.data_source_id and self.file:
-            return f"FileNotFoundException, data_source: {self.data_source_id} file: {self.file}"
+            return f"No file with name '{self.file}', in data source '{self.data_source_id}' could be found."
         else:
-            return "FileNotFoundException has been raised"
+            return "The file could not be found in the data source"
 
 
 class DuplicateFileNameException(Exception):
@@ -72,6 +71,8 @@ class DuplicateFileNameException(Exception):
 
     def __str__(self):
         if self.data_source_id and self.path:
-            return f"DuplicateFileNameInPackageException, '{self.data_source_id}/{self.path}' already exists"
+            return f"'{self.data_source_id}/{self.path}' already exists"
         else:
-            return "DuplicateFileNameInPackageException has been raised"
+            return (
+                "Can't create the requested document, one with the same name within the same package already exists."
+            )

--- a/src/utils/wipe_db.py
+++ b/src/utils/wipe_db.py
@@ -1,17 +1,9 @@
-from config import Config
 from services.database import dmt_database
 
 
 def wipe_db():
     print("Dropping all collections")
     # FIXME: Read names from the database
-    for name in [
-        Config.BLUEPRINT_COLLECTION,
-        Config.ENTITY_COLLECTION,
-        Config.SYSTEM_COLLECTION,
-        "documents",
-        "fs.chunks",
-        "fs.files",
-    ]:
+    for name in dmt_database.list_collection_names():
         print(f"Dropping collection '{name}'")
         dmt_database.drop_collection(name)


### PR DESCRIPTION
## What does this pull request change?
- Use pymongo to list all collections and delete those in wipe_db()

## Why is this pull request needed?
- The application repository was not being deleted, and to we got multiple DMT packages, and so we failed to delete them when resetting the DMT applications.

## Issues related to this change: