### PR TITLE
new builtin datatype 'complex'

### DIFF
--- a/src/domain_classes/blueprint.py
+++ b/src/domain_classes/blueprint.py
@@ -6,7 +6,7 @@ from domain_classes.blueprint_attribute import BlueprintAttribute
 from domain_classes.dto import DTO
 from domain_classes.storage_recipe import DefaultStorageRecipe, StorageRecipe
 from domain_classes.ui_recipe import DefaultRecipe, Recipe
-from enums import BLOB_TYPES, PRIMITIVES, StorageDataTypes
+from enums import PRIMITIVES, StorageDataTypes
 
 
 def get_storage_recipes(recipes: List[Dict], attributes: List[BlueprintAttribute]):
@@ -82,10 +82,6 @@ class Blueprint:
 
     def get_none_primitive_types(self) -> List[BlueprintAttribute]:
         blueprints = [attribute for attribute in self.attributes if attribute.attribute_type not in PRIMITIVES]
-        return blueprints
-
-    def get_blob_types(self) -> List[BlueprintAttribute]:
-        blueprints = [attribute for attribute in self.attributes if attribute.attribute_type in BLOB_TYPES]
         return blueprints
 
     def get_primitive_types(self) -> List[BlueprintAttribute]:

--- a/src/domain_classes/tree_node.py
+++ b/src/domain_classes/tree_node.py
@@ -7,7 +7,7 @@ from config import config
 from domain_classes.blueprint import Blueprint
 from domain_classes.blueprint_attribute import BlueprintAttribute
 from domain_classes.storage_recipe import StorageAttribute
-from enums import SIMOS, StorageDataTypes
+from enums import BuiltinDataTypes, SIMOS, StorageDataTypes
 from utils.exceptions import InvalidChildTypeException, InvalidEntityException
 from utils.logging import logger
 from utils.validators import valid_extended_type
@@ -517,7 +517,7 @@ class Node(NodeBase):
         if self.parent and self.parent.type != SIMOS.DATASOURCE.value:
             # The 'node.attribute.name' will be invalid for Package.content. Set it explicitly
             nodes_attribute_on_parent = (
-                self.attribute.name if not self.parent.type == SIMOS.ENTITY.value else "content"
+                self.attribute.name if not self.parent.type == BuiltinDataTypes.OBJECT.value else "content"
             )
             storage_attribute = self.parent.blueprint.storage_recipes[0].storage_attributes[nodes_attribute_on_parent]
 

--- a/src/enums.py
+++ b/src/enums.py
@@ -1,24 +1,26 @@
 from enum import Enum
 
 PRIMITIVES = {"string", "number", "integer", "boolean"}
-BLOB_TYPES = ("system/SIMOS/blob_types/PDF",)
 
 
-class PrimitiveDataTypes(Enum):
+class BuiltinDataTypes(Enum):
     STR = "string"
     NUM = "number"
     INT = "integer"
     BOOL = "boolean"
+    OBJECT = "object"  # Any complex type (i.e. any blueprint type)
 
     def to_py_type(self):
-        if self is PrimitiveDataTypes.BOOL:
+        if self is BuiltinDataTypes.BOOL:
             return bool
-        elif self is PrimitiveDataTypes.INT:
+        elif self is BuiltinDataTypes.INT:
             return int
-        elif self is PrimitiveDataTypes.NUM:
+        elif self is BuiltinDataTypes.NUM:
             return float
-        elif self is PrimitiveDataTypes.STR:
+        elif self is BuiltinDataTypes.STR:
             return str
+        elif self is BuiltinDataTypes.OBJECT:
+            return dict
 
 
 class RepositoryType(Enum):

--- a/src/home/system/SIMOS/Package.json
+++ b/src/home/system/SIMOS/Package.json
@@ -10,7 +10,7 @@
       "name": "isRoot"
     },
     {
-      "attributeType": "system/SIMOS/Entity",
+      "attributeType": "object",
       "type": "system/SIMOS/BlueprintAttribute",
       "name": "content",
       "dimensions": "*",
@@ -25,7 +25,7 @@
       "attributes": [
         {
           "name": "content",
-          "type": "system/SIMOS/Entity",
+          "type": "object",
           "contained": false
         }
       ]

--- a/src/services/document_service.py
+++ b/src/services/document_service.py
@@ -12,7 +12,7 @@ from domain_classes.blueprint import Blueprint
 from domain_classes.blueprint_attribute import BlueprintAttribute
 from domain_classes.dto import DTO
 from domain_classes.tree_node import ListNode, Node
-from enums import SIMOS
+from enums import BuiltinDataTypes, SIMOS
 from restful.request_types.shared import Entity, Reference
 from storage.data_source_class import DataSource
 from storage.internal.data_source_repository import get_data_source
@@ -270,8 +270,8 @@ class DocumentService:
             parent.add_child(new_node)
         else:
             parent.replace(new_node.node_id, new_node)
-        if new_node.parent.attribute.attribute_type != SIMOS.ENTITY.value:
-            new_node.validate_type_on_parent()
+
+        new_node.validate_type_on_parent()
 
         self.save(root, data_source, update_uncontained=update_uncontained)
 
@@ -422,7 +422,7 @@ class DocumentService:
         referenced_document: DTO = self.repository_provider(data_source_id, self.user).get(reference.uid)
         if not referenced_document:
             raise EntityNotFoundException(uid=data_source_id + reference.uid)
-        if SIMOS.ENTITY.value != attribute_node.type != referenced_document.type:
+        if BuiltinDataTypes.OBJECT.value != attribute_node.type != referenced_document.type:
             raise InvalidEntityException(
                 f"The referenced entity should be of type '{attribute_node.type}'"
                 f", but was '{referenced_document.type}'"
@@ -446,6 +446,7 @@ class DocumentService:
             attribute_node.entity = {**reference.dict(by_alias=True), "_id": str(reference.uid)}
             attribute_node.uid = str(reference.uid)
             attribute_node.type = reference.type
+
         self.save(root, data_source_id, update_uncontained=False)
 
         logger.info(

--- a/src/tests/bdd/steps/domain.py
+++ b/src/tests/bdd/steps/domain.py
@@ -5,7 +5,7 @@ from behave import given, then
 from authentication.models import ACL
 from domain_classes.blueprint_attribute import BlueprintAttribute
 from domain_classes.tree_node import ListNode, Node
-from enums import SIMOS, SIMOS
+from enums import BuiltinDataTypes, SIMOS
 from services.document_service import DocumentService
 from storage.internal.data_source_repository import get_data_source
 from storage.internal.data_source_repository import DataSourceRepository
@@ -27,7 +27,7 @@ def generate_tree_from_rows(node: Node, rows, document_service):
                 uid="",
                 entity=data,
                 blueprint_provider=document_service.get_blueprint,
-                attribute=BlueprintAttribute(name="content", attribute_type=SIMOS.ENTITY.value),
+                attribute=BlueprintAttribute(name="content", attribute_type=BuiltinDataTypes.OBJECT.value),
             )
             node.add_child(content_node)
     else:

--- a/src/tests/unit/test_complex_arrays.py
+++ b/src/tests/unit/test_complex_arrays.py
@@ -18,7 +18,7 @@ package_blueprint = {
     "attributes": [
         {"attributeType": "boolean", "type": "system/SIMOS/BlueprintAttribute", "name": "isRoot"},
         {
-            "attributeType": "system/SIMOS/Entity",
+            "attributeType": "object",
             "type": "system/SIMOS/BlueprintAttribute",
             "name": "content",
             "dimensions": "*",
@@ -30,7 +30,7 @@ package_blueprint = {
             "type": "system/SIMOS/StorageRecipe",
             "name": "DefaultStorageRecipe",
             "description": "",
-            "attributes": [{"name": "content", "type": "system/SIMOS/Entity", "contained": False}],
+            "attributes": [{"name": "content", "type": "object", "contained": False}],
         }
     ],
 }

--- a/src/tests/unit/test_create_default_array.py
+++ b/src/tests/unit/test_create_default_array.py
@@ -22,7 +22,7 @@ package_blueprint = {
         {"attributeType": "string", "type": "system/SIMOS/BlueprintAttribute", "name": "type"},
         {"attributeType": "boolean", "type": "system/SIMOS/BlueprintAttribute", "name": "isRoot"},
         {
-            "attributeType": "system/SIMOS/Entity",
+            "attributeType": "object",
             "type": "system/SIMOS/BlueprintAttribute",
             "name": "content",
             "dimensions": "*",
@@ -34,7 +34,7 @@ package_blueprint = {
             "type": "system/SIMOS/StorageRecipe",
             "name": "DefaultStorageRecipe",
             "description": "",
-            "attributes": [{"name": "content", "type": "system/SIMOS/Entity", "contained": False}],
+            "attributes": [{"name": "content", "type": "object", "contained": False}],
         }
     ],
 }

--- a/src/utils/create_entity.py
+++ b/src/utils/create_entity.py
@@ -4,7 +4,7 @@ from typing import Callable
 
 from domain_classes.blueprint import Blueprint
 from domain_classes.blueprint_attribute import BlueprintAttribute
-from enums import SIMOS, PRIMITIVES
+from enums import BuiltinDataTypes, SIMOS, PRIMITIVES
 
 
 class CreateEntityException(Exception):
@@ -23,6 +23,8 @@ class InvalidDefaultValue(CreateEntityException):
 
 class CreateEntity:
     def __init__(self, blueprint_provider: Callable, type: str):
+        if type == BuiltinDataTypes.OBJECT.value:
+            type = SIMOS.ENTITY.value
         self.type = type
         self.blueprint_provider = blueprint_provider
         self.attribute_types = self.blueprint_provider(SIMOS.ATTRIBUTE_TYPES.value).to_dict()
@@ -91,7 +93,11 @@ class CreateEntity:
                 if not attr.is_optional() and attr.name not in entity:
                     entity[attr.name] = CreateEntity.parse_value(attr=attr, blueprint_provider=self.blueprint_provider)
             else:
-                blueprint = self.blueprint_provider(attr.attribute_type)
+                blueprint = (
+                    self.blueprint_provider(attr.attribute_type)
+                    if attr.attribute_type != BuiltinDataTypes.OBJECT.value
+                    else SIMOS.ENTITY.value
+                )
                 if attr.is_array():
                     entity[attr.name] = attr.dimensions.create_default_array(self.blueprint_provider, CreateEntity)
                 else:

--- a/src/utils/string_helpers.py
+++ b/src/utils/string_helpers.py
@@ -1,7 +1,7 @@
 import re
 from typing import Tuple, Union
 
-from enums import PrimitiveDataTypes
+from enums import BuiltinDataTypes
 
 
 def split_absolute_ref(reference: str) -> Tuple[str, Union[str, None], Union[str, None]]:
@@ -30,7 +30,7 @@ def get_package_and_path(reference: str) -> Tuple[str, Union[list, None]]:
 # Convert dmt attribute_types to python types. If complex, return type as string.
 def get_data_type_from_dmt_type(attribute_type: str):
     try:
-        type_enum = PrimitiveDataTypes(attribute_type)
+        type_enum = BuiltinDataTypes(attribute_type)
         return type_enum.to_py_type()
     except ValueError:
         return attribute_type

--- a/src/utils/validators.py
+++ b/src/utils/validators.py
@@ -1,13 +1,13 @@
 from typing import Callable, List
 
 from domain_classes.blueprint_attribute import BlueprintAttribute
-from enums import SIMOS
+from enums import BuiltinDataTypes
 from utils.exceptions import ValidationException
 from utils.string_helpers import get_data_type_from_dmt_type
 
 
 def valid_extended_type(type: str, extended_types: List[str], get_blueprint: Callable) -> bool:
-    if type == SIMOS.ENTITY.value:
+    if type == BuiltinDataTypes.OBJECT.value:
         return True
     if type in extended_types:
         return True


### PR DESCRIPTION
## What does this pull request change?
- Use the keyword 'complex' as a type to allow "any blueprint type" instead of "system/SIMOS/Entity"
  - Choose 'complex' instead of 'any', as that could be understood to allow "integer", "string" etc. as well 

## Why is this pull request needed?
- More intuitive language for modelling
