### PR TITLE
Inherit acl

### DIFF
--- a/src/authentication/access_control.py
+++ b/src/authentication/access_control.py
@@ -33,6 +33,8 @@ class AccessLevel(Enum):
 
     @classmethod
     def validate(cls, v):
+        if isinstance(v, cls):
+            return v
         try:
             return cls[v]
         except KeyError:

--- a/src/domain_classes/tree_node.py
+++ b/src/domain_classes/tree_node.py
@@ -281,7 +281,7 @@ class NodeBase:
             return self.uid
         if self.contained and not self.storage_contained and not self.is_array():
             return self.uid
-        return ".".join(self.path() + [self.key])
+        return ".".join((self.parent.node_id, self.key))
 
     def path(self):
         path = []

--- a/src/services/document_service.py
+++ b/src/services/document_service.py
@@ -194,7 +194,8 @@ class DocumentService:
             # Expand this when adding new repositories requiring PATH
             if isinstance(repository, ZipFileClient):
                 dto.data["__path__"] = path
-            repository.update(dto, node.get_context_storage_attribute())
+            parent_uid = node.parent.node_id if node.parent else None
+            repository.update(dto, node.get_context_storage_attribute(), parent_id=parent_uid)
             return {"_id": node.uid, "type": node.entity["type"], "name": node.name}
         return ref_dict
 

--- a/src/storage/internal/data_source_repository.py
+++ b/src/storage/internal/data_source_repository.py
@@ -2,6 +2,7 @@ from typing import List, Dict
 
 from pymongo.errors import DuplicateKeyError
 
+from authentication.access_control import access_control, AccessLevel, ACL
 from enums import RepositoryType
 from services.database import data_source_collection
 from restful.request_types.create_data_source import DataSourceRequest
@@ -75,6 +76,11 @@ class DataSourceRepository:
         if not data_source:
             raise DataSourceNotFoundException(id)
         return DataSource.from_dict(data_source)
+
+    def update_access_control(self, data_source_id: str, acl: ACL) -> None:
+        data_source: DataSource = self.get(data_source_id)
+        access_control(data_source.acl, AccessLevel.WRITE)
+        data_source_collection.update_one(filter={"_id": data_source.name}, update={"$set": {"acl": acl.dict()}})
 
 
 def get_data_source(data_source_id: str) -> DataSource:

--- a/src/storage/repositories/zip.py
+++ b/src/storage/repositories/zip.py
@@ -11,7 +11,7 @@ class ZipFileClient(RepositoryInterface):
     def __init__(self, zip_file: ZipFile):
         self.zip_file = zip_file
 
-    def update(self, dto: DTO, storage_recipe=None):
+    def update(self, dto: DTO, storage_recipe=None, **kwargs):
         dto.data.pop("_id", None)
         dto.data.pop("uid", None)
         write_to = f"{dto.data['__path__']}/{dto.name}.json"

--- a/src/tests/bdd/access_control.feature
+++ b/src/tests/bdd/access_control.feature
@@ -294,3 +294,38 @@ Feature: Access Control
     "message": "MissingPrivilegeException: The requested operation requires 'READ' privileges"
     }
     """
+
+  Scenario: Add file - not contained - inherit ACL
+    Given there exist document with id "2" in data source "test-DS"
+    """
+    {
+        "name": "root_package",
+        "description": "",
+        "type": "system/SIMOS/Package",
+        "isRoot": true,
+        "content": []
+    }
+    """
+    Given AccessControlList for document "2" in data-source "test-DS" is
+    """
+    {
+      "owner": "johndoe",
+      "roles": {"someRole": "WRITE", "someOtherRole": "READ"},
+      "users": {"per": "WRITE", "pål": "READ"},
+      "others": "NONE"
+    }
+    """
+    Given the logged in user is "johndoe" with roles "a"
+    Given authentication is enabled
+    Given i access the resource url "/api/v1/explorer/test-DS/add-to-parent"
+    When i make a "POST" request
+    """
+    {
+      "_id": "3",
+      "name": "new_document",
+      "parentId": "2",
+      "type": "system/SIMOS/Blueprint",
+      "attribute": "content"
+    }
+    """
+    Then the response status should be "OK"

--- a/src/tests/bdd/explorer/add_file.feature
+++ b/src/tests/bdd/explorer/add_file.feature
@@ -4,15 +4,15 @@ Feature: Explorer - Add file
     Given the system data source and SIMOS core package are available
     Given there are data sources
       | name             |
-      | data-source-name |
+      | test-DS |
 
     Given there are repositories in the data sources
-      | data-source      | host | port  | username | password | tls   | name      | database | collection | type     | dataTypes |
-      | data-source-name | db   | 27017 | maf      | maf      | false | repo1     |  bdd-test    | documents  | mongo-db | default   |
-      | data-source-name | db   | 27017 | maf      | maf      | false | blob-repo |  bdd-test    | test       | mongo-db | blob      |
+      | data-source | host | port  | username | password | tls   | name      | database  | collection | type     | dataTypes |
+      | test-DS     | db   | 27017 | maf      | maf      | false | repo1     |  bdd-test | documents  | mongo-db | default   |
+      | test-DS     | db   | 27017 | maf      | maf      | false | blob-repo |  bdd-test | test       | mongo-db | blob      |
 
 
-    Given there exist document with id "1" in data source "data-source-name"
+    Given there exist document with id "1" in data source "test-DS"
     """
     {
         "name": "root_package",
@@ -43,7 +43,7 @@ Feature: Explorer - Add file
             {
                 "_id": "6",
                 "name": "parentEntity",
-                "type": "data-source-name/root_package/Parent"
+                "type": "test-DS/root_package/Parent"
             },
             {
                 "_id": "7",
@@ -53,7 +53,7 @@ Feature: Explorer - Add file
         ]
     }
     """
-    Given there exist document with id "2" in data source "data-source-name"
+    Given there exist document with id "2" in data source "test-DS"
     """
     {
       "type": "system/SIMOS/Blueprint",
@@ -88,7 +88,7 @@ Feature: Explorer - Add file
         },
         {
           "name": "pdf_container",
-          "attributeType": "data-source-name/root_package/MultiplePdfContainer",
+          "attributeType": "test-DS/root_package/MultiplePdfContainer",
           "type": "system/SIMOS/BlueprintAttribute",
           "optional": true
         }
@@ -96,7 +96,7 @@ Feature: Explorer - Add file
     }
     """
 
-    Given there exist document with id "3" in data source "data-source-name"
+    Given there exist document with id "3" in data source "test-DS"
     """
     {
       "type": "system/SIMOS/Blueprint",
@@ -114,7 +114,7 @@ Feature: Explorer - Add file
     """
 
 
-    Given there exist document with id "4" in data source "data-source-name"
+    Given there exist document with id "4" in data source "test-DS"
     """
     {
       "type": "system/SIMOS/Blueprint",
@@ -124,7 +124,7 @@ Feature: Explorer - Add file
       "attributes": [
         {
         "name": "SomeChild",
-        "attributeType": "data-source-name/root_package/BaseChild",
+        "attributeType": "test-DS/root_package/BaseChild",
         "type": "system/SIMOS/BlueprintAttribute",
         "optional": true
         }
@@ -132,13 +132,13 @@ Feature: Explorer - Add file
     }
     """
 
-    Given there exist document with id "5" in data source "data-source-name"
+    Given there exist document with id "5" in data source "test-DS"
     """
     {
       "type": "system/SIMOS/Blueprint",
       "name": "SpecialChild",
       "description": "",
-      "extends": ["data-source-name/root_package/BaseChild"],
+      "extends": ["test-DS/root_package/BaseChild"],
       "attributes": [
         {
           "name": "AnExtraValue",
@@ -147,7 +147,7 @@ Feature: Explorer - Add file
         },
         {
           "name": "Hobbies",
-          "attributeType": "data-source-name/root_package/Hobby",
+          "attributeType": "test-DS/root_package/Hobby",
           "type": "system/SIMOS/BlueprintAttribute",
           "optional": true,
           "dimensions": "*"
@@ -157,17 +157,17 @@ Feature: Explorer - Add file
     """
 
 
-  Given there exist document with id "6" in data source "data-source-name"
+  Given there exist document with id "6" in data source "test-DS"
     """
     {
-      "type": "data-source-name/root_package/Parent",
+      "type": "test-DS/root_package/Parent",
       "name": "parentEntity",
       "description": "",
       "SomeChild": {}
     }
     """
 
-  Given there exist document with id "7" in data source "data-source-name"
+  Given there exist document with id "7" in data source "test-DS"
     """
     {
       "type": "system/SIMOS/Blueprint",
@@ -184,23 +184,21 @@ Feature: Explorer - Add file
     }
     """
 
-
-
   Scenario: Add file - attribute for parentEntity
-    Given i access the resource url "/api/v1/explorer/data-source-name/add-to-parent"
+    Given i access the resource url "/api/v1/explorer/test-DS/add-to-parent"
     When i make a "POST" request
     """
     {
       "name": "baseChildInParentEntity",
       "parentId": "6",
-      "type": "data-source-name/root_package/BaseChild",
+      "type": "test-DS/root_package/BaseChild",
       "attribute": "SomeChild",
       "description": "base child in parent",
       "AValue": 0
     }
     """
     Then the response status should be "OK"
-    Given I access the resource url "/api/v1/documents/data-source-name/6"
+    Given I access the resource url "/api/v1/documents/test-DS/6"
     When I make a "GET" request
     Then the response status should be "OK"
     And the response should contain
@@ -210,12 +208,12 @@ Feature: Explorer - Add file
       {
           "_id": "6",
           "name": "parentEntity",
-          "type": "data-source-name/root_package/Parent",
+          "type": "test-DS/root_package/Parent",
           "description": "",
           "SomeChild":
           {
             "name": "baseChildInParentEntity",
-            "type": "data-source-name/root_package/BaseChild",
+            "type": "test-DS/root_package/BaseChild",
             "description": "base child in parent",
             "AValue": 0
           }
@@ -224,20 +222,20 @@ Feature: Explorer - Add file
     """
 
   Scenario: Add file with wrong subtype to parent entity
-    Given i access the resource url "/api/v1/explorer/data-source-name/add-to-parent"
+    Given i access the resource url "/api/v1/explorer/test-DS/add-to-parent"
     When i make a "POST" request
     """
     {
       "name": "hobbynumber1",
       "parentId": "6",
-      "type": "data-source-name/root_package/Hobby",
+      "type": "test-DS/root_package/Hobby",
       "attribute": "SomeChild",
       "description": "example hobby",
       "difficulty": "high"
     }
     """
     Then the response status should be "System Error"
-    Given I access the resource url "/api/v1/documents/data-source-name/6"
+    Given I access the resource url "/api/v1/documents/test-DS/6"
     When I make a "GET" request
     Then the response status should be "OK"
     And the response should contain
@@ -247,22 +245,21 @@ Feature: Explorer - Add file
       {
           "_id": "6",
           "name": "parentEntity",
-          "type": "data-source-name/root_package/Parent",
+          "type": "test-DS/root_package/Parent",
           "description": "",
           "SomeChild": {}
       }
     }
     """
 
-
   Scenario: Add file with an extended type to parent entity
-    Given i access the resource url "/api/v1/explorer/data-source-name/add-to-parent"
+    Given i access the resource url "/api/v1/explorer/test-DS/add-to-parent"
     When i make a "POST" request
     """
     {
       "name": "specialChild",
       "parentId": "6",
-      "type": "data-source-name/root_package/SpecialChild",
+      "type": "test-DS/root_package/SpecialChild",
       "attribute": "SomeChild",
       "description": "specialized child",
       "AValue": 39,
@@ -270,7 +267,7 @@ Feature: Explorer - Add file
       "Hobbies": [
         {
           "name": "Football",
-          "type": "data-source-name/root_package/Hobby",
+          "type": "test-DS/root_package/Hobby",
           "description": "sport",
           "difficulty": "high"
         }
@@ -278,7 +275,7 @@ Feature: Explorer - Add file
     }
     """
     Then the response status should be "OK"
-    Given I access the resource url "/api/v1/documents/data-source-name/6"
+    Given I access the resource url "/api/v1/documents/test-DS/6"
     When I make a "GET" request
     Then the response status should be "OK"
     And the response should contain
@@ -288,12 +285,12 @@ Feature: Explorer - Add file
       {
           "_id": "6",
           "name": "parentEntity",
-          "type": "data-source-name/root_package/Parent",
+          "type": "test-DS/root_package/Parent",
           "description": "",
           "SomeChild":
           {
             "name": "specialChild",
-            "type": "data-source-name/root_package/SpecialChild",
+            "type": "test-DS/root_package/SpecialChild",
             "description": "specialized child",
             "AValue": 0,
             "AnExtraValue": ""
@@ -303,7 +300,7 @@ Feature: Explorer - Add file
     """
 
   Scenario: Add file - not contained
-    Given i access the resource url "/api/v1/explorer/data-source-name/add-to-parent"
+    Given i access the resource url "/api/v1/explorer/test-DS/add-to-parent"
     When i make a "POST" request
     """
     {
@@ -314,7 +311,7 @@ Feature: Explorer - Add file
     }
     """
     Then the response status should be "OK"
-    Given I access the resource url "/api/v1/documents/data-source-name/1"
+    Given I access the resource url "/api/v1/documents/test-DS/1"
     When I make a "GET" request
     Then the response status should be "OK"
     And the response should contain
@@ -355,10 +352,9 @@ Feature: Explorer - Add file
     }
     """
 
-
   @skip
   Scenario: Add file with missing parameter name should fail
-    Given i access the resource url "/api/v1/explorer/data-source-name/add-to-parent"
+    Given i access the resource url "/api/v1/explorer/test-DS/add-to-parent"
     When i make a "POST" request
     """
     {
@@ -374,7 +370,7 @@ Feature: Explorer - Add file
 
   @skip
   Scenario: Add file with missing parameters should fail
-    Given i access the resource url "/api/v1/explorer/data-source-name/add-to-parent"
+    Given i access the resource url "/api/v1/explorer/test-DS/add-to-parent"
     When i make a "POST" request
     """
     {}
@@ -389,7 +385,7 @@ Feature: Explorer - Add file
     """
 
   Scenario: Add file to parent that does not exists
-    Given i access the resource url "/api/v1/explorer/data-source-name/add-to-parent"
+    Given i access the resource url "/api/v1/explorer/test-DS/add-to-parent"
     When i make a "POST" request
     """
     {
@@ -402,18 +398,47 @@ Feature: Explorer - Add file
     Then the response status should be "Not Found"
     And the response should equal
     """
-    {"type": "RESOURCE_ERROR", "message": "EntityNotFoundException: Document with id '-1' was not found in the 'data-source-name' data-source"}
+    {"type": "RESOURCE_ERROR", "message": "EntityNotFoundException: Document with id '-1' was not found in the 'test-DS' data-source"}
+    """
+
+  Scenario: Add file to parent with missing permissions on parent
+    Given AccessControlList for document "1" in data-source "test-DS" is
+    """
+    {
+      "owner": "someoneElse",
+      "others": "READ"
+    }
+    """
+    Given the logged in user is "johndoe" with roles "a"
+    Given authentication is enabled
+    Given i access the resource url "/api/v1/explorer/test-DS/add-to-parent"
+    When i make a "POST" request
+    """
+    {
+      "name": "new_document",
+      "parentId": "1",
+      "type": "system/SIMOS/Blueprint",
+      "attribute": "content"
+    }
+    """
+    Then the response status should be "Forbidden"
+    And the response should equal
+    """
+    {
+    "type": "FORBIDDEN",
+    "message": "MissingPrivilegeException: The requested operation requires 'WRITE' privileges"
+    }
     """
 
   Scenario: Add file with multiple PDFs
-    Given i access the resource url "/api/v1/explorer/data-source-name/add-to-path"
+    Given i access the resource url "/api/v1/explorer/test-DS/add-to-path"
     When i make a "POST" request with "4" files
     """
     {
       "directory": "/root_package/",
       "document": {
         "name": "new_pdf_container",
-        "type": "data-source-name/root_package/MultiplePdfContainer",
+        "type": "test-DS/root_package/MultiplePdfContainer",
         "description": "",
         "a_pdf": {
           "name": "MyPDF1",
@@ -431,7 +456,7 @@ Feature: Explorer - Add file
         },
         "pdf_container": {
           "name": "second_pdf_container",
-          "type": "data-source-name/root_package/MultiplePdfContainer",
+          "type": "test-DS/root_package/MultiplePdfContainer",
           "description": "",
           "a_pdf": {
             "name": "MyPDF3",

--- a/src/tests/bdd/export_package.feature
+++ b/src/tests/bdd/export_package.feature
@@ -6,10 +6,10 @@ Feature: Exporting root packages
       | test-DS |
 
     Given there are documents for the data source "test-DS" in collection "test-DS"
-      | uid                                  | parent_uid                           | name          | type                   |
-      | 1 |                                      | blueprints    | system/SIMOS/Package   |
-      | 2 | 1 | sub_package_1 | system/SIMOS/Package   |
-      | 3 | 2 | document_1    | system/SIMOS/Blueprint |
+      | uid | parent_uid | name          | type                   |
+      | 1   |            | blueprints    | system/SIMOS/Package   |
+      | 2   | 1          | sub_package_1 | system/SIMOS/Package   |
+      | 3   | 2          | document_1    | system/SIMOS/Blueprint |
 
 
   Scenario: A user want's to export a root package

--- a/src/tests/bdd/steps/domain.py
+++ b/src/tests/bdd/steps/domain.py
@@ -8,6 +8,7 @@ from domain_classes.tree_node import ListNode, Node
 from enums import DMT, SIMOS
 from services.document_service import DocumentService
 from storage.internal.data_source_repository import get_data_source
+from storage.internal.data_source_repository import DataSourceRepository
 from utils.create_entity import CreateEntity
 
 document_service = DocumentService(get_data_source)
@@ -96,3 +97,9 @@ def step_impl_documents(context, data_source_id: str, collection: str):
 def step_impl(context, document_id, data_source):
     acl = ACL(**json.loads(context.text))
     document_service.repository_provider(data_source).update_access_control(document_id, acl)
+
+
+@given('AccessControlList for data-source "{data_source}" is')
+def step_impl(context, data_source):
+    acl = ACL(**json.loads(context.text))
+    DataSourceRepository().update_access_control(data_source, acl)

--- a/src/tests/bdd/steps/schemas.py
+++ b/src/tests/bdd/steps/schemas.py
@@ -14,7 +14,7 @@ from utils.package_import import import_package
 def step_impl_2(context, uid: str, data_source_id: str):
     document: DTO = DTO(uid=uid, data=json.loads(context.text))
     document_repository = get_data_source(data_source_id)
-    document_repository.add(document)
+    document_repository.update(document)
 
 
 @given("the system data source and SIMOS core package are available")

--- a/src/tests/unit/test_complex_arrays.py
+++ b/src/tests/unit/test_complex_arrays.py
@@ -120,7 +120,7 @@ class ArraysDocumentServiceTestCase(unittest.TestCase):
         def mock_get(document_id: str):
             return DTO(doc_storage[document_id])
 
-        def mock_update(dto: DTO, storage_attribute):
+        def mock_update(dto: DTO, *args, **kwargs):
             doc_storage[dto.uid] = dto.data
 
         document_repository = mock.Mock()
@@ -271,7 +271,7 @@ class ArraysDocumentServiceTestCase(unittest.TestCase):
         def mock_get(document_id: str):
             return DTO(doc_storage[document_id])
 
-        def mock_update(dto: DTO, storage_attribute):
+        def mock_update(dto: DTO, *args, **kwargs):
             doc_storage[dto.uid] = dto.data
 
         document_repository = mock.Mock()

--- a/src/tests/unit/test_get_extended.py
+++ b/src/tests/unit/test_get_extended.py
@@ -63,7 +63,7 @@ class GetExtendedBlueprintTestCase(unittest.TestCase):
             "a_third_value": "amanothastring",
         }
 
-        def mock_update(dto: DTO, storage_attribute):
+        def mock_update(dto: DTO, *args, **kwargs):
             doc_storage[dto.uid] = dto.data
 
         repository.get = lambda doc_id: DTO(doc_storage[doc_id])

--- a/src/tests/unit/test_reference.py
+++ b/src/tests/unit/test_reference.py
@@ -30,7 +30,7 @@ class ReferenceTestCase(unittest.TestCase):
             },
         }
 
-        def mock_update(dto: DTO, storage_attribute):
+        def mock_update(dto: DTO, *args, **kwargs):
             doc_storage[dto.uid] = dto.data
             return None
 
@@ -73,7 +73,7 @@ class ReferenceTestCase(unittest.TestCase):
             except KeyError:
                 raise EntityNotFoundException(f"{document_id} was not found in the 'test' data-sources lookupTable")
 
-        def mock_update(dto: DTO, storage_attribute):
+        def mock_update(dto: DTO, *args, **kwargs):
             doc_storage[dto.uid] = dto.data
             return None
 
@@ -113,7 +113,7 @@ class ReferenceTestCase(unittest.TestCase):
             },
         }
 
-        def mock_update(dto: DTO, storage_attribute):
+        def mock_update(dto: DTO, *args, **kwargs):
             doc_storage[dto.uid] = dto.data
 
         repository.get = lambda x: DTO(doc_storage[str(x)])
@@ -154,7 +154,7 @@ class ReferenceTestCase(unittest.TestCase):
         def mock_get(document_id: str):
             return DTO(doc_storage[str(document_id)])
 
-        def mock_update(dto: DTO, storage_attribute):
+        def mock_update(dto: DTO, *args, **kwargs):
             doc_storage[dto.uid] = dto.data
             return None
 
@@ -200,7 +200,7 @@ class ReferenceTestCase(unittest.TestCase):
         def mock_get(document_id: str):
             return DTO(doc_storage[document_id])
 
-        def mock_update(dto: DTO, storage_attribute):
+        def mock_update(dto: DTO, *args, **kwargs):
             doc_storage[dto.uid] = dto.data
             return None
 
@@ -237,7 +237,7 @@ class ReferenceTestCase(unittest.TestCase):
             "something": {"_id": "something", "name": "something", "description": "", "type": "blueprint_2",},
         }
 
-        def mock_update(dto: DTO, storage_attribute):
+        def mock_update(dto: DTO, *args, **kwargs):
             doc_storage[dto.uid] = dto.data
             return None
 
@@ -276,7 +276,7 @@ class ReferenceTestCase(unittest.TestCase):
             "something": {"_id": "something", "name": "something", "description": "", "type": "blueprint_2",},
         }
 
-        def mock_update(dto: DTO, storage_attribute):
+        def mock_update(dto: DTO, *args, **kwargs):
             doc_storage[dto.uid] = dto.data
             return None
 
@@ -317,9 +317,8 @@ class ReferenceTestCase(unittest.TestCase):
             },
         }
 
-        def mock_update(dto: DTO, *args):
+        def mock_update(dto: DTO, *args, **kwargs):
             doc_storage[dto.uid] = dto.data
-            return None
 
         repository.get = lambda x: DTO(doc_storage[str(x)])
         repository.update = mock_update
@@ -362,9 +361,8 @@ class ReferenceTestCase(unittest.TestCase):
             },
         }
 
-        def mock_update(dto: DTO, *args):
+        def mock_update(dto: DTO, *args, **kwargs):
             doc_storage[dto.uid] = dto.data
-            return None
 
         repository.get = lambda x: DTO(doc_storage[str(x)])
         repository.update = mock_update

--- a/src/tests/unit/test_remove.py
+++ b/src/tests/unit/test_remove.py
@@ -39,7 +39,7 @@ class DocumentServiceTestCase(unittest.TestCase):
         def mock_get(document_id: str):
             return DTO(doc_storage[document_id])
 
-        def mock_update(dto: DTO, storage_attribute):
+        def mock_update(dto: DTO, *args, **kwargs):
             doc_storage[dto.uid] = dto.data
 
         def mock_delete(document_id: str):
@@ -147,7 +147,7 @@ class DocumentServiceTestCase(unittest.TestCase):
         def mock_get(document_id: str):
             return DTO(doc_storage[document_id])
 
-        def mock_update(dto: DTO, storage_attribute):
+        def mock_update(dto: DTO, *args, **kwargs):
             doc_storage[dto.uid] = dto.data
             return None
 

--- a/src/tests/unit/test_rename.py
+++ b/src/tests/unit/test_rename.py
@@ -27,7 +27,7 @@ class DocumentServiceTestCase(unittest.TestCase):
                 return DTO(data=doc_storage["1"])
             return None
 
-        def mock_update(dto: DTO, storage_attribute):
+        def mock_update(dto: DTO, *args, **kwargs):
             doc_storage[dto.uid] = dto.data
 
         document_repository.get = mock_get
@@ -66,7 +66,7 @@ class DocumentServiceTestCase(unittest.TestCase):
                 return DTO(data=doc_storage["1"].copy())
             return None
 
-        def mock_update(dto: DTO, storage_attribute):
+        def mock_update(dto: DTO, *args, **kwargs):
             doc_storage[dto.uid] = dto.data
 
         document_repository.get = mock_get
@@ -102,7 +102,7 @@ class DocumentServiceTestCase(unittest.TestCase):
         def mock_get(document_id: str):
             return DTO(doc_storage[document_id])
 
-        def mock_update(dto: DTO, storage_attribute):
+        def mock_update(dto: DTO, *args, **kwargs):
             doc_storage[dto.uid] = dto.data
 
         document_repository.get = mock_get
@@ -140,7 +140,7 @@ class DocumentServiceTestCase(unittest.TestCase):
         def mock_get(document_id: str):
             return DTO(doc_storage[document_id])
 
-        def mock_update(dto: DTO, storage_attribute):
+        def mock_update(dto: DTO, *args, **kwargs):
             doc_storage[dto.uid] = dto.data
 
         document_repository.get = mock_get

--- a/src/tests/unit/test_save.py
+++ b/src/tests/unit/test_save.py
@@ -33,7 +33,7 @@ class DocumentServiceTestCase(unittest.TestCase):
         def mock_get(document_id: str):
             return DTO(doc_storage[document_id])
 
-        def mock_update(dto: DTO, storage_attribute):
+        def mock_update(dto: DTO, *args, **kwargs):
             doc_storage[dto.uid] = dto.data
             return None
 
@@ -61,7 +61,7 @@ class DocumentServiceTestCase(unittest.TestCase):
         def mock_get(document_id: str):
             return DTO(doc_storage[document_id])
 
-        def mock_update(dto: DTO, storage_attribute):
+        def mock_update(dto: DTO, *args, **kwargs):
             doc_storage[dto.uid] = dto.data
             return None
 
@@ -123,7 +123,7 @@ class DocumentServiceTestCase(unittest.TestCase):
         def mock_get(document_id: str):
             return DTO(doc_storage[document_id])
 
-        def mock_update(dto: DTO, storage_attribute):
+        def mock_update(dto: DTO, *args, **kwargs):
             doc_storage[dto.uid] = dto.data
             return None
 
@@ -175,9 +175,8 @@ class DocumentServiceTestCase(unittest.TestCase):
             },
         }
 
-        def mock_update(dto: DTO, *args):
+        def mock_update(dto: DTO, *args, **kwargs):
             doc_storage[dto.uid] = dto.data
-            return None
 
         repository.get = lambda id: DTO(doc_storage[id])
         repository.update = mock_update

--- a/src/tests/unit/test_tree_node_update.py
+++ b/src/tests/unit/test_tree_node_update.py
@@ -136,7 +136,7 @@ class DocumentServiceTestCase(unittest.TestCase):
         def mock_get(document_id: str):
             return DTO(doc_storage[document_id])
 
-        def mock_update(dto: DTO, storage_attribute):
+        def mock_update(dto: DTO, *args, **kwargs):
             doc_storage[dto.uid] = dto.data
             return None
 
@@ -188,7 +188,7 @@ class DocumentServiceTestCase(unittest.TestCase):
         def mock_get(document_id: str):
             return DTO(doc_storage[document_id])
 
-        def mock_update(dto: DTO, storage_attribute):
+        def mock_update(dto: DTO, *args, **kwargs):
             doc_storage[dto.uid] = dto.data
             return None
 
@@ -267,7 +267,7 @@ class DocumentServiceTestCase(unittest.TestCase):
         def mock_get(document_id: str):
             return DTO(doc_storage[document_id])
 
-        def mock_update(dto: DTO, storage_attribute):
+        def mock_update(dto: DTO, *args, **kwargs):
             doc_storage[dto.uid] = dto.data
             return None
 
@@ -302,7 +302,7 @@ class DocumentServiceTestCase(unittest.TestCase):
         def mock_get(document_id: str):
             return DTO(doc_storage[document_id])
 
-        def mock_update(dto: DTO, storage_attribute):
+        def mock_update(dto: DTO, *args, **kwargs):
             doc_storage[dto.uid] = dto.data
             return None
 
@@ -323,9 +323,8 @@ class DocumentServiceTestCase(unittest.TestCase):
         def mock_get(document_id: str):
             return DTO(doc_storage[document_id])
 
-        def mock_update(dto: DTO, *args):
+        def mock_update(dto: DTO, *args, **kwargs):
             doc_storage[dto.uid] = dto.data
-            return None
 
         repository.get = mock_get
         repository.update = mock_update
@@ -352,9 +351,8 @@ class DocumentServiceTestCase(unittest.TestCase):
         def mock_get(document_id: str):
             return DTO(doc_storage[document_id])
 
-        def mock_update(dto: DTO, *args):
+        def mock_update(dto: DTO, *args, **kwargs):
             doc_storage[dto.uid] = dto.data
-            return None
 
         repository.get = mock_get
         repository.update = mock_update
@@ -389,9 +387,8 @@ class DocumentServiceTestCase(unittest.TestCase):
         def mock_get(document_id: str):
             return DTO(doc_storage[document_id])
 
-        def mock_update(dto: DTO, *args):
+        def mock_update(dto: DTO, *args, **kwargs):
             doc_storage[dto.uid] = dto.data
-            return None
 
         repository.get = mock_get
         repository.update = mock_update
@@ -432,9 +429,8 @@ class DocumentServiceTestCase(unittest.TestCase):
         def mock_get(document_id: str):
             return DTO(doc_storage[document_id])
 
-        def mock_update(dto: DTO, *args):
+        def mock_update(dto: DTO, *args, **kwargs):
             doc_storage[dto.uid] = dto.data
-            return None
 
         repository.get = mock_get
         repository.update = mock_update

--- a/src/use_case/add_raw.py
+++ b/src/use_case/add_raw.py
@@ -18,7 +18,7 @@ class AddRawUseCase(UseCase):
         new_node_id = req.document.dict(by_alias=True).get("_id", str(uuid4()))
         document: DTO = DTO(uid=new_node_id, data=req.document.dict())
         document_repository = get_data_source(req.data_source_id)
-        document_repository.add(document)
+        document_repository.update(document)
         if document.type == SIMOS.BLUEPRINT.value:
             DocumentService().invalidate_cache()
         return res.ResponseSuccess(new_node_id)

--- a/src/use_case/move_file_use_case.py
+++ b/src/use_case/move_file_use_case.py
@@ -51,7 +51,7 @@ class MoveFileUseCase(UseCase):
         data = source_document.data
         data["name"] = destination.name
         destination_document = DTO(uid=source_document.uid, data=data)
-        destination_document_repository.add(destination_document)
+        destination_document_repository.update(destination_document)
         logger.info(f"Added document '{destination_document.uid}' to data source '{destination_data_source_uid}")
 
         # Update parent(s)

--- a/src/utils/package_import.py
+++ b/src/utils/package_import.py
@@ -21,7 +21,7 @@ def _add_documents(path, documents, data_source) -> List[Dict]:
         document = DTO(data)
         if not url_safe_name(document.name):
             raise InvalidDocumentNameException(document.name)
-        data_source.add(document)
+        data_source.update(document)
         docs.append({"_id": document.uid, "name": document.name, "type": document.type})
 
     return docs
@@ -54,6 +54,6 @@ def import_package(path, data_source: str, is_root: bool = False) -> Union[Dict]
         package["content"].append(import_package(f"{path}/{folder}", is_root=False, data_source=data_source.name))
 
     package = DTO(package)
-    data_source.add(package)
+    data_source.update(package)
     logger.info(f"Imported package {package.name}")
     return {"_id": package.uid, "name": package.name, "type": package.type}


### PR DESCRIPTION
## What does this pull request change?
- DataSource.update() now takes a kwarg "parent_id". Used to lookup parent ACL for access control and ACL inheritance.
- DataSource has a new attribute "acl". Used to set default acl, and control who can create root packages.
- Node.node_id() now only builds dotted path up to the first "self_contained" document.

## Why is this pull request needed?
- Newely created files should inherit ACL from parent.
- Files without parents (root-packages) needs some kind if access control

## Issues related to this change:
closes #121 