### PR TITLE
add document by path and dont update uncontained

### DIFF
--- a/src/controllers/explorer_controller.py
+++ b/src/controllers/explorer_controller.py
@@ -26,6 +26,7 @@ def add_to_path(
     document: Json = Form(...),
     directory: str = Form(...),
     files: Optional[List[UploadFile]] = File(None),
+    update_uncontained: Optional[bool] = False,
     user: User = Depends(auth_w_jwt_or_pat),
 ):
     """
@@ -35,7 +36,11 @@ def add_to_path(
     try:
         response = use_case.execute(
             AddDocumentToPathRequest(
-                data_source_id=data_source_id, document=document, directory=directory, files=files
+                data_source_id=data_source_id,
+                document=document,
+                directory=directory,
+                files=files,
+                update_uncontained=update_uncontained,
             )
         )
     except ValidationError as error:

--- a/src/domain_classes/tree_node.py
+++ b/src/domain_classes/tree_node.py
@@ -7,7 +7,7 @@ from config import config
 from domain_classes.blueprint import Blueprint
 from domain_classes.blueprint_attribute import BlueprintAttribute
 from domain_classes.storage_recipe import StorageAttribute
-from enums import DMT, StorageDataTypes
+from enums import SIMOS, StorageDataTypes
 from utils.exceptions import InvalidChildTypeException, InvalidEntityException
 from utils.logging import logger
 from utils.validators import valid_extended_type
@@ -163,7 +163,7 @@ class DictImporter:
 
                     # If the node is of type DMT/Package, we need to override the attribute_type "Entity",
                     # and get it from the child.
-                    if node.type == DMT.PACKAGE.value:
+                    if node.type == SIMOS.PACKAGE.value:
                         content_attribute: BlueprintAttribute = deepcopy(child_attribute)
                         content_attribute.attribute_type = child["type"]
                         list_child_attribute = content_attribute
@@ -252,7 +252,7 @@ class NodeBase:
 
     @property
     def storage_contained(self):
-        if not self.parent or self.parent.type == DMT.DATASOURCE.value:
+        if not self.parent or self.parent.type == SIMOS.DATASOURCE.value:
             return False
         return self.parent.blueprint.storage_recipes[0].is_contained(self.attribute.name)
 
@@ -267,7 +267,7 @@ class NodeBase:
         only contained attributes with none-contained storage return UUID,
         the rest return dotted path
         """
-        if self.type == DMT.DATASOURCE.value:
+        if self.type == SIMOS.DATASOURCE.value:
             return self.uid
         if not self.parent:
             return self.uid
@@ -514,9 +514,11 @@ class Node(NodeBase):
 
     def get_context_storage_attribute(self):
         # TODO: How to decide which storage_recipe?
-        if self.parent and self.parent.type != DMT.DATASOURCE.value:
+        if self.parent and self.parent.type != SIMOS.DATASOURCE.value:
             # The 'node.attribute.name' will be invalid for Package.content. Set it explicitly
-            nodes_attribute_on_parent = self.attribute.name if not self.parent.type == DMT.ENTITY.value else "content"
+            nodes_attribute_on_parent = (
+                self.attribute.name if not self.parent.type == SIMOS.ENTITY.value else "content"
+            )
             storage_attribute = self.parent.blueprint.storage_recipes[0].storage_attributes[nodes_attribute_on_parent]
 
             # If the attribute has default StorageAffinity in the parent, get it from the nodes own storageRecipe

--- a/src/enums.py
+++ b/src/enums.py
@@ -42,13 +42,10 @@ class StorageDataTypes(str, Enum):
 
 class SIMOS(Enum):
     BLUEPRINT = "system/SIMOS/Blueprint"
+    ENTITY = "system/SIMOS/Entity"
+    PACKAGE = "system/SIMOS/Package"
     BLUEPRINT_ATTRIBUTE = "system/SIMOS/BlueprintAttribute"
     APPLICATION = "system/SIMOS/Application"
     ATTRIBUTE_TYPES = "system/SIMOS/AttributeTypes"
     BLOB = "system/SIMOS/Blob"
-
-
-class DMT(Enum):
-    PACKAGE = "system/SIMOS/Package"
-    ENTITY = "system/SIMOS/Entity"
     DATASOURCE = "datasource"

--- a/src/storage/repositories/zip.py
+++ b/src/storage/repositories/zip.py
@@ -2,7 +2,7 @@ import json
 from zipfile import ZipFile
 
 from domain_classes.dto import DTO
-from enums import DMT
+from enums import SIMOS
 from storage.repository_interface import RepositoryInterface
 from utils.logging import logger
 
@@ -19,7 +19,7 @@ class ZipFileClient(RepositoryInterface):
         json_data = json.dumps(dto.data)
         binary_data = json_data.encode()
         logger.debug(f"Writing: {dto.type} to {write_to}")
-        if dto.type != DMT.PACKAGE.value:
+        if dto.type != SIMOS.PACKAGE.value:
             self.zip_file.writestr(write_to, binary_data)
 
     def get(self, uid: str):

--- a/src/tests/bdd/steps/domain.py
+++ b/src/tests/bdd/steps/domain.py
@@ -5,7 +5,7 @@ from behave import given, then
 from authentication.models import ACL
 from domain_classes.blueprint_attribute import BlueprintAttribute
 from domain_classes.tree_node import ListNode, Node
-from enums import DMT, SIMOS
+from enums import SIMOS, SIMOS
 from services.document_service import DocumentService
 from storage.internal.data_source_repository import get_data_source
 from storage.internal.data_source_repository import DataSourceRepository
@@ -17,17 +17,17 @@ def generate_tree_from_rows(node: Node, rows, document_service):
     if len(rows) == 0:
         return node
 
-    if node.type == DMT.PACKAGE.value:
+    if node.type == SIMOS.PACKAGE.value:
         content_node = node.search(f"{node.node_id}.content")
         # Create content not if not exists
         if not content_node:
-            data = {"name": "content", "type": DMT.PACKAGE.value, "attributeType": SIMOS.BLUEPRINT_ATTRIBUTE.value}
+            data = {"name": "content", "type": SIMOS.PACKAGE.value, "attributeType": SIMOS.BLUEPRINT_ATTRIBUTE.value}
             content_node = ListNode(
                 key="content",
                 uid="",
                 entity=data,
                 blueprint_provider=document_service.get_blueprint,
-                attribute=BlueprintAttribute(name="content", attribute_type=DMT.ENTITY.value),
+                attribute=BlueprintAttribute(name="content", attribute_type=SIMOS.ENTITY.value),
             )
             node.add_child(content_node)
     else:
@@ -50,7 +50,7 @@ def generate_tree_from_rows(node: Node, rows, document_service):
             print(f"adding {child_node.node_id} to {node.node_id}")
             content_node.add_child(child_node)
 
-            if child_node.type == DMT.PACKAGE.value:
+            if child_node.type == SIMOS.PACKAGE.value:
                 filtered = list(filter(lambda i: i["uid"] != node.uid, rows))
                 generate_tree_from_rows(child_node, filtered, document_service)
 
@@ -60,7 +60,7 @@ def generate_tree_from_rows(node: Node, rows, document_service):
 def generate_tree(data_source_id: str, table, document_service):
     root = Node(
         key=data_source_id,
-        attribute=BlueprintAttribute(name=data_source_id, attribute_type=DMT.DATASOURCE.value),
+        attribute=BlueprintAttribute(name=data_source_id, attribute_type=SIMOS.DATASOURCE.value),
         uid=data_source_id,
     )
     root_package = list(filter(lambda row: row["parent_uid"] == "", table.rows))[0]
@@ -74,7 +74,7 @@ def generate_tree(data_source_id: str, table, document_service):
         entity=root_package_data,
         blueprint_provider=document_service.get_blueprint,
         parent=root,
-        attribute=BlueprintAttribute(name="root", attribute_type=DMT.PACKAGE.value),
+        attribute=BlueprintAttribute(name="root", attribute_type=SIMOS.PACKAGE.value),
     )
     rows = list(filter(lambda row: row["parent_uid"] != "", table.rows))
     generate_tree_from_rows(root_package_node, rows, document_service)

--- a/src/tests/unit/test_complex_arrays.py
+++ b/src/tests/unit/test_complex_arrays.py
@@ -8,7 +8,7 @@ from domain_classes.dto import DTO
 from services.document_service import DocumentService
 from storage.repositories.file import LocalFileRepository
 from utils.data_structure.compare import pretty_eq
-from enums import DMT
+from enums import SIMOS
 
 package_blueprint = {
     "type": "system/SIMOS/Blueprint",
@@ -104,7 +104,7 @@ class ArraysDocumentServiceTestCase(unittest.TestCase):
                 "_id": "1",
                 "name": "Package",
                 "description": "My package",
-                "type": DMT.PACKAGE.value,
+                "type": SIMOS.PACKAGE.value,
                 "content": [],
             }
         }

--- a/src/tests/unit/test_rename.py
+++ b/src/tests/unit/test_rename.py
@@ -5,7 +5,7 @@ from authentication.models import User
 
 from domain_classes.dto import DTO
 from services.document_service import DocumentService
-from enums import DMT
+from enums import SIMOS
 from tests.unit.mock_blueprint_provider import blueprint_provider
 from utils.data_structure.compare import pretty_eq
 
@@ -60,7 +60,7 @@ class DocumentServiceTestCase(unittest.TestCase):
                 "_id": "1",
                 "name": "RootPackage",
                 "description": "My root package",
-                "type": DMT.PACKAGE.value,
+                "type": SIMOS.PACKAGE.value,
                 "isRoot": True,
                 "content": [],
             }

--- a/src/use_case/add_document_to_path_use_case.py
+++ b/src/use_case/add_document_to_path_use_case.py
@@ -15,6 +15,7 @@ class AddDocumentToPathRequest(DataSource):
     document: Entity
     directory: str
     files: Optional[List[UploadFile]] = None
+    update_uncontained: Optional[bool] = (False,)
 
     @validator("directory", always=True)
     def validate_directory(cls, value):
@@ -34,5 +35,6 @@ class AddDocumentToPathUseCase(UseCase):
             path=req.directory,
             document=request_document,
             files={f.filename: f.file for f in req.files} if req.files else None,
+            update_uncontained=req.update_uncontained,
         )
         return ResponseSuccess(document)

--- a/src/utils/package_import.py
+++ b/src/utils/package_import.py
@@ -4,7 +4,7 @@ from typing import Dict, List, Union
 
 from authentication.models import User
 from domain_classes.dto import DTO
-from enums import DMT
+from enums import SIMOS
 from storage.data_source_class import DataSource
 from storage.internal.data_source_repository import get_data_source
 from utils.exceptions import (
@@ -35,7 +35,7 @@ def _add_documents(path, documents, data_source) -> List[Dict]:
 
 def import_package(path, user: User, data_source: str, is_root: bool = False) -> Union[Dict]:
     data_source: DataSource = get_data_source(data_source_id=data_source, user=user)
-    package = {"name": os.path.basename(path), "type": DMT.PACKAGE.value, "isRoot": is_root}
+    package = {"name": os.path.basename(path), "type": SIMOS.PACKAGE.value, "isRoot": is_root}
     try:
         if get_document_by_ref(f"{data_source.name}/{package['name']}", user):
             raise EntityAlreadyExistsException(

--- a/src/utils/validators.py
+++ b/src/utils/validators.py
@@ -1,11 +1,14 @@
 from typing import Callable, List
 
 from domain_classes.blueprint_attribute import BlueprintAttribute
+from enums import SIMOS
 from utils.exceptions import ValidationException
 from utils.string_helpers import get_data_type_from_dmt_type
 
 
 def valid_extended_type(type: str, extended_types: List[str], get_blueprint: Callable) -> bool:
+    if type == SIMOS.ENTITY.value:
+        return True
     if type in extended_types:
         return True
     for inherited_type in extended_types:


### PR DESCRIPTION
## What does this pull request change?
- Fixes a bug where "validate_child_type" did not allow all types for a attribute of "system/SIMOS/Entity"
- Adds the "updateUncontained" parameter to the addByPath endpoint
- Fix a bug where references where created with the parents blueprints attribute type (instead of actual referenced entity)
- Merged the "DMT" and "SIMOS" enums (They where actually all SIMOS)