### PR TITLE
change default ACL. others=READ

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -6,8 +6,8 @@ import uvicorn
 from fastapi import APIRouter, FastAPI, Security
 from starlette.requests import Request
 
-from authentication.authentication import get_current_user
-import authentication
+from authentication import authentication
+from authentication.authentication import get_current_user, User
 from config import config
 from controllers import (
     blob_controller,
@@ -124,6 +124,10 @@ def nuke_db():
 @cli.command()
 @click.pass_context
 def reset_app(context):
+    # Running commands locally sets the user_context to "DMSS_ADMIN"
+    authentication.user_context = User(
+        **{"username": config.DMSS_ADMIN, "full_name": "Local Admin", "email": "admin@example.com"}
+    )
     context.invoke(nuke_db)
     logger.info("CREATING SYSTEM DATA SOURCE")
     context.invoke(import_data_source, file="/code/home/system/data_sources/system.json")

--- a/src/authentication/authentication.py
+++ b/src/authentication/authentication.py
@@ -8,7 +8,6 @@ from jose import jwt, JWTError
 from pydantic import BaseModel
 from starlette import status
 
-from authentication.mock_users import fake_users_db
 from config import config
 from utils.logging import logger
 
@@ -52,7 +51,9 @@ def fetch_openid_configuration() -> dict:
 async def get_current_user(token: str = Security(oauth2_scheme) if config.AUTH_ENABLED else None) -> User:
     global user_context
     if not config.AUTH_ENABLED:
-        user_context = User(**fake_users_db["nologin"])
+        user_context = User(
+            **{"username": "nologin", "full_name": "Not Authenticated", "email": "nologin@example.com"}
+        )
         return user_context
     oid_config = fetch_openid_configuration()
     try:

--- a/src/authentication/mock_users.py
+++ b/src/authentication/mock_users.py
@@ -1,9 +1,0 @@
-fake_users_db = {
-    "johndoe": {"username": "johndoe", "full_name": "John Doe", "email": "johndoe@example.com"},
-    "4417e9ce-d9eb-41b9-b5a0-b887d6215b1f": {
-        "username": "hermes",
-        "full_name": "Hermes Athen",
-        "email": "hermes@example.com",
-    },
-    "nologin": {"username": "nologin", "full_name": "Not Authenticated", "email": "nologin@example.com"},
-}

--- a/src/storage/data_source_class.py
+++ b/src/storage/data_source_class.py
@@ -24,8 +24,8 @@ class DataSource:
         self, name: str, acl: ACL = DEFAULT_ACL, repositories=None, data_source_collection=data_source_collection,
     ):
         self.name = name
-        # This ACL is used when there is no parent document to read ACL from. Controls who can create root-packages,
-        # and which ACL imported files will get.
+
+        # This ACL is used when there is no parent to inherit ACL from. Controls who can create root-packages.
         self.acl = acl
         self.repositories: Dict[str, Repository] = repositories
         self.data_source_collection = data_source_collection

--- a/src/tests/bdd/authentication/create_entity_with_user_as_owner.feature
+++ b/src/tests/bdd/authentication/create_entity_with_user_as_owner.feature
@@ -8,7 +8,7 @@ Feature: Set logged in user as owner when creating an entity
 
   Scenario: create entity with add_by_parent_id endpoint
       Given authentication is enabled
-      Given the logged in user is "johndoe" with roles "a"
+      Given the logged in user is "johndoe" with roles "dmss-admin"
       Given there exist document with id "2" in data source "test-DS"
       """
       {
@@ -35,14 +35,14 @@ Feature: Set logged in user as owner when creating an entity
           "owner": "johndoe",
           "roles": {"dmss-admin": "WRITE"},
           "users": {},
-          "others": "WRITE"
+          "others": "READ"
       }
       """
 
 
   Scenario: create entity with add_raw endpoint
       Given authentication is enabled
-      Given the logged in user is "johndoe" with roles "a"
+      Given the logged in user is "johndoe" with roles "dmss-admin"
       Given there exist document with id "2" in data source "test-DS"
       """
       {
@@ -69,14 +69,14 @@ Feature: Set logged in user as owner when creating an entity
           "owner": "johndoe",
           "roles": {"dmss-admin": "WRITE"},
           "users": {},
-          "others": "WRITE"
+          "others": "READ"
       }
       """
 
 
     Scenario: create package with add_package endpoint
       Given authentication is enabled
-      Given the logged in user is "johndoe" with roles "a"
+      Given the logged in user is "johndoe" with roles "dmss-admin"
       Given there exist document with id "2" in data source "test-DS"
       """
       {
@@ -106,7 +106,7 @@ Feature: Set logged in user as owner when creating an entity
           "owner": "johndoe",
           "roles": {"dmss-admin": "WRITE"},
           "users": {},
-          "others": "WRITE"
+          "others": "READ"
       }
       """
 

--- a/src/tests/bdd/authentication/set_access_control_list.feature
+++ b/src/tests/bdd/authentication/set_access_control_list.feature
@@ -46,6 +46,7 @@ Feature: Set Access Control List
     "OK"
     """
     Then I access the resource url "/api/v1/acl/test-DS/1"
+    Given the logged in user is "johndoe" with roles "a,b"
     When I make a "GET" request
     Then the response status should be "OK"
     And the response should contain
@@ -86,6 +87,7 @@ Feature: Set Access Control List
     }
     """
     Then I access the resource url "/api/v1/acl/test-DS/1"
+    Given the logged in user is "johndoe" with roles "a,b"
     When I make a "GET" request
     Then the response status should be "OK"
     And the response should contain
@@ -106,6 +108,7 @@ Feature: Set Access Control List
     Given the logged in user is "johndoe" with roles "a,b"
     Given authentication is enabled
     Given I access the resource url "/api/v1/acl/test-DS/1"
+    Given the logged in user is "johndoe" with roles "a,b"
     When I make a "GET" request
     Then the response status should be "Forbidden"
     And the response should contain

--- a/src/utils/encryption.py
+++ b/src/utils/encryption.py
@@ -24,6 +24,8 @@ def encrypt(message: str) -> str:
 
 
 def decrypt(token: str) -> str:
+    if not token:
+        return ""
     key_loaded()
     fernet = Fernet(config.SECRET_KEY)
     token_as_bytes = token.encode()


### PR DESCRIPTION
## What does this pull request change?
- Change default ACL from others=write to others=read
- One must now have the "dmss-admin" role for modifying dataSources and creating rootPackages

## Why is this pull request needed?
- Not everyone should be able to change all data


## Issues related to this change:
closes #143 
