### PR TITLE
quickfix: update datasource name for widget enum

### DIFF
--- a/src/home/system/SIMOS/UiAttribute.json
+++ b/src/home/system/SIMOS/UiAttribute.json
@@ -59,7 +59,7 @@
       "name": "widget",
       "description": "Widget for this property",
       "optional": true,
-      "enumType": "DMT-DS/DMT/plugins/ui/edit/WidgetEnum",
+      "enumType": "DMT-Internal/DMT/plugins/ui/edit/WidgetEnum",
       "default": ""
     },
     {


### PR DESCRIPTION
## What does this pull request change?
quick fix: update datasource name
## Why is this pull request needed?
bug when viewing the edit tab for a UI plugin
## Issues related to this change:
closes #110 
