### PR TITLE
Bug on recursively updating contained attributes

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -196,11 +196,11 @@ unicode_backport = ["unicodedata2"]
 
 [[package]]
 name = "click"
-version = "8.0.0"
+version = "8.1.3"
 description = "Composable command line interface toolkit"
 category = "main"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 
 [package.dependencies]
 colorama = {version = "*", markers = "platform_system == \"Windows\""}
@@ -1065,7 +1065,7 @@ python-versions = ">=3.7"
 [metadata]
 lock-version = "1.1"
 python-versions = "3.9.*"
-content-hash = "45f55fef8743d628dade5c572beda4503d6b173d345169e7c92b09899ee1bcb8"
+content-hash = "e844d557ddecff17430178341dec865f04cb7088733416ff298a86b00a8fa477"
 
 [metadata.files]
 aiofiles = [
@@ -1202,8 +1202,8 @@ charset-normalizer = [
     {file = "charset_normalizer-2.0.12-py3-none-any.whl", hash = "sha256:6881edbebdb17b39b4eaaa821b438bf6eddffb4468cf344f09f89def34a8b1df"},
 ]
 click = [
-    {file = "click-8.0.0-py3-none-any.whl", hash = "sha256:e90e62ced43dc8105fb9a26d62f0d9340b5c8db053a814e25d95c19873ae87db"},
-    {file = "click-8.0.0.tar.gz", hash = "sha256:7d8c289ee437bcb0316820ccee14aefcb056e58d31830ecab8e47eda6540e136"},
+    {file = "click-8.1.3-py3-none-any.whl", hash = "sha256:bb4d8133cb15a609f44e8213d9b391b0809795062913b383c62be0ee95b1db48"},
+    {file = "click-8.1.3.tar.gz", hash = "sha256:7682dc8afb30297001674575ea00d1814d808d6a36af415a82bd481d37ba7b8e"},
 ]
 colorama = [
     {file = "colorama-0.4.4-py2.py3-none-any.whl", hash = "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,9 @@
 [tool.poetry]
-name = "api"
+name = "Data Modeling Storage Service"
 version = "0.1.0"
-description = "API for data-modelling-tool"
+description = "A model based storage service"
 authors = ["Stig Ofstad <stoo@equinor.com>","Christoffer","Eirik"]
-license = "TBD"
+license = "MIT"
 
 [tool.poetry.dependencies]
 python = "3.9.*"
@@ -17,7 +17,7 @@ azure-storage-blob = "2.1.0"
 fastapi = "^0.75.1"
 python-multipart = "^0.0.5"
 uvicorn = {extras = ["standard"], version = "^0.15.0"}
-click = "8.0.0"
+click = "^8.0.0"
 aiofiles = "^0.7.0"
 python-jose = {extras = ["cryptography"], version = "^3.3.0"}
 cachetools = "^4.2.2"

--- a/src/restful/use_case.py
+++ b/src/restful/use_case.py
@@ -28,12 +28,12 @@ def create_error_response(
     status: int,
 ) -> JSONResponse:
     types = {
-        404: "RESOURCE_ERROR",
         400: "PARAMETERS_ERROR",
-        422: "UNPROCESSABLE_ENTITY",
-        500: "SYSTEM_ERROR",
         401: "UNAUTHORIZED",
         403: "FORBIDDEN",
+        404: "RESOURCE_ERROR",
+        422: "UNPROCESSABLE_ENTITY",
+        500: "SYSTEM_ERROR",
     }
 
     return JSONResponse({"type": types[status], "message": f"{error.__class__.__name__}: {error.message}"}, status)
@@ -58,9 +58,10 @@ class UseCase:
             ValidationError,
             ValidationException,
         ) as e:
-            logger.error(e)
+            logger.warning(e.message)
             return create_error_response(e, status.HTTP_422_UNPROCESSABLE_ENTITY)
         except MissingPrivilegeException as e:
+            logger.warning(e.message)
             return create_error_response(e, status.HTTP_403_FORBIDDEN)
         except (
             DataSourceAlreadyExistsException,
@@ -69,6 +70,7 @@ class UseCase:
             DuplicateFileNameException,
             InvalidChildTypeException,
         ) as e:
+            logger.warning(e.message)
             return create_error_response(e, status.HTTP_400_BAD_REQUEST)
         except Exception:
             traceback.print_exc()

--- a/src/tests/unit/mock_blueprint_provider.py
+++ b/src/tests/unit/mock_blueprint_provider.py
@@ -15,16 +15,16 @@ from domain_classes.blueprint import Blueprint
 from domain_classes.dto import DTO
 from storage.repositories.file import LocalFileRepository
 
-blueprint_1 = {
+all_contained_cases_blueprint = {
     "type": "system/SIMOS/Blueprint",
     "name": "Blueprint 1",
     "description": "First blueprint",
     "extends": ["system/SIMOS/NamedEntity"],
     "attributes": [
-        {"attributeType": "blueprint_2", "type": "system/SIMOS/BlueprintAttribute", "name": "nested"},
-        {"attributeType": "blueprint_2", "type": "system/SIMOS/BlueprintAttribute", "name": "reference"},
+        {"attributeType": "basic_blueprint", "type": "system/SIMOS/BlueprintAttribute", "name": "nested"},
+        {"attributeType": "basic_blueprint", "type": "system/SIMOS/BlueprintAttribute", "name": "reference"},
         {
-            "attributeType": "blueprint_2",
+            "attributeType": "basic_blueprint",
             "type": "system/SIMOS/BlueprintAttribute",
             "name": "references",
             "dimensions": "*",
@@ -50,14 +50,24 @@ blueprint_with_second_level_reference = {
     "extends": ["system/SIMOS/NamedEntity"],
     "attributes": [
         {
-            "attributeType": "blueprint_1",
+            "attributeType": "all_contained_cases_blueprint",
             "type": "system/SIMOS/BlueprintAttribute",
             "name": "contained_with_child_references",
         },
     ],
 }
 
-blueprint_2 = {
+two_contained_deep_attributes = {
+    "type": "system/SIMOS/Blueprint",
+    "name": "two_contained_deep_attributes",
+    "description": "Two contained deeply nested attributes",
+    "attributes": [
+        {"attributeType": "all_contained_cases_blueprint", "type": "system/SIMOS/BlueprintAttribute", "name": "a"},
+        {"attributeType": "all_contained_cases_blueprint", "type": "system/SIMOS/BlueprintAttribute", "name": "b"},
+    ],
+}
+
+basic_blueprint = {
     "type": "system/SIMOS/Blueprint",
     "name": "Blueprint 2",
     "description": "Second blueprint",
@@ -69,7 +79,7 @@ blueprint_2 = {
 
 extended_blueprint = {
     "type": "system/SIMOS/Blueprint",
-    "extends": ["blueprint_2"],
+    "extends": ["basic_blueprint"],
     "name": "ExtendedBlueprint",
     "description": "This Blueprint extends blueprint 2",
     "attributes": [{"attributeType": "string", "type": "system/SIMOS/BlueprintAttribute", "name": "another_value"}],
@@ -105,7 +115,7 @@ uncontained_blueprint = {
     "extends": ["system/SIMOS/NamedEntity"],
     "attributes": [
         {
-            "attributeType": "blueprint_2",
+            "attributeType": "basic_blueprint",
             "type": "system/SIMOS/BlueprintAttribute",
             "name": "uncontained_in_every_way",
             "contained": False,
@@ -135,7 +145,7 @@ uncontained_list_blueprint = {
     "extends": ["system/SIMOS/NamedEntity"],
     "attributes": [
         {
-            "attributeType": "blueprint_2",
+            "attributeType": "basic_blueprint",
             "type": "system/SIMOS/BlueprintAttribute",
             "name": "uncontained_in_every_way",
             "contained": False,
@@ -165,7 +175,7 @@ blueprint_with_optional_attr = {
     "extends": ["system/SIMOS/NamedEntity"],
     "attributes": [
         {
-            "attributeType": "blueprint_2",
+            "attributeType": "basic_blueprint",
             "type": "system/SIMOS/BlueprintAttribute",
             "name": "im_optional",
             "optional": True,
@@ -235,12 +245,14 @@ file_repository_test = LocalFileRepository()
 class BlueprintProvider:
     @staticmethod
     def get_blueprint(type: str):
-        if type == "blueprint_1":
-            return Blueprint(DTO(blueprint_1))
+        if type == "all_contained_cases_blueprint":
+            return Blueprint(DTO(all_contained_cases_blueprint))
+        if type == "basic_blueprint":
+            return Blueprint(DTO(basic_blueprint))
         if type == "blueprint_with_second_level_reference":
             return Blueprint(DTO(blueprint_with_second_level_reference))
-        if type == "blueprint_2":
-            return Blueprint(DTO(blueprint_2))
+        if type == "two_contained_deep_attributes":
+            return Blueprint(DTO(two_contained_deep_attributes))
         if type == "ExtendedBlueprint":
             return Blueprint(DTO(extended_blueprint))
         if type == "SecondLevelExtendedBlueprint":

--- a/src/tests/unit/test_data_source_and_repositories.py
+++ b/src/tests/unit/test_data_source_and_repositories.py
@@ -20,7 +20,7 @@ class DataSourceTestCase(unittest.TestCase):
             "name": "Parent",
             "description": "",
             "type": "uncontained_blueprint",
-            "uncontained_in_every_way": {"name": "a_reference", "type": "blueprint_2"},
+            "uncontained_in_every_way": {"name": "a_reference", "type": "basic_blueprint"},
         }
 
         default_doc_storage = {}

--- a/src/tests/unit/test_get.py
+++ b/src/tests/unit/test_get.py
@@ -13,18 +13,18 @@ class DocumentServiceTestCase(unittest.TestCase):
             "_id": "1",
             "name": "Parent",
             "description": "",
-            "type": "blueprint_1",
-            "nested": {"name": "Nested", "description": "", "type": "blueprint_2"},
-            "reference": {"_id": "2", "name": "Reference", "type": "blueprint_2"},
+            "type": "all_contained_cases_blueprint",
+            "nested": {"name": "Nested", "description": "", "type": "basic_blueprint"},
+            "reference": {"_id": "2", "name": "Reference", "type": "basic_blueprint"},
             "references": [
-                {"_id": "3", "name": "Reference1", "type": "blueprint_2"},
-                {"_id": "4", "name": "Reference2", "type": "blueprint_2"},
+                {"_id": "3", "name": "Reference1", "type": "basic_blueprint"},
+                {"_id": "4", "name": "Reference2", "type": "basic_blueprint"},
             ],
         }
 
-        document_2 = {"_id": "2", "name": "Reference", "description": "", "type": "blueprint_2"}
-        document_3 = {"_id": "3", "name": "Reference1", "description": "", "type": "blueprint_2"}
-        document_4 = {"_id": "4", "name": "Reference2", "description": "", "type": "blueprint_2"}
+        document_2 = {"_id": "2", "name": "Reference", "description": "", "type": "basic_blueprint"}
+        document_3 = {"_id": "3", "name": "Reference1", "description": "", "type": "basic_blueprint"}
+        document_4 = {"_id": "4", "name": "Reference2", "description": "", "type": "basic_blueprint"}
 
         def mock_get(document_id: str):
             if document_id == "1":
@@ -51,8 +51,8 @@ class DocumentServiceTestCase(unittest.TestCase):
             "_id": "1",
             "name": "Parent",
             "description": "",
-            "type": "blueprint_1",
-            "nested": {"name": "Nested", "description": "", "type": "blueprint_2"},
+            "type": "all_contained_cases_blueprint",
+            "nested": {"name": "Nested", "description": "", "type": "basic_blueprint"},
             "reference": document_2,
             "references": [document_3, document_4],
         }
@@ -68,19 +68,19 @@ class DocumentServiceTestCase(unittest.TestCase):
             "contained_with_child_references": {
                 "name": "First child",
                 "description": "",
-                "type": "blueprint_1",
-                "nested": {"name": "Nested", "description": "", "type": "blueprint_2"},
-                "reference": {"_id": "2", "name": "Reference", "type": "blueprint_2"},
+                "type": "all_contained_cases_blueprint",
+                "nested": {"name": "Nested", "description": "", "type": "basic_blueprint"},
+                "reference": {"_id": "2", "name": "Reference", "type": "basic_blueprint"},
                 "references": [
-                    {"_id": "3", "name": "Reference1", "type": "blueprint_2"},
-                    {"_id": "4", "name": "Reference2", "type": "blueprint_2"},
+                    {"_id": "3", "name": "Reference1", "type": "basic_blueprint"},
+                    {"_id": "4", "name": "Reference2", "type": "basic_blueprint"},
                 ],
             },
         }
 
-        document_2 = {"_id": "2", "name": "Reference", "description": "", "type": "blueprint_2"}
-        document_3 = {"_id": "3", "name": "Reference1", "description": "", "type": "blueprint_2"}
-        document_4 = {"_id": "4", "name": "Reference2", "description": "", "type": "blueprint_2"}
+        document_2 = {"_id": "2", "name": "Reference", "description": "", "type": "basic_blueprint"}
+        document_3 = {"_id": "3", "name": "Reference1", "description": "", "type": "basic_blueprint"}
+        document_4 = {"_id": "4", "name": "Reference2", "description": "", "type": "basic_blueprint"}
 
         def mock_get(document_id: str):
             if document_id == "1":
@@ -111,8 +111,8 @@ class DocumentServiceTestCase(unittest.TestCase):
             "contained_with_child_references": {
                 "name": "First child",
                 "description": "",
-                "type": "blueprint_1",
-                "nested": {"name": "Nested", "description": "", "type": "blueprint_2"},
+                "type": "all_contained_cases_blueprint",
+                "nested": {"name": "Nested", "description": "", "type": "basic_blueprint"},
                 "reference": document_2,
                 "references": [document_3, document_4],
             },

--- a/src/tests/unit/test_reference.py
+++ b/src/tests/unit/test_reference.py
@@ -26,7 +26,7 @@ class ReferenceTestCase(unittest.TestCase):
                 "_id": "2d7c3249-985d-43d2-83cf-a887e440825a",
                 "name": "something",
                 "description": "",
-                "type": "blueprint_2",
+                "type": "basic_blueprint",
             },
         }
 
@@ -44,7 +44,7 @@ class ReferenceTestCase(unittest.TestCase):
             "testing",
             document_id="1",
             reference=Reference.parse_obj(
-                {"_id": "2d7c3249-985d-43d2-83cf-a887e440825a", "name": "something", "type": "blueprint_2"}
+                {"_id": "2d7c3249-985d-43d2-83cf-a887e440825a", "name": "something", "type": "basic_blueprint"}
             ),
             attribute_path="uncontained_in_every_way",
         )
@@ -52,7 +52,7 @@ class ReferenceTestCase(unittest.TestCase):
             "_id": "2d7c3249-985d-43d2-83cf-a887e440825a",
             "name": "something",
             "contained": False,
-            "type": "blueprint_2",
+            "type": "basic_blueprint",
         }
 
     def test_insert_reference_target_does_not_exist(self):
@@ -148,7 +148,7 @@ class ReferenceTestCase(unittest.TestCase):
                 "_id": "2d7c3249-985d-43d2-83cf-a887e440825a",
                 "name": "something",
                 "description": "",
-                "type": "blueprint_2",
+                "type": "basic_blueprint",
             },
         }
 
@@ -172,7 +172,7 @@ class ReferenceTestCase(unittest.TestCase):
                 {
                     "_id": "2d7c3249-985d-43d2-83cf-a887e440825a",
                     "name": "something",
-                    "type": "blueprint_2",
+                    "type": "basic_blueprint",
                     "description": "hallO",
                     "something": "something",
                 }
@@ -182,7 +182,7 @@ class ReferenceTestCase(unittest.TestCase):
         assert doc_storage["1"]["uncontained_in_every_way"] == {
             "_id": "2d7c3249-985d-43d2-83cf-a887e440825a",
             "name": "something",
-            "type": "blueprint_2",
+            "type": "basic_blueprint",
             "contained": False,
         }
 
@@ -233,14 +233,14 @@ class ReferenceTestCase(unittest.TestCase):
                     "_id": "something",
                     "name": "something",
                     "description": "",
-                    "type": "blueprint_2",
+                    "type": "basic_blueprint",
                 },
             },
             "something": {
                 "_id": "something",
                 "name": "something",
                 "description": "",
-                "type": "blueprint_2",
+                "type": "basic_blueprint",
             },
         }
 
@@ -278,7 +278,7 @@ class ReferenceTestCase(unittest.TestCase):
                         "_id": "something",
                         "name": "something",
                         "description": "",
-                        "type": "blueprint_2",
+                        "type": "basic_blueprint",
                     },
                 },
             },
@@ -286,7 +286,7 @@ class ReferenceTestCase(unittest.TestCase):
                 "_id": "something",
                 "name": "something",
                 "description": "",
-                "type": "blueprint_2",
+                "type": "basic_blueprint",
             },
         }
 
@@ -320,24 +320,24 @@ class ReferenceTestCase(unittest.TestCase):
                     {
                         "_id": "2d7c3249-985d-43d2-83cf-a887e440825a",
                         "name": "something",
-                        "type": "blueprint_2",
+                        "type": "basic_blueprint",
                     },
                     {
                         "_id": "42dbe4a5-0eb0-4ee2-826c-695172c3c35a",
                         "name": "something",
-                        "type": "blueprint_2",
+                        "type": "basic_blueprint",
                     },
                 ],
             },
             "2d7c3249-985d-43d2-83cf-a887e440825a": {
                 "_id": "2d7c3249-985d-43d2-83cf-a887e440825a",
                 "name": "something",
-                "type": "blueprint_2",
+                "type": "basic_blueprint",
             },
             "42dbe4a5-0eb0-4ee2-826c-695172c3c35a": {
                 "_id": "42dbe4a5-0eb0-4ee2-826c-695172c3c35a",
                 "name": "something",
-                "type": "blueprint_2",
+                "type": "basic_blueprint",
             },
         }
 
@@ -359,7 +359,7 @@ class ReferenceTestCase(unittest.TestCase):
         assert doc_storage["1"]["uncontained_in_every_way"][0] == {
             "_id": "42dbe4a5-0eb0-4ee2-826c-695172c3c35a",
             "name": "something",
-            "type": "blueprint_2",
+            "type": "basic_blueprint",
             "contained": False,
         }
 
@@ -376,19 +376,19 @@ class ReferenceTestCase(unittest.TestCase):
                     {
                         "_id": "2d7c3249-985d-43d2-83cf-a887e440825a",
                         "name": "something",
-                        "type": "blueprint_2",
+                        "type": "basic_blueprint",
                     }
                 ],
             },
             "2d7c3249-985d-43d2-83cf-a887e440825a": {
                 "_id": "2d7c3249-985d-43d2-83cf-a887e440825a",
                 "name": "something",
-                "type": "blueprint_2",
+                "type": "basic_blueprint",
             },
             "42dbe4a5-0eb0-4ee2-826c-695172c3c35a": {
                 "_id": "42dbe4a5-0eb0-4ee2-826c-695172c3c35a",
                 "name": "something",
-                "type": "blueprint_2",
+                "type": "basic_blueprint",
             },
         }
 
@@ -404,7 +404,7 @@ class ReferenceTestCase(unittest.TestCase):
             "testing",
             document_id="1",
             reference=Reference(
-                **{"_id": "42dbe4a5-0eb0-4ee2-826c-695172c3c35a", "name": "something", "type": "blueprint_2"}
+                **{"_id": "42dbe4a5-0eb0-4ee2-826c-695172c3c35a", "name": "something", "type": "basic_blueprint"}
             ),
             attribute_path="uncontained_in_every_way",
         )
@@ -412,6 +412,6 @@ class ReferenceTestCase(unittest.TestCase):
         assert doc_storage["1"]["uncontained_in_every_way"][1] == {
             "_id": "42dbe4a5-0eb0-4ee2-826c-695172c3c35a",
             "name": "something",
-            "type": "blueprint_2",
+            "type": "basic_blueprint",
             "contained": False,
         }

--- a/src/tests/unit/test_remove.py
+++ b/src/tests/unit/test_remove.py
@@ -13,7 +13,7 @@ class DocumentServiceTestCase(unittest.TestCase):
     def test_remove_document(self):
         document_repository = mock.Mock()
 
-        document_1 = {"_id": "1", "name": "Parent", "description": "", "type": "blueprint_1"}
+        document_1 = {"_id": "1", "name": "Parent", "description": "", "type": "all_contained_cases_blueprint"}
 
         document_repository.get = lambda id: DTO(data=document_1.copy())
 
@@ -25,7 +25,7 @@ class DocumentServiceTestCase(unittest.TestCase):
 
     def test_remove_document_wo_existing_blueprint(self):
         repository = mock.Mock()
-        doc_storage = {"1": {"_id": "1", "name": "Parent", "description": "", "type": "blueprint_1"}}
+        doc_storage = {"1": {"_id": "1", "name": "Parent", "description": "", "type": "all_contained_cases_blueprint"}}
 
         class NoBlueprints:
             def get_blueprint(self, type):
@@ -48,9 +48,9 @@ class DocumentServiceTestCase(unittest.TestCase):
                 "name": "Parent",
                 "description": "",
                 "type": "uncontained_blueprint",
-                "uncontained_in_every_way": {"_id": "2", "name": "a_reference", "type": "blueprint_2"},
+                "uncontained_in_every_way": {"_id": "2", "name": "a_reference", "type": "basic_blueprint"},
             },
-            "2": {"uid": "2", "_id": "2", "name": "a_reference", "description": "", "type": "blueprint_2"},
+            "2": {"uid": "2", "_id": "2", "name": "a_reference", "description": "", "type": "basic_blueprint"},
         }
 
         def mock_get(document_id: str):
@@ -77,7 +77,7 @@ class DocumentServiceTestCase(unittest.TestCase):
             blueprint_provider=blueprint_provider, repository_provider=repository_provider
         )
         document_service.remove_document(data_source_id="testing", document_id="1")
-        expected = {"2": {"uid": "2", "_id": "2", "name": "a_reference", "description": "", "type": "blueprint_2"}}
+        expected = {"2": {"uid": "2", "_id": "2", "name": "a_reference", "description": "", "type": "basic_blueprint"}}
         assert pretty_eq(expected, doc_storage) is None
 
     def test_remove_nested(self):
@@ -88,8 +88,8 @@ class DocumentServiceTestCase(unittest.TestCase):
                 "_id": "1",
                 "name": "Parent",
                 "description": "",
-                "type": "blueprint_1",
-                "nested": {"name": "Nested", "description": "", "type": "blueprint_2"},
+                "type": "all_contained_cases_blueprint",
+                "nested": {"name": "Nested", "description": "", "type": "basic_blueprint"},
             }
         }
 
@@ -109,19 +109,24 @@ class DocumentServiceTestCase(unittest.TestCase):
                 "_id": "1",
                 "name": "Parent",
                 "description": "",
-                "type": "blueprint_1",
+                "type": "all_contained_cases_blueprint",
                 "nested": {
                     "name": "Nested",
                     "description": "",
-                    "type": "blueprint_1",
-                    "nested": {"_id": "2", "name": "Parent", "contained": True, "type": "blueprint_1"},
+                    "type": "all_contained_cases_blueprint",
+                    "nested": {
+                        "_id": "2",
+                        "name": "Parent",
+                        "contained": True,
+                        "type": "all_contained_cases_blueprint",
+                    },
                 },
             },
             "2": {
                 "_id": "2",
                 "name": "Parent",
                 "description": "",
-                "type": "blueprint_1",
+                "type": "all_contained_cases_blueprint",
             },
         }
 
@@ -142,21 +147,35 @@ class DocumentServiceTestCase(unittest.TestCase):
                 "_id": "1",
                 "name": "Parent",
                 "description": "",
-                "type": "blueprint_1",
+                "type": "all_contained_cases_blueprint",
                 "nested": {
                     "name": "Nested",
                     "description": "",
-                    "type": "blueprint_1",
+                    "type": "all_contained_cases_blueprint",
                     "nested": [
                         {
                             "name": "Parent",
-                            "type": "blueprint_1",
-                            "nested": [{"_id": "2", "name": "Parent", "contained": True, "type": "blueprint_1"}],
+                            "type": "all_contained_cases_blueprint",
+                            "nested": [
+                                {
+                                    "_id": "2",
+                                    "name": "Parent",
+                                    "contained": True,
+                                    "type": "all_contained_cases_blueprint",
+                                }
+                            ],
                         },
                         {
                             "name": "Parent",
-                            "type": "blueprint_1",
-                            "nested": [{"_id": "3", "name": "Parent", "contained": True, "type": "blueprint_1"}],
+                            "type": "all_contained_cases_blueprint",
+                            "nested": [
+                                {
+                                    "_id": "3",
+                                    "name": "Parent",
+                                    "contained": True,
+                                    "type": "all_contained_cases_blueprint",
+                                }
+                            ],
                         },
                     ],
                 },
@@ -165,13 +184,13 @@ class DocumentServiceTestCase(unittest.TestCase):
                 "_id": "2",
                 "name": "Parent",
                 "description": "",
-                "type": "blueprint_1",
+                "type": "all_contained_cases_blueprint",
             },
             "3": {
                 "_id": "3",
                 "name": "Parent",
                 "description": "",
-                "type": "blueprint_1",
+                "type": "all_contained_cases_blueprint",
             },
         }
 
@@ -193,10 +212,10 @@ class DocumentServiceTestCase(unittest.TestCase):
                 "_id": "1",
                 "name": "Parent",
                 "description": "",
-                "type": "blueprint_1",
-                "reference": {"_id": "2", "name": "Reference", "type": "blueprint_2", "contained": False},
+                "type": "all_contained_cases_blueprint",
+                "reference": {"_id": "2", "name": "Reference", "type": "basic_blueprint", "contained": False},
             },
-            "2": {"_id": "2", "name": "Reference", "description": "", "type": "blueprint_2"},
+            "2": {"_id": "2", "name": "Reference", "description": "", "type": "basic_blueprint"},
         }
         repository.delete = lambda doc_id: doc_storage.pop(doc_id)
         repository.get = lambda uid: DTO(doc_storage[uid])
@@ -213,7 +232,7 @@ class DocumentServiceTestCase(unittest.TestCase):
             "_id": "1",
             "name": "Parent",
             "description": "",
-            "type": "blueprint_1",
+            "type": "all_contained_cases_blueprint",
         }
         assert doc_storage.get("2")
 
@@ -226,7 +245,11 @@ class DocumentServiceTestCase(unittest.TestCase):
                 "name": "Parent",
                 "description": "",
                 "type": "blueprint_with_optional_attr",
-                "im_optional": {"name": "old_entity", "type": "blueprint_2", "description": "This is my old entity"},
+                "im_optional": {
+                    "name": "old_entity",
+                    "type": "basic_blueprint",
+                    "description": "This is my old entity",
+                },
             }
         }
 

--- a/src/tests/unit/test_rename.py
+++ b/src/tests/unit/test_rename.py
@@ -19,9 +19,9 @@ class DocumentServiceTestCase(unittest.TestCase):
                 "_id": "1",
                 "name": "Parent",
                 "description": "",
-                "type": "blueprint_1",
-                "nested": {"name": "Nested", "description": "", "type": "blueprint_2"},
-                "reference": {"name": "some reference", "description": "", "type": "blueprint_2"},
+                "type": "all_contained_cases_blueprint",
+                "nested": {"name": "Nested", "description": "", "type": "basic_blueprint"},
+                "reference": {"name": "some reference", "description": "", "type": "basic_blueprint"},
                 "references": [],
             }
         }
@@ -48,7 +48,7 @@ class DocumentServiceTestCase(unittest.TestCase):
             data_source_id="testing", parent_uid="1", document_id="1.nested", name="New_name"
         )
 
-        actual = {"name": "New_name", "description": "", "type": "blueprint_2"}
+        actual = {"name": "New_name", "description": "", "type": "basic_blueprint"}
 
         assert pretty_eq(actual, doc_storage["1"]["nested"]) is None
 
@@ -98,12 +98,12 @@ class DocumentServiceTestCase(unittest.TestCase):
                 "_id": "1",
                 "name": "Parent",
                 "description": "",
-                "type": "blueprint_1",
-                "nested": {"name": "Nested", "description": "", "type": "blueprint_2"},
+                "type": "all_contained_cases_blueprint",
+                "nested": {"name": "Nested", "description": "", "type": "basic_blueprint"},
                 "references": [],
-                "reference": {"_id": "2", "name": "Reference", "type": "blueprint_2"},
+                "reference": {"_id": "2", "name": "Reference", "type": "basic_blueprint"},
             },
-            "2": {"_id": "2", "name": "Reference", "description": "", "type": "blueprint_2"},
+            "2": {"_id": "2", "name": "Reference", "description": "", "type": "basic_blueprint"},
         }
 
         def mock_get(document_id: str):
@@ -124,8 +124,8 @@ class DocumentServiceTestCase(unittest.TestCase):
         )
         document_service.rename_document(data_source_id="testing", document_id="2", parent_uid="1", name="New_name")
 
-        actual = {"_id": "1", "reference": {"_id": "2", "name": "New_name", "type": "blueprint_2"}}
-        actual2 = {"_id": "2", "name": "New_name", "type": "blueprint_2"}
+        actual = {"_id": "1", "reference": {"_id": "2", "name": "New_name", "type": "basic_blueprint"}}
+        actual2 = {"_id": "2", "name": "New_name", "type": "basic_blueprint"}
 
         assert pretty_eq(actual, doc_storage["1"]) is None
         assert pretty_eq(actual2, doc_storage["2"]) is None
@@ -138,12 +138,12 @@ class DocumentServiceTestCase(unittest.TestCase):
                 "_id": "1",
                 "name": "Parent",
                 "description": "",
-                "type": "blueprint_1",
-                "nested": {"name": "Nested", "description": "", "type": "blueprint_2"},
-                "reference": {"_id": "2", "name": "Reference", "type": "blueprint_2"},
-                "references": [{"_id": "2", "name": "Reference", "type": "blueprint_2"}],
+                "type": "all_contained_cases_blueprint",
+                "nested": {"name": "Nested", "description": "", "type": "basic_blueprint"},
+                "reference": {"_id": "2", "name": "Reference", "type": "basic_blueprint"},
+                "references": [{"_id": "2", "name": "Reference", "type": "basic_blueprint"}],
             },
-            "2": {"_id": "2", "name": "Reference", "description": "", "type": "blueprint_2"},
+            "2": {"_id": "2", "name": "Reference", "description": "", "type": "basic_blueprint"},
         }
 
         def mock_get(document_id: str):
@@ -164,8 +164,8 @@ class DocumentServiceTestCase(unittest.TestCase):
         )
         document_service.rename_document(data_source_id="testing", document_id="2", parent_uid="1", name="New_name")
 
-        actual = {"_id": "1", "references": [{"_id": "2", "name": "New_name", "type": "blueprint_2"}]}
-        actual2 = {"_id": "2", "name": "New_name", "type": "blueprint_2"}
+        actual = {"_id": "1", "references": [{"_id": "2", "name": "New_name", "type": "basic_blueprint"}]}
+        actual2 = {"_id": "2", "name": "New_name", "type": "basic_blueprint"}
 
         assert pretty_eq(actual, doc_storage["1"]) is None
         assert pretty_eq(actual2, doc_storage["2"]) is None

--- a/src/tests/unit/test_save.py
+++ b/src/tests/unit/test_save.py
@@ -3,7 +3,6 @@ from copy import deepcopy
 from unittest import mock
 
 from authentication.models import User
-
 from domain_classes.blueprint_attribute import BlueprintAttribute
 from domain_classes.dto import DTO
 from domain_classes.tree_node import Node
@@ -20,17 +19,17 @@ class DocumentServiceTestCase(unittest.TestCase):
                 "_id": "1",
                 "name": "Parent",
                 "description": "",
-                "type": "blueprint_1",
-                "nested": {"name": "Nested", "description": "", "type": "blueprint_2"},
-                "reference": {"_id": "2", "name": "a_reference", "type": "blueprint_2"},
+                "type": "all_contained_cases_blueprint",
+                "nested": {"name": "Nested", "description": "", "type": "basic_blueprint"},
+                "reference": {"_id": "2", "name": "a_reference", "type": "basic_blueprint"},
                 "references": [
-                    {"_id": "3", "name": "ref1", "type": "blueprint_2"},
-                    {"_id": "4", "name": "ref2", "type": "blueprint_2"},
+                    {"_id": "3", "name": "ref1", "type": "basic_blueprint"},
+                    {"_id": "4", "name": "ref2", "type": "basic_blueprint"},
                 ],
             },
-            "2": {"_id": "2", "name": "a_reference", "description": "", "type": "blueprint_2"},
-            "3": {"_id": "3", "name": "ref1", "description": "", "type": "blueprint_2"},
-            "4": {"_id": "4", "name": "ref2", "description": "TEST", "type": "blueprint_2"},
+            "2": {"_id": "2", "name": "a_reference", "description": "", "type": "basic_blueprint"},
+            "3": {"_id": "3", "name": "ref1", "description": "", "type": "basic_blueprint"},
+            "4": {"_id": "4", "name": "ref2", "description": "TEST", "type": "basic_blueprint"},
         }
 
         def mock_get(document_id: str):
@@ -48,10 +47,15 @@ class DocumentServiceTestCase(unittest.TestCase):
 
         node: Node = document_service.get_node_by_uid("testing", "1")
         contained_node: Node = node.get_by_path("references.1".split("."))
-        contained_node.update({"_id": "4", "name": "ref2", "description": "TEST_MODIFY", "type": "blueprint_2"})
+        contained_node.update({"_id": "4", "name": "ref2", "description": "TEST_MODIFY", "type": "basic_blueprint"})
         document_service.save(node, "testing")
 
-        assert doc_storage["4"] == {"_id": "4", "name": "ref2", "description": "TEST_MODIFY", "type": "blueprint_2"}
+        assert doc_storage["4"] == {
+            "_id": "4",
+            "name": "ref2",
+            "description": "TEST_MODIFY",
+            "type": "basic_blueprint",
+        }
 
     def test_save_append(self):
         repository = mock.Mock()
@@ -61,12 +65,12 @@ class DocumentServiceTestCase(unittest.TestCase):
                 "_id": "1",
                 "name": "Parent",
                 "description": "",
-                "type": "blueprint_1",
-                "nested": {"name": "Nested", "description": "", "type": "blueprint_2"},
-                "reference": {"name": "a_reference", "type": "blueprint_2"},
+                "type": "all_contained_cases_blueprint",
+                "nested": {"name": "Nested", "description": "", "type": "basic_blueprint"},
+                "reference": {"name": "a_reference", "type": "basic_blueprint"},
                 "references": [],
             },
-            "2": {"_id": "2", "name": "a_reference", "description": "", "type": "blueprint_2"},
+            "2": {"_id": "2", "name": "a_reference", "description": "", "type": "basic_blueprint"},
         }
 
         def mock_get(document_id: str):
@@ -91,13 +95,13 @@ class DocumentServiceTestCase(unittest.TestCase):
                 uid="2",
                 entity=doc_storage["2"],
                 blueprint_provider=document_service.get_blueprint,
-                attribute=BlueprintAttribute(name="references", attribute_type="blueprint_2"),
+                attribute=BlueprintAttribute(name="references", attribute_type="basic_blueprint"),
             )
         )
         document_service.save(node, "testing")
 
         assert doc_storage["1"]["references"] == [
-            {"name": "a_reference", "type": "blueprint_2", "_id": "2", "contained": True}
+            {"name": "a_reference", "type": "basic_blueprint", "_id": "2", "contained": True}
         ]
 
     def test_save_delete(self):
@@ -108,30 +112,30 @@ class DocumentServiceTestCase(unittest.TestCase):
                 "_id": "1",
                 "name": "Parent",
                 "description": "",
-                "type": "blueprint_1",
-                "nested": {"name": "Nested", "description": "", "type": "blueprint_2"},
-                "reference": {"_id": "2", "name": "a_reference", "type": "blueprint_2"},
+                "type": "all_contained_cases_blueprint",
+                "nested": {"name": "Nested", "description": "", "type": "basic_blueprint"},
+                "reference": {"_id": "2", "name": "a_reference", "type": "basic_blueprint"},
                 "references": [
-                    {"_id": "2", "name": "a_reference", "type": "blueprint_2"},
-                    {"_id": "3", "name": "a_reference", "type": "blueprint_2"},
-                    {"_id": "4", "name": "a_reference", "type": "blueprint_2"},
+                    {"_id": "2", "name": "a_reference", "type": "basic_blueprint"},
+                    {"_id": "3", "name": "a_reference", "type": "basic_blueprint"},
+                    {"_id": "4", "name": "a_reference", "type": "basic_blueprint"},
                 ],
             },
-            "2": {"_id": "2", "name": "a_reference", "description": "Index 1", "type": "blueprint_2"},
-            "3": {"_id": "3", "name": "a_reference", "description": "Index 2", "type": "blueprint_2"},
-            "4": {"_id": "4", "name": "a_reference", "description": "Index 3", "type": "blueprint_2"},
+            "2": {"_id": "2", "name": "a_reference", "description": "Index 1", "type": "basic_blueprint"},
+            "3": {"_id": "3", "name": "a_reference", "description": "Index 2", "type": "basic_blueprint"},
+            "4": {"_id": "4", "name": "a_reference", "description": "Index 3", "type": "basic_blueprint"},
         }
 
         doc_1_after = {
             "name": "Parent",
             "_id": "1",
             "description": "",
-            "type": "blueprint_1",
+            "type": "all_contained_cases_blueprint",
             "nested": {},
             "reference": {},
             "references": [
-                {"_id": "2", "name": "a_reference", "type": "blueprint_2", "contained": True},
-                {"_id": "4", "name": "a_reference", "type": "blueprint_2", "contained": True},
+                {"_id": "2", "name": "a_reference", "type": "basic_blueprint", "contained": True},
+                {"_id": "4", "name": "a_reference", "type": "basic_blueprint", "contained": True},
             ],
         }
 
@@ -177,7 +181,7 @@ class DocumentServiceTestCase(unittest.TestCase):
                     "uncontained_in_every_way": {
                         "_id": "2",
                         "name": "im_a_uncontained_attribute",
-                        "type": "blueprint_2",
+                        "type": "basic_blueprint",
                         "description": "I'm the second nested document, uncontained",
                     },
                 },
@@ -185,7 +189,7 @@ class DocumentServiceTestCase(unittest.TestCase):
             "3": {
                 "_id": "3",
                 "name": "ASelfContainedEntity",
-                "type": "blueprint_2",
+                "type": "basic_blueprint",
                 "description": "ASelfContainedEntity",
             },
         }
@@ -231,7 +235,7 @@ class DocumentServiceTestCase(unittest.TestCase):
                     "uncontained_in_every_way": {
                         "_id": "2",
                         "name": "im_a_uncontained_attribute",
-                        "type": "blueprint_2",
+                        "type": "basic_blueprint",
                         "contained": False,
                     },
                 },
@@ -239,7 +243,7 @@ class DocumentServiceTestCase(unittest.TestCase):
             "2": {
                 "_id": "2",
                 "name": "im_a_uncontained_attribute",
-                "type": "blueprint_2",
+                "type": "basic_blueprint",
                 "description": "I'm the second nested document, uncontained",
             },
         }
@@ -269,7 +273,7 @@ class DocumentServiceTestCase(unittest.TestCase):
                     "uncontained_in_every_way": {
                         "_id": "2",
                         "name": "im_a_uncontained_attribute",
-                        "type": "blueprint_2",
+                        "type": "basic_blueprint",
                         "contained": False,
                     },
                 },
@@ -279,3 +283,57 @@ class DocumentServiceTestCase(unittest.TestCase):
         # Test that the "2" document has not been overwritten
         assert doc_storage["2"].get("description") == "I'm the second nested document, uncontained"
         assert doc_storage["1"]["i_have_a_uncontained_attribute"]["description"] == "This has changed!"
+
+    """
+    This test tests that we can update a contained attribute, and all it's children (contained or not), without
+    modifying the "root" document.     
+    """
+
+    def test_save_update_children_of_contained_attribute(self):
+        repository = mock.Mock()
+
+        doc_storage = {
+            "1": {
+                "_id": "1",
+                "type": "two_contained_deep_attributes",
+                "name": "Root",
+                "a": {
+                    "type": "all_contained_cases_blueprint",
+                    "reference": {"_id": "2", "name": "a_reference", "type": "basic_blueprint"},
+                },
+                "b": {},
+            },
+            "2": {"_id": "2", "name": "a_reference", "description": "", "type": "basic_blueprint"},
+            "3": {"_id": "3", "description": " This is malformed, with missing type"},
+        }
+
+        def mock_get(document_id: str):
+            return DTO(doc_storage[document_id])
+
+        def mock_update(dto: DTO, *args, **kwargs):
+            doc_storage[dto.uid] = dto.data
+            return None
+
+        repository.get = mock_get
+        repository.update = mock_update
+        document_service = DocumentService(
+            blueprint_provider=blueprint_provider, repository_provider=lambda x, y: repository
+        )
+        new_data = {
+            "name": "A-contained_attribute",
+            "type": "all_contained_cases_blueprint",
+            "description": "SOME DESCRIPTION",
+            "reference": {
+                "_id": "2",
+                "name": "a_reference",
+                "type": "basic_blueprint",
+                "description": "A NEW DESCRIPTION HERE",
+            },
+            "nested": {},
+            "references": [],
+        }
+        document_service.update_document("testing", "1.a", new_data, update_uncontained=True)
+
+        assert doc_storage["1"]["a"]["description"] == "SOME DESCRIPTION"
+        assert doc_storage["1"]["a"]["reference"]["description"] == "A NEW DESCRIPTION HERE"
+        assert doc_storage["1"]["b"] == {}

--- a/src/tests/unit/test_tree_error_node.py
+++ b/src/tests/unit/test_tree_error_node.py
@@ -5,7 +5,7 @@ from domain_classes.dto import DTO
 from domain_classes.tree_node import Node
 
 
-blueprint_1 = {
+all_contained_cases_blueprint = {
     "type": "system/SIMOS/Blueprint",
     "name": "Blueprint1",
     "description": "First blueprint",
@@ -13,7 +13,7 @@ blueprint_1 = {
         {"attributeType": "string", "type": "system/SIMOS/BlueprintAttribute", "name": "name"},
         {"attributeType": "string", "type": "system/SIMOS/BlueprintAttribute", "name": "type"},
         {"attributeType": "string", "type": "system/SIMOS/BlueprintAttribute", "name": "description"},
-        {"attributeType": "blueprint_2", "type": "system/SIMOS/BlueprintAttribute", "name": "nested"},
+        {"attributeType": "basic_blueprint", "type": "system/SIMOS/BlueprintAttribute", "name": "nested"},
     ],
     "storageRecipes": [],
     "uiRecipes": [],
@@ -30,10 +30,10 @@ class ErrorTreenodeTestCase(unittest.TestCase):
             "uid": "1",
             "name": "Parent",
             "description": "",
-            "type": "blueprint_1",
+            "type": "all_contained_cases_blueprint",
             # renamed nested to nested2
-            "nested2": {"name": "Nested 1", "description": "", "type": "blueprint_2"},
-            "_blueprint": blueprint_1,
+            "nested2": {"name": "Nested 1", "description": "", "type": "basic_blueprint"},
+            "_blueprint": all_contained_cases_blueprint,
         }
 
         class BlueprintProvider:

--- a/src/tests/unit/test_tree_node_helpers.py
+++ b/src/tests/unit/test_tree_node_helpers.py
@@ -7,7 +7,7 @@ from domain_classes.tree_node import DictExporter, DictImporter, ListNode, Node
 from tests.unit.mock_blueprint_provider import flatten_dict
 from utils.data_structure.compare import pretty_eq
 
-blueprint_1 = {
+all_contained_cases_blueprint = {
     "type": "system/SIMOS/Blueprint",
     "name": "Blueprint1",
     "description": "First blueprint",
@@ -15,10 +15,10 @@ blueprint_1 = {
         {"attributeType": "string", "type": "system/SIMOS/BlueprintAttribute", "name": "name"},
         {"attributeType": "string", "type": "system/SIMOS/BlueprintAttribute", "name": "type"},
         {"attributeType": "string", "type": "system/SIMOS/BlueprintAttribute", "name": "description"},
-        {"attributeType": "blueprint_2", "type": "system/SIMOS/BlueprintAttribute", "name": "nested"},
-        {"attributeType": "blueprint_2", "type": "system/SIMOS/BlueprintAttribute", "name": "reference"},
+        {"attributeType": "basic_blueprint", "type": "system/SIMOS/BlueprintAttribute", "name": "nested"},
+        {"attributeType": "basic_blueprint", "type": "system/SIMOS/BlueprintAttribute", "name": "reference"},
         {
-            "attributeType": "blueprint_2",
+            "attributeType": "basic_blueprint",
             "type": "system/SIMOS/BlueprintAttribute",
             "name": "references",
             "dimensions": "*",
@@ -38,7 +38,7 @@ blueprint_1 = {
     "uiRecipes": [],
 }
 
-blueprint_2 = {
+basic_blueprint = {
     "type": "system/SIMOS/Blueprint",
     "name": "Blueprint2",
     "description": "Second blueprint",
@@ -72,7 +72,7 @@ blueprint_3 = {
         },
         # This have to be optional, or else we will have an infinite loop caused by recursion
         {
-            "attributeType": "blueprint_2",
+            "attributeType": "basic_blueprint",
             "type": "system/SIMOS/BlueprintAttribute",
             "name": "reference",
             "optional": True,
@@ -119,10 +119,10 @@ recursive_blueprint = {
 
 
 def get_blueprint(type: str):
-    if type == "blueprint_1":
-        return Blueprint(DTO(data=blueprint_1))
-    if type == "blueprint_2":
-        return Blueprint(DTO(data=blueprint_2))
+    if type == "all_contained_cases_blueprint":
+        return Blueprint(DTO(data=all_contained_cases_blueprint))
+    if type == "basic_blueprint":
+        return Blueprint(DTO(data=basic_blueprint))
     if type == "blueprint_3":
         return Blueprint(DTO(data=blueprint_3))
     if type == "blueprint_4":
@@ -134,63 +134,63 @@ def get_blueprint(type: str):
 
 class TreenodeTestCase(unittest.TestCase):
     def test_is_root(self):
-        root_data = {"_id": 1, "name": "root", "description": "", "type": "blueprint_1"}
+        root_data = {"_id": 1, "name": "root", "description": "", "type": "all_contained_cases_blueprint"}
         root = Node(
             key="root",
             uid="1",
             entity=root_data,
             blueprint_provider=get_blueprint,
-            attribute=BlueprintAttribute(name="", attribute_type="blueprint_1"),
+            attribute=BlueprintAttribute(name="", attribute_type="all_contained_cases_blueprint"),
         )
 
-        nested_data = {"name": "Nested", "description": "", "type": "blueprint_2"}
+        nested_data = {"name": "Nested", "description": "", "type": "basic_blueprint"}
         nested = Node(
             key="nested",
             uid="",
             entity=nested_data,
             blueprint_provider=get_blueprint,
             parent=root,
-            attribute=BlueprintAttribute(name="", attribute_type="blueprint_2"),
+            attribute=BlueprintAttribute(name="", attribute_type="basic_blueprint"),
         )
 
         assert root.is_root()
         assert not nested.is_root()
 
     def test_replace(self):
-        root_data = {"_id": 1, "name": "root", "description": "", "type": "blueprint_1"}
+        root_data = {"_id": 1, "name": "root", "description": "", "type": "all_contained_cases_blueprint"}
         root = Node(
             key="",
             uid="1",
             entity=root_data,
             blueprint_provider=get_blueprint,
-            attribute=BlueprintAttribute(name="", attribute_type="blueprint_1"),
+            attribute=BlueprintAttribute(name="", attribute_type="all_contained_cases_blueprint"),
         )
 
-        nested_1_data = {"name": "Nested1", "description": "", "type": "blueprint_2"}
+        nested_1_data = {"name": "Nested1", "description": "", "type": "basic_blueprint"}
         nested_1 = Node(
             key="nested",
             uid="",
             entity=nested_1_data,
             blueprint_provider=get_blueprint,
             parent=root,
-            attribute=BlueprintAttribute(name="", attribute_type="blueprint_2"),
+            attribute=BlueprintAttribute(name="", attribute_type="basic_blueprint"),
         )
 
-        nested_2_data = {"name": "Nested2", "description": "", "type": "blueprint_2"}
+        nested_2_data = {"name": "Nested2", "description": "", "type": "basic_blueprint"}
         nested_2 = Node(
             key="nested",
             uid="",
             entity=nested_2_data,
             blueprint_provider=get_blueprint,
-            attribute=BlueprintAttribute(name="", attribute_type="blueprint_2"),
+            attribute=BlueprintAttribute(name="", attribute_type="basic_blueprint"),
         )
 
         actual_before = {
             "_id": "1",
             "name": "root",
             "description": "",
-            "type": "blueprint_1",
-            "nested": {"name": "Nested1", "description": "", "type": "blueprint_2"},
+            "type": "all_contained_cases_blueprint",
+            "nested": {"name": "Nested1", "description": "", "type": "basic_blueprint"},
         }
 
         assert actual_before == root.to_dict()
@@ -201,66 +201,66 @@ class TreenodeTestCase(unittest.TestCase):
             "_id": "1",
             "name": "root",
             "description": "",
-            "type": "blueprint_1",
-            "nested": {"name": "Nested2", "description": "", "type": "blueprint_2"},
+            "type": "all_contained_cases_blueprint",
+            "nested": {"name": "Nested2", "description": "", "type": "basic_blueprint"},
         }
 
         assert actual_after_replaced == root.to_dict()
 
     def test_delete_root_child(self):
-        root_data = {"_id": 1, "name": "root", "description": "", "type": "blueprint_1"}
+        root_data = {"_id": 1, "name": "root", "description": "", "type": "all_contained_cases_blueprint"}
         root = Node(
             key="root",
             uid="1",
             entity=root_data,
             blueprint_provider=get_blueprint,
-            attribute=BlueprintAttribute(name="", attribute_type="blueprint_1"),
+            attribute=BlueprintAttribute(name="", attribute_type="all_contained_cases_blueprint"),
         )
 
-        nested_1_data = {"name": "Nested1", "description": "", "type": "blueprint_2"}
+        nested_1_data = {"name": "Nested1", "description": "", "type": "basic_blueprint"}
         nested_1 = Node(
             key="nested",
             uid="",
             entity=nested_1_data,
             blueprint_provider=get_blueprint,
             parent=root,
-            attribute=BlueprintAttribute(name="", attribute_type="blueprint_2"),
+            attribute=BlueprintAttribute(name="", attribute_type="basic_blueprint"),
         )
 
         actual_before = {
             "_id": "1",
             "name": "root",
             "description": "",
-            "type": "blueprint_1",
-            "nested": {"name": "Nested1", "description": "", "type": "blueprint_2"},
+            "type": "all_contained_cases_blueprint",
+            "nested": {"name": "Nested1", "description": "", "type": "basic_blueprint"},
         }
 
         assert actual_before == root.to_dict()
 
         root.remove_by_path(["nested"])
 
-        actual_after_delete = {"_id": "1", "name": "root", "description": "", "type": "blueprint_1"}
+        actual_after_delete = {"_id": "1", "name": "root", "description": "", "type": "all_contained_cases_blueprint"}
 
         assert actual_after_delete == root.to_dict()
 
     def test_delete_nested_child(self):
-        root_data = {"_id": 1, "name": "root", "description": "", "type": "blueprint_1"}
+        root_data = {"_id": 1, "name": "root", "description": "", "type": "all_contained_cases_blueprint"}
         root = Node(
             key="root",
             uid="1",
             entity=root_data,
             blueprint_provider=get_blueprint,
-            attribute=BlueprintAttribute(name="", attribute_type="blueprint_1"),
+            attribute=BlueprintAttribute(name="", attribute_type="all_contained_cases_blueprint"),
         )
 
-        nested_1_data = {"name": "Nested1", "description": "", "type": "blueprint_2"}
+        nested_1_data = {"name": "Nested1", "description": "", "type": "basic_blueprint"}
         nested_1 = Node(
             key="nested",
             uid="",
             entity=nested_1_data,
             blueprint_provider=get_blueprint,
             parent=root,
-            attribute=BlueprintAttribute(name="", attribute_type="blueprint_2"),
+            attribute=BlueprintAttribute(name="", attribute_type="basic_blueprint"),
         )
         nested_2_data = {"name": "Nested2", "description": "", "type": "blueprint_3"}
         nested_2 = Node(
@@ -276,11 +276,11 @@ class TreenodeTestCase(unittest.TestCase):
             "_id": "1",
             "name": "root",
             "description": "",
-            "type": "blueprint_1",
+            "type": "all_contained_cases_blueprint",
             "nested": {
                 "name": "Nested1",
                 "description": "",
-                "type": "blueprint_2",
+                "type": "basic_blueprint",
                 "nested2": {"name": "Nested2", "description": "", "type": "blueprint_3"},
             },
         }
@@ -293,8 +293,8 @@ class TreenodeTestCase(unittest.TestCase):
             "_id": "1",
             "name": "root",
             "description": "",
-            "type": "blueprint_1",
-            "nested": {"name": "Nested1", "description": "", "type": "blueprint_2"},
+            "type": "all_contained_cases_blueprint",
+            "nested": {"name": "Nested1", "description": "", "type": "basic_blueprint"},
         }
 
         assert actual_after_delete == root.to_dict()
@@ -359,23 +359,23 @@ class TreenodeTestCase(unittest.TestCase):
         assert actual_after_delete == root.to_dict()
 
     def test_depth(self):
-        root_data = {"_id": 1, "name": "root", "description": "", "type": "blueprint_1"}
+        root_data = {"_id": 1, "name": "root", "description": "", "type": "all_contained_cases_blueprint"}
         root = Node(
             key="root",
             uid="1",
             entity=root_data,
             blueprint_provider=get_blueprint,
-            attribute=BlueprintAttribute(name="", attribute_type="blueprint_1"),
+            attribute=BlueprintAttribute(name="", attribute_type="all_contained_cases_blueprint"),
         )
 
-        nested_data = {"name": "Nested", "description": "", "type": "blueprint_2"}
+        nested_data = {"name": "Nested", "description": "", "type": "basic_blueprint"}
         nested = Node(
             key="nested",
             uid="",
             entity=nested_data,
             blueprint_provider=get_blueprint,
             parent=root,
-            attribute=BlueprintAttribute(name="", attribute_type="blueprint_2"),
+            attribute=BlueprintAttribute(name="", attribute_type="basic_blueprint"),
         )
 
         assert root.depth() == 0
@@ -386,16 +386,16 @@ class TreenodeTestCase(unittest.TestCase):
             "_id": "1",
             "name": "Parent",
             "description": "",
-            "type": "blueprint_1",
+            "type": "all_contained_cases_blueprint",
             "nested": {
                 "name": "Nested1",
                 "description": "",
-                "type": "blueprint_2",
+                "type": "basic_blueprint",
                 "nested": {
                     "name": "Nested2",
                     "description": "",
                     "type": "blueprint_3",
-                    "reference": {"_id": "2", "name": "Reference", "description": "", "type": "blueprint_2"},
+                    "reference": {"_id": "2", "name": "Reference", "description": "", "type": "basic_blueprint"},
                 },
             },
         }
@@ -408,23 +408,23 @@ class TreenodeTestCase(unittest.TestCase):
         assert result == expected
 
     def test_traverse_reverse(self):
-        root_data = {"_id": 1, "name": "root", "description": "", "type": "blueprint_1"}
+        root_data = {"_id": 1, "name": "root", "description": "", "type": "all_contained_cases_blueprint"}
         root = Node(
             key="root",
             uid="1",
             entity=root_data,
             blueprint_provider=get_blueprint,
-            attribute=BlueprintAttribute(name="", attribute_type="blueprint_1"),
+            attribute=BlueprintAttribute(name="", attribute_type="all_contained_cases_blueprint"),
         )
 
-        nested_data = {"name": "Nested1", "description": "", "type": "blueprint_2"}
+        nested_data = {"name": "Nested1", "description": "", "type": "basic_blueprint"}
         nested = Node(
             key="nested",
             uid="",
             entity=nested_data,
             blueprint_provider=get_blueprint,
             parent=root,
-            attribute=BlueprintAttribute(name="", attribute_type="blueprint_2"),
+            attribute=BlueprintAttribute(name="", attribute_type="basic_blueprint"),
         )
 
         nested_2_data = {"name": "Nested2", "description": "", "type": "blueprint_3"}
@@ -442,23 +442,23 @@ class TreenodeTestCase(unittest.TestCase):
         assert result == expected
 
     def test_node_id(self):
-        root_data = {"_id": 1, "name": "root", "description": "", "type": "blueprint_1"}
+        root_data = {"_id": 1, "name": "root", "description": "", "type": "all_contained_cases_blueprint"}
         root = Node(
             key="",
             uid="1",
             entity=root_data,
             blueprint_provider=get_blueprint,
-            attribute=BlueprintAttribute(name="", attribute_type="blueprint_1"),
+            attribute=BlueprintAttribute(name="", attribute_type="all_contained_cases_blueprint"),
         )
 
-        nested_data = {"name": "Nested", "description": "", "type": "blueprint_2"}
+        nested_data = {"name": "Nested", "description": "", "type": "basic_blueprint"}
         nested = Node(
             key="nested",
             uid="",
             entity=nested_data,
             blueprint_provider=get_blueprint,
             parent=root,
-            attribute=BlueprintAttribute(name="", attribute_type="blueprint_2"),
+            attribute=BlueprintAttribute(name="", attribute_type="basic_blueprint"),
         )
 
         nested_2_data = {"name": "Nested", "description": "", "type": "blueprint_3"}
@@ -471,14 +471,14 @@ class TreenodeTestCase(unittest.TestCase):
             attribute=BlueprintAttribute(name="", attribute_type="blueprint_3"),
         )
 
-        nested_2_reference_data = {"_id": "2", "name": "Reference", "description": "", "type": "blueprint_2"}
+        nested_2_reference_data = {"_id": "2", "name": "Reference", "description": "", "type": "basic_blueprint"}
         reference = Node(
             key="reference",
             uid="2",
             entity=nested_2_reference_data,
             blueprint_provider=get_blueprint,
             parent=nested_2,
-            attribute=BlueprintAttribute(name="", attribute_type="blueprint_2"),
+            attribute=BlueprintAttribute(name="", attribute_type="basic_blueprint"),
         )
 
         list_data = {"name": "List", "type": "blueprint_3"}
@@ -491,14 +491,14 @@ class TreenodeTestCase(unittest.TestCase):
             attribute=BlueprintAttribute(name="", attribute_type="blueprint_3"),
         )
 
-        item_1_data = {"name": "Item1", "description": "", "type": "blueprint_2"}
+        item_1_data = {"name": "Item1", "description": "", "type": "basic_blueprint"}
         item_1 = Node(
             key="0",
             uid="",
             entity=item_1_data,
             blueprint_provider=get_blueprint,
             parent=list_node,
-            attribute=BlueprintAttribute(name="", attribute_type="blueprint_2"),
+            attribute=BlueprintAttribute(name="", attribute_type="basic_blueprint"),
         )
 
         assert root.node_id == "1"
@@ -514,16 +514,16 @@ class TreenodeTestCase(unittest.TestCase):
             "_id": "1",
             "name": "Parent",
             "description": "",
-            "type": "blueprint_1",
+            "type": "all_contained_cases_blueprint",
             "nested": {
                 "name": "Nested",
                 "description": "",
-                "type": "blueprint_2",
+                "type": "basic_blueprint",
                 "nested": {
                     "name": "Nested",
                     "description": "",
                     "type": "blueprint_3",
-                    "reference": {"_id": "2", "name": "Reference", "description": "", "type": "blueprint_2"},
+                    "reference": {"_id": "2", "name": "Reference", "description": "", "type": "basic_blueprint"},
                 },
                 "reference": {},
                 "references": [],
@@ -545,16 +545,16 @@ class TreenodeTestCase(unittest.TestCase):
             "_id": "1",
             "name": "Parent",
             "description": "",
-            "type": "blueprint_1",
+            "type": "all_contained_cases_blueprint",
             "nested": {
                 "name": "Nested",
                 "description": "",
-                "type": "blueprint_2",
+                "type": "basic_blueprint",
                 "nested": {
                     "name": "Nested",
                     "description": "",
                     "type": "blueprint_3",
-                    "reference": {"_id": "2", "name": "Reference", "description": "", "type": "blueprint_2"},
+                    "reference": {"_id": "2", "name": "Reference", "description": "", "type": "basic_blueprint"},
                 },
             },
         }
@@ -574,19 +574,19 @@ class TreenodeTestCase(unittest.TestCase):
             "_id": "1",
             "name": "Parent",
             "description": "",
-            "type": "blueprint_1",
+            "type": "all_contained_cases_blueprint",
             "nested": {
                 "name": "Nested",
                 "description": "",
-                "type": "blueprint_2",
+                "type": "basic_blueprint",
                 "nested": {
                     "name": "Nested",
                     "description": "",
                     "type": "blueprint_3",
-                    "reference": {"_id": "2", "name": "Reference", "description": "", "type": "blueprint_2"},
+                    "reference": {"_id": "2", "name": "Reference", "description": "", "type": "basic_blueprint"},
                 },
             },
-            "reference": {"_id": "2", "name": "a_reference", "type": "blueprint_2"},
+            "reference": {"_id": "2", "name": "a_reference", "type": "basic_blueprint"},
             "references": [],
         }
 
@@ -595,19 +595,19 @@ class TreenodeTestCase(unittest.TestCase):
         update_0 = {
             "name": "New-name",
             "description": "",
-            "type": "blueprint_1",
+            "type": "all_contained_cases_blueprint",
             "nested": {
                 "name": "Nested",
                 "description": "Some description",
-                "type": "blueprint_2",
+                "type": "basic_blueprint",
                 "nested": {
                     "name": "Nested",
                     "description": "",
                     "type": "blueprint_3",
-                    "reference": {"_id": "2", "name": "Reference", "description": "", "type": "blueprint_2"},
+                    "reference": {"_id": "2", "name": "Reference", "description": "", "type": "basic_blueprint"},
                 },
             },
-            "reference": {"_id": "2", "name": "a_reference", "type": "blueprint_2"},
+            "reference": {"_id": "2", "name": "a_reference", "type": "basic_blueprint"},
             "references": [],
         }
 
@@ -618,19 +618,19 @@ class TreenodeTestCase(unittest.TestCase):
         update_1 = {
             "name": "New-name",
             "description": "",
-            "type": "blueprint_1",
+            "type": "all_contained_cases_blueprint",
             "nested": {
                 "name": "Nested",
                 "description": "Some description",
-                "type": "blueprint_2",
+                "type": "basic_blueprint",
                 "nested": {
                     "name": "New-name",
                     "description": "",
                     "type": "blueprint_3",
-                    "reference": {"_id": "2", "name": "Reference", "description": "", "type": "blueprint_2"},
+                    "reference": {"_id": "2", "name": "Reference", "description": "", "type": "basic_blueprint"},
                 },
             },
-            "reference": {"_id": "2", "name": "a_reference", "type": "blueprint_2"},
+            "reference": {"_id": "2", "name": "a_reference", "type": "basic_blueprint"},
             "references": [],
         }
 
@@ -641,19 +641,19 @@ class TreenodeTestCase(unittest.TestCase):
         update_2 = {
             "name": "New-name",
             "description": "",
-            "type": "blueprint_1",
+            "type": "all_contained_cases_blueprint",
             "nested": {
                 "name": "Nested",
                 "description": "Some description",
-                "type": "blueprint_2",
+                "type": "basic_blueprint",
                 "nested": {
                     "name": "New-name",
                     "description": "",
                     "type": "blueprint_3",
-                    "reference": {"_id": "2", "name": "New-name", "description": "", "type": "blueprint_2"},
+                    "reference": {"_id": "2", "name": "New-name", "description": "", "type": "basic_blueprint"},
                 },
             },
-            "reference": {"_id": "2", "name": "a_reference", "type": "blueprint_2"},
+            "reference": {"_id": "2", "name": "a_reference", "type": "basic_blueprint"},
             "references": [],
         }
 
@@ -664,20 +664,20 @@ class TreenodeTestCase(unittest.TestCase):
         expected = {
             "_id": "1",
             "name": "New-name",
-            "type": "blueprint_1",
+            "type": "all_contained_cases_blueprint",
             "description": "",
             "nested": {
                 "name": "Nested",
-                "type": "blueprint_2",
+                "type": "basic_blueprint",
                 "description": "Some description",
                 "nested": {
                     "name": "New-name",
                     "type": "blueprint_3",
                     "description": "",
-                    "reference": {"_id": "2", "name": "New-name", "type": "blueprint_2", "description": ""},
+                    "reference": {"_id": "2", "name": "New-name", "type": "basic_blueprint", "description": ""},
                 },
             },
-            "reference": {"_id": "2", "name": "a_reference", "type": "blueprint_2"},
+            "reference": {"_id": "2", "name": "a_reference", "type": "basic_blueprint"},
             "references": [],
         }
 
@@ -694,12 +694,12 @@ class TreenodeTestCase(unittest.TestCase):
             "_id": "1",
             "name": "Parent",
             "description": "",
-            "type": "blueprint_1",
+            "type": "all_contained_cases_blueprint",
             "nested": {
                 "name": "Nested",
                 "description": "",
-                "type": "blueprint_2",
-                "_blueprint": blueprint_2,
+                "type": "basic_blueprint",
+                "_blueprint": basic_blueprint,
                 "nested": {
                     "name": "Nested",
                     "description": "",
@@ -709,8 +709,8 @@ class TreenodeTestCase(unittest.TestCase):
                         "_id": "5",
                         "name": "Reference",
                         "description": "",
-                        "type": "blueprint_2",
-                        "_blueprint": blueprint_2,
+                        "type": "basic_blueprint",
+                        "_blueprint": basic_blueprint,
                     },
                 },
             },
@@ -718,26 +718,26 @@ class TreenodeTestCase(unittest.TestCase):
                 "_id": "2",
                 "name": "Reference",
                 "description": "",
-                "type": "blueprint_2",
-                "_blueprint": blueprint_2,
+                "type": "basic_blueprint",
+                "_blueprint": basic_blueprint,
             },
             "references": [
                 {
                     "_id": "3",
                     "name": "Reference-1",
                     "description": "",
-                    "type": "blueprint_2",
-                    "_blueprint": blueprint_2,
+                    "type": "basic_blueprint",
+                    "_blueprint": basic_blueprint,
                 },
                 {
                     "_id": "4",
                     "name": "Reference-2",
                     "description": "",
-                    "type": "blueprint_2",
-                    "_blueprint": blueprint_2,
+                    "type": "basic_blueprint",
+                    "_blueprint": basic_blueprint,
                 },
             ],
-            "_blueprint": blueprint_1,
+            "_blueprint": all_contained_cases_blueprint,
         }
 
         root = Node.from_dict(document_1, document_1.get("_id"), get_blueprint)
@@ -746,22 +746,22 @@ class TreenodeTestCase(unittest.TestCase):
             "_id": "1",
             "name": "Parent",
             "description": "",
-            "type": "blueprint_1",
+            "type": "all_contained_cases_blueprint",
             "nested": {
                 "name": "Nested",
                 "description": "",
-                "type": "blueprint_2",
+                "type": "basic_blueprint",
                 "nested": {
                     "name": "Nested",
                     "description": "",
                     "type": "blueprint_3",
-                    "reference": {"_id": "5", "name": "Reference", "description": "", "type": "blueprint_2"},
+                    "reference": {"_id": "5", "name": "Reference", "description": "", "type": "basic_blueprint"},
                 },
             },
-            "reference": {"_id": "2", "name": "Reference", "description": "", "type": "blueprint_2"},
+            "reference": {"_id": "2", "name": "Reference", "description": "", "type": "basic_blueprint"},
             "references": [
-                {"_id": "3", "name": "Reference-1", "description": "", "type": "blueprint_2"},
-                {"_id": "4", "name": "Reference-2", "description": "", "type": "blueprint_2"},
+                {"_id": "3", "name": "Reference-1", "description": "", "type": "basic_blueprint"},
+                {"_id": "4", "name": "Reference-2", "description": "", "type": "basic_blueprint"},
             ],
         }
 
@@ -778,12 +778,12 @@ class TreenodeTestCase(unittest.TestCase):
             "_id": "1",
             "name": "Parent",
             "description": "",
-            "type": "blueprint_1",
+            "type": "all_contained_cases_blueprint",
             "nested": {
                 "name": "Nested",
                 "description": "",
-                "type": "blueprint_2",
-                "_blueprint": blueprint_2,
+                "type": "basic_blueprint",
+                "_blueprint": basic_blueprint,
                 "nested": {
                     "name": "Nested",
                     "description": "",
@@ -793,8 +793,8 @@ class TreenodeTestCase(unittest.TestCase):
                         "_id": "5",
                         "name": "Reference",
                         "description": "",
-                        "type": "blueprint_2",
-                        "_blueprint": blueprint_2,
+                        "type": "basic_blueprint",
+                        "_blueprint": basic_blueprint,
                     },
                 },
             },
@@ -802,48 +802,48 @@ class TreenodeTestCase(unittest.TestCase):
                 "_id": "2",
                 "name": "Reference",
                 "description": "",
-                "type": "blueprint_2",
-                "_blueprint": blueprint_2,
+                "type": "basic_blueprint",
+                "_blueprint": basic_blueprint,
             },
             "references": [
                 {
                     "_id": "3",
                     "name": "Reference-1",
                     "description": "",
-                    "type": "blueprint_2",
-                    "_blueprint": blueprint_2,
+                    "type": "basic_blueprint",
+                    "_blueprint": basic_blueprint,
                 },
                 {
                     "_id": "4",
                     "name": "Reference-2",
                     "description": "",
-                    "type": "blueprint_2",
-                    "_blueprint": blueprint_2,
+                    "type": "basic_blueprint",
+                    "_blueprint": basic_blueprint,
                 },
             ],
-            "_blueprint": blueprint_1,
+            "_blueprint": all_contained_cases_blueprint,
         }
 
         actual = {
             "_id": "1",
             "name": "Parent",
             "description": "",
-            "type": "blueprint_1",
+            "type": "all_contained_cases_blueprint",
             "nested": {
                 "name": "Nested",
                 "description": "",
-                "type": "blueprint_2",
+                "type": "basic_blueprint",
                 "nested": {
                     "name": "Nested",
                     "description": "",
                     "type": "blueprint_3",
-                    "reference": {"_id": "5", "name": "Reference", "description": "", "type": "blueprint_2"},
+                    "reference": {"_id": "5", "name": "Reference", "description": "", "type": "basic_blueprint"},
                 },
             },
-            "reference": {"_id": "2", "name": "Reference", "description": "", "type": "blueprint_2"},
+            "reference": {"_id": "2", "name": "Reference", "description": "", "type": "basic_blueprint"},
             "references": [
-                {"_id": "3", "name": "Reference-1", "description": "", "type": "blueprint_2"},
-                {"_id": "4", "name": "Reference-2", "description": "", "type": "blueprint_2"},
+                {"_id": "3", "name": "Reference-1", "description": "", "type": "basic_blueprint"},
+                {"_id": "4", "name": "Reference-2", "description": "", "type": "basic_blueprint"},
             ],
         }
 
@@ -852,23 +852,23 @@ class TreenodeTestCase(unittest.TestCase):
         assert pretty_eq(actual, root.to_dict()) is None
 
     def test_to_dict(self):
-        root_data = {"_id": 1, "name": "root", "description": "", "type": "blueprint_1"}
+        root_data = {"_id": 1, "name": "root", "description": "", "type": "all_contained_cases_blueprint"}
         root = Node(
             key="root",
             uid="1",
             entity=root_data,
             blueprint_provider=get_blueprint,
-            attribute=BlueprintAttribute(name="", attribute_type="blueprint_1"),
+            attribute=BlueprintAttribute(name="", attribute_type="all_contained_cases_blueprint"),
         )
 
-        nested_data = {"name": "Nested", "description": "", "type": "blueprint_2"}
+        nested_data = {"name": "Nested", "description": "", "type": "basic_blueprint"}
         nested = Node(
             key="nested",
             uid="",
             entity=nested_data,
             blueprint_provider=get_blueprint,
             parent=root,
-            attribute=BlueprintAttribute(name="", attribute_type="blueprint_2"),
+            attribute=BlueprintAttribute(name="", attribute_type="basic_blueprint"),
         )
 
         nested_2_data = {"name": "Nested", "description": "", "type": "blueprint_3"}
@@ -881,14 +881,14 @@ class TreenodeTestCase(unittest.TestCase):
             attribute=BlueprintAttribute(name="", attribute_type="blueprint_3"),
         )
 
-        nested_2_reference_data = {"_id": "2", "name": "Reference", "description": "", "type": "blueprint_2"}
+        nested_2_reference_data = {"_id": "2", "name": "Reference", "description": "", "type": "basic_blueprint"}
         Node(
             key="reference",
             uid="2",
             entity=nested_2_reference_data,
             blueprint_provider=get_blueprint,
             parent=nested_2,
-            attribute=BlueprintAttribute(name="", attribute_type="blueprint_2"),
+            attribute=BlueprintAttribute(name="", attribute_type="basic_blueprint"),
         )
 
         list_data = {"name": "List", "type": "blueprint_3"}
@@ -901,33 +901,33 @@ class TreenodeTestCase(unittest.TestCase):
             attribute=BlueprintAttribute(name="", attribute_type="blueprint_3"),
         )
 
-        item_1_data = {"name": "Item1", "description": "", "type": "blueprint_2"}
+        item_1_data = {"name": "Item1", "description": "", "type": "basic_blueprint"}
         item_1 = Node(
             key="0",
             uid="",
             entity=item_1_data,
             blueprint_provider=get_blueprint,
             parent=list_node,
-            attribute=BlueprintAttribute(name="", attribute_type="blueprint_2"),
+            attribute=BlueprintAttribute(name="", attribute_type="basic_blueprint"),
         )
 
         actual_root = {
             "_id": "1",
             "name": "root",
             "description": "",
-            "type": "blueprint_1",
+            "type": "all_contained_cases_blueprint",
             "nested": {
                 "name": "Nested",
                 "description": "",
-                "type": "blueprint_2",
+                "type": "basic_blueprint",
                 "nested": {
                     "name": "Nested",
                     "description": "",
                     "type": "blueprint_3",
-                    "reference": {"_id": "2", "name": "Reference", "description": "", "type": "blueprint_2"},
+                    "reference": {"_id": "2", "name": "Reference", "description": "", "type": "basic_blueprint"},
                 },
             },
-            "list": [{"name": "Item1", "description": "", "type": "blueprint_2"}],
+            "list": [{"name": "Item1", "description": "", "type": "basic_blueprint"}],
         }
 
         self.assertEqual(actual_root, DictExporter.to_dict(root))
@@ -935,17 +935,17 @@ class TreenodeTestCase(unittest.TestCase):
         actual_nested = {
             "name": "Nested",
             "description": "",
-            "type": "blueprint_2",
+            "type": "basic_blueprint",
             "nested": {
                 "name": "Nested",
                 "description": "",
                 "type": "blueprint_3",
-                "reference": {"_id": "2", "name": "Reference", "description": "", "type": "blueprint_2"},
+                "reference": {"_id": "2", "name": "Reference", "description": "", "type": "basic_blueprint"},
             },
         }
 
         self.assertEqual(actual_nested, nested.to_dict())
 
-        item_1_actual = {"name": "Item1", "description": "", "type": "blueprint_2"}
+        item_1_actual = {"name": "Item1", "description": "", "type": "basic_blueprint"}
 
         self.assertEqual(item_1_actual, item_1.to_dict())

--- a/src/tests/unit/test_tree_node_update.py
+++ b/src/tests/unit/test_tree_node_update.py
@@ -205,7 +205,7 @@ class DocumentServiceTestCase(unittest.TestCase):
             "name": "Parent",
             "description": "",
             "type": "blueprint_with_optional_attr",
-            "im_optional": {"name": "new_entity", "type": "blueprint_2", "description": "This is my new entity"},
+            "im_optional": {"name": "new_entity", "type": "basic_blueprint", "description": "This is my new entity"},
         }
 
         def mock_get(document_id: str):
@@ -226,7 +226,7 @@ class DocumentServiceTestCase(unittest.TestCase):
         )
         document_service.add_document(
             "testing/1.im_optional",
-            data={"type": "blueprint_2", "name": "new_entity", "description": "This is my new entity"},
+            data={"type": "basic_blueprint", "name": "new_entity", "description": "This is my new entity"},
         )
 
         assert pretty_eq(doc_1_after, doc_storage["1"]) is None
@@ -291,7 +291,11 @@ class DocumentServiceTestCase(unittest.TestCase):
                 "name": "Parent",
                 "description": "",
                 "type": "blueprint_with_optional_attr",
-                "im_optional": {"name": "new_entity", "type": "blueprint_2", "description": "This is my new entity"},
+                "im_optional": {
+                    "name": "new_entity",
+                    "type": "basic_blueprint",
+                    "description": "This is my new entity",
+                },
             },
         }
 
@@ -313,7 +317,7 @@ class DocumentServiceTestCase(unittest.TestCase):
         )
         document_service.add_document(
             "testing/1.nested_with_optional.im_optional",
-            {"name": "new_entity", "description": "This is my new entity", "type": "blueprint_2"},
+            {"name": "new_entity", "description": "This is my new entity", "type": "basic_blueprint"},
         )
 
         assert pretty_eq(doc_1_after, doc_storage["1"]) is None
@@ -330,7 +334,7 @@ class DocumentServiceTestCase(unittest.TestCase):
                 "im_optional": {
                     "name": "duplicate",
                     "description": "",
-                    "type": "blueprint_2",
+                    "type": "basic_blueprint",
                 },
             }
         }
@@ -351,7 +355,7 @@ class DocumentServiceTestCase(unittest.TestCase):
         with self.assertRaises(DuplicateFileNameException):
             document_service.add_document(
                 "testing/1.im_optional",
-                data={"type": "blueprint_2", "name": "duplicate", "description": "This is my new entity"},
+                data={"type": "basic_blueprint", "name": "duplicate", "description": "This is my new entity"},
             )
 
     def test_add_valid_specialized_child_type(self):


### PR DESCRIPTION
fix bug where sibling attributes where updated on a contained node update

## What does this pull request change?
If we'r updating an attribute, only update that attribute node with "update_uncontained=True".
Then update the root document, but always with "update_uncontained=False" 

\+ some renaming of test blueprints to be more descriptive

## Why is this pull request needed?
DocumentService() would try to update sibling attributes of the attribute node with "update_uncontained=True".
This would not work as the data for these nodes had not been fetched. Resulted in "MissingRequiredAttribute" exception on those nodes.


## Issues related to this change:
closes #201 