### PR TITLE
default update_uncontained=False

### DIFF
--- a/src/controllers/document_controller.py
+++ b/src/controllers/document_controller.py
@@ -68,7 +68,7 @@ def update(
     data: Json = Form(...),
     attribute: Optional[str] = Form(None),
     files: Optional[List[UploadFile]] = File(None),
-    update_uncontained: Optional[bool] = True,
+    update_uncontained: Optional[bool] = False,
     user: User = Depends(get_current_user),
 ):
     update_use_case = UpdateDocumentUseCase(user)

--- a/src/tests/bdd/authentication/create_entity_with_user_as_owner.feature
+++ b/src/tests/bdd/authentication/create_entity_with_user_as_owner.feature
@@ -19,7 +19,7 @@ Feature: Set logged in user as owner when creating an entity
       """
       Given the logged in user is "johndoe" with roles "dmss-admin"
       Given authentication is enabled
-      Given i access the resource url "/api/v1/explorer/test-DS/2.content"
+      Given i access the resource url "/api/v1/explorer/test-DS/2.content?update_uncontained=True"
       When i make a "POST" request
       """
       {

--- a/src/tests/bdd/explorer/add_file.feature
+++ b/src/tests/bdd/explorer/add_file.feature
@@ -315,7 +315,7 @@ Feature: Explorer - Add file
     """
 
   Scenario: Add file - not contained
-    Given i access the resource url "/api/v1/explorer/test-DS/1.content"
+    Given i access the resource url "/api/v1/explorer/test-DS/1.content?update_uncontained=True"
     When i make a "POST" request
     """
     {
@@ -464,7 +464,7 @@ Feature: Explorer - Add file
 
 
   Scenario: Add Parent entity without a name attribute with add-to-path endpoint
-    Given i access the resource url "/api/v1/explorer/test-DS/add-to-path"
+    Given i access the resource url "/api/v1/explorer/test-DS/add-to-path?update_uncontained=True"
     When i make a "POST" request with "1" files
     """
     {
@@ -486,7 +486,7 @@ Feature: Explorer - Add file
     """
 
   Scenario: Add Comment entity without a name attribute with add-to-path endpoint
-    Given i access the resource url "/api/v1/explorer/test-DS/add-to-path"
+    Given i access the resource url "/api/v1/explorer/test-DS/add-to-path?update_uncontained=True"
     When i make a "POST" request with "1" files
     """
     {
@@ -502,7 +502,7 @@ Feature: Explorer - Add file
     Then the response status should be "OK"
 
   Scenario: Add blueprint without a name attribute with add-to-path endpoint should fail
-    Given i access the resource url "/api/v1/explorer/test-DS/add-to-path"
+    Given i access the resource url "/api/v1/explorer/test-DS/add-to-path?update_uncontained=True"
     When i make a "POST" request with "1" files
     """
     {
@@ -524,7 +524,7 @@ Feature: Explorer - Add file
     """
 
   Scenario: Add package without a name attribute with add-to-path endpoint should fail
-    Given i access the resource url "/api/v1/explorer/test-DS/add-to-path"
+    Given i access the resource url "/api/v1/explorer/test-DS/add-to-path?update_uncontained=True"
     When i make a "POST" request with "1" files
     """
     {
@@ -548,7 +548,7 @@ Feature: Explorer - Add file
 
 
   Scenario: Add parent entity without a name attribute with add_by_parent_id endpoint
-    Given i access the resource url "/api/v1/explorer/test-DS/1.content"
+    Given i access the resource url "/api/v1/explorer/test-DS/1.content?update_uncontained=True"
     When i make a "POST" request
     """
     {
@@ -566,7 +566,7 @@ Feature: Explorer - Add file
     """
 
   Scenario: Add comment entity without a name attribute with add_by_parent_id endpoint
-    Given i access the resource url "/api/v1/explorer/test-DS/1.content"
+    Given i access the resource url "/api/v1/explorer/test-DS/1.content?update_uncontained=True"
     When i make a "POST" request
     """
     {
@@ -615,7 +615,7 @@ Feature: Explorer - Add file
     """
 
   Scenario: Add file with multiple PDFs
-    Given i access the resource url "/api/v1/explorer/test-DS/add-to-path"
+    Given i access the resource url "/api/v1/explorer/test-DS/add-to-path?update_uncontained=True"
     When i make a "POST" request with "4" files
     """
     {

--- a/src/tests/bdd/steps/domain.py
+++ b/src/tests/bdd/steps/domain.py
@@ -85,7 +85,7 @@ def step_impl_documents(context, data_source_id: str, collection: str):
     document_service = DocumentService(get_data_source, user=context.user)
     tree: Node = generate_tree(data_source_id, context.table, document_service)
     tree.show_tree()
-    document_service.save(node=tree, data_source_id=data_source_id)
+    document_service.save(node=tree, data_source_id=data_source_id, update_uncontained=True)
 
 
 @given('AccessControlList for document "{document_id}" in data-source "{data_source}" is')

--- a/src/tests/unit/test_data_source_and_repositories.py
+++ b/src/tests/unit/test_data_source_and_repositories.py
@@ -73,7 +73,7 @@ class DataSourceTestCase(unittest.TestCase):
 
         node: Node = Node.from_dict(uncontained_doc, "1", document_service.get_blueprint)
 
-        document_service.save(node, "testing")
+        document_service.save(node, "testing", update_uncontained=True)
 
         # Test that both repos get's written into
         assert blob_doc_storage and default_doc_storage
@@ -194,7 +194,7 @@ class DataSourceTestCase(unittest.TestCase):
 
         node: Node = Node.from_dict(blob_doc, "1", document_service.get_blueprint)
 
-        document_service.save(node, "testing")
+        document_service.save(node, "testing", update_uncontained=True)
 
         # Test that both repos get's written into
         assert blob_doc_storage and default_doc_storage

--- a/src/tests/unit/test_save.py
+++ b/src/tests/unit/test_save.py
@@ -200,7 +200,7 @@ class DocumentServiceTestCase(unittest.TestCase):
         )
 
         node: Node = Node.from_dict(doc_storage["1"], "1", document_service.get_blueprint)
-        document_service.save(node, "testing")
+        document_service.save(node, "testing", update_uncontained=True)
 
         assert doc_storage["2"]["description"] == "I'm the second nested document, uncontained"
         assert (


### PR DESCRIPTION
## What does this pull request change?
- Change the default update_uncontained strategy to "Don't do that", as this seems to be the most natural way.

## Issues related to this change:
None, but will fix a few bugs in FoR where uncontained entities gets overwritten (result gets deleted on every update).
