### PR TITLE
Support absolute document ref in document_id parameter

### DIFF
--- a/src/controllers/document_controller.py
+++ b/src/controllers/document_controller.py
@@ -26,13 +26,20 @@ def get_by_id(
     depth: conint(gt=-1, lt=1000) = 999,
     user: User = Depends(get_current_user),
 ):
+    # Allow specification of absolute document ref in document_id
+    id_list = document_id.split(".", 1)
+    if len(id_list) >= 2 and attribute:
+        raise ValueError(
+            "An attribute was specified in both the 'attribute' parameter and the 'document_id' parameter."
+            "Please provide a single attribute specification."
+        )
     use_case = GetDocumentUseCase(user)
     response: GetDocumentResponse = use_case.execute(
         GetDocumentRequest(
             data_source_id=data_source_id,
-            document_id=document_id,
+            document_id=id_list[0],
             ui_recipe=ui_recipe,
-            attribute=attribute,
+            attribute=attribute if len(id_list) == 1 else id_list[1],
             depth=depth,
         )
     )


### PR DESCRIPTION
## What does this pull request change?
- Changed parameter `document_id` in `get_by_id()` (`GET /documents/{data_source_id}/{document_id}`) to support absolute_document_ref (i.e. dotted attribute path), so that one can fetch e.g. the STask of a document with `GET /documents/ForecastDS/26a4d888-3ab4-4ad2-9bd9-9614dcb066d4.stask`
  - If the parameter `attribute` is specified while having an absolute document ref, it will now raise an error.

## Why is this pull request needed?
To support access to contained documents on the `get_by_id()` endpoint. Required in order to fetch the `STask` document in the equinor/data-modelling-tool 's `srs-wrapper/job_wrapper.py`

## Issues related to this change:
equinor/data-modelling-tool#956
equinor/data-modelling-tool#957
equinor/data-modelling-tool#959
equinor/data-modelling-tool#967
equinor/data-modelling-tool#968