### PR TITLE
add widget field on extends attribute

### DIFF
--- a/src/home/system/SIMOS/Blueprint.json
+++ b/src/home/system/SIMOS/Blueprint.json
@@ -98,6 +98,11 @@
           "contained": false
         },
         {
+          "name": "extends",
+          "type": "system/SIMOS/UiAttribute",
+          "contained": false
+        },
+        {
           "name": "storageRecipes",
           "type": "system/SIMOS/UiAttribute",
           "dimensions": "*",


### PR DESCRIPTION
## What does this pull request change?
- Associate the blueprint widget to the "extends" attribute.

## Why is this pull request needed?
So you don't have to type blueprint references

## Issues related to this change:
