### PR TITLE
Add abstract to Blueprint

### DIFF
--- a/src/domain_classes/blueprint.py
+++ b/src/domain_classes/blueprint.py
@@ -27,6 +27,7 @@ class Blueprint:
     def __init__(self, dto: DTO):
         self.name = dto.data["name"]
         self.description = dto.data.get("description", "")
+        self.abstract = dto.data.get("abstract", False)
         self.extends = dto.data.get("extends", [])
         self.type = dto.type
         self.dto = dto
@@ -63,6 +64,7 @@ class Blueprint:
             "name": self.name,
             "description": self.description,
             "type": self.type,
+            "abstract": self.abstract,
             "extends": self.extends,
             "attributes": [attribute.to_dict() for attribute in self.attributes],
             "storageRecipes": [recipe.to_dict() for recipe in self.storage_recipes],

--- a/src/home/system/SIMOS/Blueprint.json
+++ b/src/home/system/SIMOS/Blueprint.json
@@ -4,6 +4,13 @@
   "description": "This describes a blueprint",
   "attributes": [
     {
+      "attributeType": "boolean",
+      "type": "system/SIMOS/BlueprintAttribute",
+      "name": "abstract",
+      "default": false,
+      "optional": true
+    },
+    {
       "attributeType": "string",
       "type": "system/SIMOS/BlueprintAttribute",
       "name": "name"
@@ -135,6 +142,11 @@
           "contained": true
         }
       ]
+    },
+    {
+      "name": "Diagram",
+      "type": "system/SIMOS/UiRecipe",
+      "plugin": "mermaid"
     }
   ]
 }


### PR DESCRIPTION
## What does this pull request change?

* Be able to define abstract blueprints, that is blueprints that can't be instantiated. Only concrete implementations, that is, does that extends the abstract blueprints can be instantiate.

## Why is this pull request needed?

## Issues related to this change:
