### PR TITLE
updateDoc handle dotted_id

### DIFF
--- a/src/services/document_service.py
+++ b/src/services/document_service.py
@@ -34,7 +34,7 @@ from utils.get_resolved_document_by_id import get_complete_document
 from utils.get_document_by_path import get_document_uid_by_path
 from utils.logging import logger
 from utils.sort_entities_by_attribute import sort_dtos_by_attribute
-from utils.string_helpers import split_absolute_ref
+from utils.string_helpers import split_absolute_ref, split_dotted_id
 from utils.validators import entity_has_all_required_attributes
 
 pretty_printer = pprint.PrettyPrinter()
@@ -196,18 +196,18 @@ class DocumentService:
     def update_document(
         self,
         data_source_id: str,
-        document_id: str,
+        dotted_id: str,
         data: Union[dict, list],
-        attribute_path: str = None,
         files: dict = None,
         update_uncontained: bool = True,
     ):
+        document_id, attribute = split_dotted_id(dotted_id)
         root: Node = self.get_node_by_uid(data_source_id, document_id)
         target_node = root
 
         # If it's a contained nested node, set the modify target based on dotted-path
-        if attribute_path:
-            target_node = root.get_by_path(attribute_path.split("."))
+        if attribute:
+            target_node = root.get_by_path(attribute.split("."))
 
         target_node.update(data)
         if files:

--- a/src/tests/unit/test_complex_arrays.py
+++ b/src/tests/unit/test_complex_arrays.py
@@ -278,7 +278,7 @@ class ArraysDocumentServiceTestCase(unittest.TestCase):
         # fmt: off
         document_service.update_document(
             data_source_id="testing",
-            document_id="1",
+            dotted_id="1",
             data={
                 "_id": "1",
                 "name": "complexArraysEntity",

--- a/src/tests/unit/test_tree_node_update.py
+++ b/src/tests/unit/test_tree_node_update.py
@@ -259,8 +259,7 @@ class DocumentServiceTestCase(unittest.TestCase):
         with self.assertRaises(InvalidChildTypeException):
             document_service.update_document(
                 data_source_id="testing",
-                document_id="1",
-                attribute_path="SomeChild",
+                dotted_id="1.SomeChild",
                 data={"name": "whatever", "type": "special_child_no_inherit", "AnExtraValue": "Hallo there!"},
             )
         assert not doc_storage["1"]["SomeChild"]
@@ -373,8 +372,7 @@ class DocumentServiceTestCase(unittest.TestCase):
         )
         document_service.update_document(
             data_source_id="testing",
-            document_id="1",
-            attribute_path="SomeChild",
+            dotted_id="1.SomeChild",
             data={"name": "whatever", "type": "special_child", "AnExtraValue": "Hallo there!", "AValue": 13},
         )
         assert doc_storage["1"]["SomeChild"] == {
@@ -402,8 +400,7 @@ class DocumentServiceTestCase(unittest.TestCase):
         )
         document_service.update_document(
             data_source_id="testing",
-            document_id="1",
-            attribute_path="SomeChild",
+            dotted_id="1.SomeChild",
             data={
                 "name": "whatever",
                 "type": "extra_special_child",
@@ -440,8 +437,7 @@ class DocumentServiceTestCase(unittest.TestCase):
         )
         document_service.update_document(
             data_source_id="testing",
-            document_id="1",
-            attribute_path="SomeChild",
+            dotted_id="1.SomeChild",
             data=[
                 {"name": "whatever", "type": "special_child", "AnExtraValue": "Hallo there!", "AValue": 13},
                 {
@@ -486,8 +482,7 @@ class DocumentServiceTestCase(unittest.TestCase):
         with self.assertRaises(InvalidChildTypeException) as error:
             document_service.update_document(
                 data_source_id="testing",
-                document_id="1",
-                attribute_path="SomeChild",
+                dotted_id="1.SomeChild",
                 data=[
                     {"name": "whatever", "type": "special_child", "AnExtraValue": "Hallo there!", "AValue": 13},
                     {
@@ -521,7 +516,7 @@ class DocumentServiceTestCase(unittest.TestCase):
 
         document_service.update_document(
             data_source_id="testing",
-            document_id="1",
+            dotted_id="1",
             data={
                 "_id": "1",
                 "name": "parent",

--- a/src/use_case/update_document_use_case.py
+++ b/src/use_case/update_document_use_case.py
@@ -25,11 +25,17 @@ class UpdateDocumentUseCase(UseCase):
 
     def process_request(self, req: UpdateDocumentRequest):
         document_service = DocumentService(repository_provider=self.repository_provider, user=self.user)
+        if req.attribute and "." in req.document_id:
+            raise ValueError(
+                "Attribute may only be specified in ether dotted path on "
+                + "documentId or the 'attribute' query parameter"
+            )
+        attribute = req.attribute if req.attribute else ""
+        dotted_id = req.document_id + attribute
         document = document_service.update_document(
             data_source_id=req.data_source_id,
-            document_id=req.document_id,
+            dotted_id=dotted_id,
             data=req.data,
-            attribute_path=req.attribute,
             files={f.filename: f.file for f in req.files} if req.files else None,
             update_uncontained=req.update_uncontained,
         )

--- a/src/utils/string_helpers.py
+++ b/src/utils/string_helpers.py
@@ -4,16 +4,19 @@ from typing import Tuple, Union
 from enums import PrimitiveDataTypes
 
 
-def split_absolute_ref(reference: str) -> Tuple[str, str, str]:
+def split_absolute_ref(reference: str) -> Tuple[str, Union[str, None], Union[str, None]]:
     reference = reference.strip("/. ")  # Remove leading and trailing stuff
     if "/" not in reference:  # It's reference to the data_source itself
         return reference, None, None
-    data_source, dotted_path = reference.split("/", 1)
-    attribute = ""
-    path = dotted_path
-    if "." in dotted_path:  # Dotted path has a attribute reference.
-        path, attribute = dotted_path.split(".", 1)
-    return data_source, path, attribute
+    data_source, dotted_id = reference.split("/", 1)
+    document_id, attributes = split_dotted_id(dotted_id)
+    return data_source, document_id, attributes
+
+
+def split_dotted_id(dotted_id: str) -> Tuple[str, Union[str, None]]:
+    if "." not in dotted_id:  # No attribute path in the id
+        return dotted_id, None
+    return dotted_id.split(".", 1)
 
 
 def get_package_and_path(reference: str) -> Tuple[str, Union[list, None]]:


### PR DESCRIPTION
## What does this pull request change?

Makes updateDoc behave more like the other endpoints. Accepting a dotted id instead of the "attribute" parameter

