### PR TITLE
add reference switch in 'update_document()'

### DIFF
--- a/src/controllers/document_controller.py
+++ b/src/controllers/document_controller.py
@@ -55,9 +55,13 @@ def get_by_path(
 
 
 @router.put("/documents/{data_source_id}/{document_id}", operation_id="document_update")
-def update(data_source_id: str, document_id: str, data: dict, attribute: Optional[str] = None):
+def update(
+    data_source_id: str, document_id: str, data: dict, attribute: Optional[str] = None, reference: bool = False
+):
     update_use_case = UpdateDocumentUseCase()
     response = update_use_case.execute(
-        UpdateDocumentRequest(data_source_id=data_source_id, data=data, document_id=document_id, attribute=attribute)
+        UpdateDocumentRequest(
+            data_source_id=data_source_id, data=data, document_id=document_id, attribute=attribute, reference=reference
+        )
     )
     return JSONResponse(response.value, status_code=STATUS_CODES[response.type])

--- a/src/use_case/update_document_use_case.py
+++ b/src/use_case/update_document_use_case.py
@@ -11,6 +11,7 @@ class UpdateDocumentRequest(DataSource):
     document_id: str
     data: dict
     attribute: Optional[str] = None
+    reference: bool = False
 
 
 class UpdateDocumentUseCase(UseCase):
@@ -24,6 +25,7 @@ class UpdateDocumentUseCase(UseCase):
             document_id=req.document_id,
             data=req.data,
             attribute_path=req.attribute,
+            reference=req.reference,
         )
         document_service.invalidate_cache()
         return ResponseSuccess(document)


### PR DESCRIPTION
## What does this pull request change?
- Add a bool switch to "DocumentService().update() to handle the request data as a reference (should be added to the parent as is, without updating the child)

## Why is this pull request needed?
updateDocument() was too clever, and tried to update the referenced document, instead of just the document where it was being referenced from.
