### PR TITLE
optionally not update uncontained documents

### DIFF
--- a/src/controllers/document_controller.py
+++ b/src/controllers/document_controller.py
@@ -59,11 +59,17 @@ def update(
     data: Json = Form(...),
     attribute: Optional[str] = Form(None),
     files: Optional[List[UploadFile]] = File(None),
+    update_uncontained: Optional[bool] = True,
 ):
     update_use_case = UpdateDocumentUseCase()
     response = update_use_case.execute(
         UpdateDocumentRequest(
-            data_source_id=data_source_id, data=data, document_id=document_id, attribute=attribute, files=files
+            data_source_id=data_source_id,
+            data=data,
+            document_id=document_id,
+            attribute=attribute,
+            files=files,
+            update_uncontained=update_uncontained,
         )
     )
     return JSONResponse(response.value, status_code=STATUS_CODES[response.type])

--- a/src/services/document_service.py
+++ b/src/services/document_service.py
@@ -70,7 +70,14 @@ class DocumentService:
 
         return node.entity
 
-    def save(self, node: Union[Node, ListNode], data_source_id: str, repository=None, path="") -> Dict:
+    def save(
+        self,
+        node: Union[Node, ListNode],
+        data_source_id: str,
+        repository=None,
+        path="",
+        update_uncontained: bool = True,
+    ) -> Dict:
         """
         Recursively saves a Node.
         Digs down to the leaf child, and based on storageContained,
@@ -86,11 +93,12 @@ class DocumentService:
         if node.type == DMT.PACKAGE.value:
             path = f"{path}/{node.name}/" if path else f"{node.name}"
 
-        for child in node.children:
-            if child.is_array():
-                [self.save(x, data_source_id, repository, path) for x in child.children]
-            else:
-                self.save(child, data_source_id, repository, path)
+        if update_uncontained:  # If flag is set, dig down and save uncontained documents
+            for child in node.children:
+                if child.is_array():
+                    [self.save(x, data_source_id, repository, path) for x in child.children]
+                else:
+                    self.save(child, data_source_id, repository, path)
 
         if node.type == SIMOS.BLOB.value:
             node.entity = self.save_blob_data(node, repository)
@@ -182,6 +190,7 @@ class DocumentService:
         data: Union[dict, list],
         attribute_path: str = None,
         files: dict = None,
+        update_uncontained: bool = True,
     ):
         root: Node = self.get_by_uid(data_source_id, document_id)
         target_node = root
@@ -193,7 +202,7 @@ class DocumentService:
         target_node.update(data)
         if files:
             self._merge_entity_and_files(target_node, files)
-        self.save(root, data_source_id)
+        self.save(root, data_source_id, update_uncontained=update_uncontained)
 
         logger.info(f"Updated document '{target_node.node_id}''")
         return {"data": target_node.to_dict()}

--- a/src/tests/unit/test_save.py
+++ b/src/tests/unit/test_save.py
@@ -201,3 +201,68 @@ class DocumentServiceTestCase(unittest.TestCase):
         target_node.update(doc_storage["3"])
         document_service.save(node, "testing")
         assert doc_storage["1"]["i_have_a_uncontained_attribute"]["uncontained_in_every_way"]["_id"] == "3"
+
+    def test_save_no_overwrite_uncontained_document(self):
+        repository = mock.Mock()
+
+        doc_storage = {
+            "1": {
+                "_id": "1",
+                "name": "Root",
+                "description": "I'm the root document",
+                "type": "blueprint_with_second_level_nested_uncontained_attribute",
+                "i_have_a_uncontained_attribute": {
+                    "type": "uncontained_blueprint",
+                    "name": "first",
+                    "description": "I'm the first nested document, contained",
+                    "uncontained_in_every_way": {
+                        "_id": "2",
+                        "name": "im_a_uncontained_attribute",
+                        "type": "blueprint_2",
+                        "contained": False,
+                    },
+                },
+            },
+            "2": {
+                "_id": "2",
+                "name": "im_a_uncontained_attribute",
+                "type": "blueprint_2",
+                "description": "I'm the second nested document, uncontained",
+            },
+        }
+
+        def mock_update(dto: DTO, *args, **kwargs):
+            doc_storage[dto.uid] = dto.data
+
+        repository.get = lambda id: DTO(doc_storage[id])
+        repository.update = mock_update
+
+        document_service = DocumentService(
+            blueprint_provider=blueprint_provider, repository_provider=lambda x: repository
+        )
+
+        document_service.update_document(
+            "test",
+            "1",
+            {
+                "_id": "1",
+                "name": "Root",
+                "description": "I'm the root document",
+                "type": "blueprint_with_second_level_nested_uncontained_attribute",
+                "i_have_a_uncontained_attribute": {
+                    "type": "uncontained_blueprint",
+                    "name": "first",
+                    "description": "This has changed!",
+                    "uncontained_in_every_way": {
+                        "_id": "2",
+                        "name": "im_a_uncontained_attribute",
+                        "type": "blueprint_2",
+                        "contained": False,
+                    },
+                },
+            },
+            update_uncontained=False,
+        )
+        # Test that the "2" document has not been overwritten
+        assert doc_storage["2"].get("description")
+        assert doc_storage["1"]["i_have_a_uncontained_attribute"]["description"] == "This has changed!"

--- a/src/use_case/update_document_use_case.py
+++ b/src/use_case/update_document_use_case.py
@@ -14,6 +14,7 @@ class UpdateDocumentRequest(DataSource):
     data: Union[dict, list]
     attribute: Optional[str] = None
     files: Optional[List[UploadFile]] = File(None)
+    update_uncontained: Optional[bool] = True
 
 
 class UpdateDocumentUseCase(UseCase):
@@ -28,6 +29,7 @@ class UpdateDocumentUseCase(UseCase):
             data=req.data,
             attribute_path=req.attribute,
             files={f.filename: f.file for f in req.files} if req.files else None,
+            update_uncontained=req.update_uncontained,
         )
         document_service.invalidate_cache()
         return ResponseSuccess(document)


### PR DESCRIPTION
## What does this pull request change?
- New flag to the "updateDocument()" endpoint , optionally update uncontained children

## Why is this pull request needed?
- Should be possible to update a document without passing along every uncontained child

closes #159 
