### PR TITLE
cache on get_blueprint, hash user_id

### DIFF
--- a/src/authentication/models.py
+++ b/src/authentication/models.py
@@ -48,6 +48,9 @@ class User(BaseModel):
     roles: List[str] = []
     scope: AccessLevel = AccessLevel.WRITE
 
+    def __hash__(self):
+        return hash(self.user_id)
+
 
 class ACL(BaseModel):
     """

--- a/src/services/document_service.py
+++ b/src/services/document_service.py
@@ -29,7 +29,7 @@ from utils.exceptions import (
     MissingPrivilegeException,
     RepositoryException,
 )
-from utils.get_blueprint import BlueprintProvider
+from utils.get_blueprint import get_blueprint_provider
 from utils.get_resolved_document_by_id import get_complete_document
 
 from utils.get_document_by_path import get_document_uid_by_path
@@ -43,7 +43,7 @@ pretty_printer = pprint.PrettyPrinter()
 
 class DocumentService:
     def __init__(self, repository_provider=get_data_source, blueprint_provider=None, user=default_user):
-        self.blueprint_provider = blueprint_provider or BlueprintProvider(user)
+        self.blueprint_provider = blueprint_provider or get_blueprint_provider(user)
         self.repository_provider = repository_provider
         self.user = user
 

--- a/src/use_case/add_file_use_case.py
+++ b/src/use_case/add_file_use_case.py
@@ -1,3 +1,4 @@
+from enums import SIMOS
 from starlette.responses import JSONResponse
 
 from authentication.models import User
@@ -17,6 +18,9 @@ class AddFileUseCase(UseCase):
         document = document_service.add_document(
             absolute_ref=req["absolute_ref"], data=req["data"], update_uncontained=req["update_uncontained"]
         )
-        document_service.invalidate_cache()
+        # Do not invalidate the blueprint cache if it was not a blueprint that was changed
+        if req["data"]["type"] == SIMOS.BLUEPRINT.value:
+            document_service.invalidate_cache()
+
         data_source, _, _ = split_absolute_ref(req["absolute_ref"])
         return JSONResponse(document)

--- a/src/use_case/update_document_use_case.py
+++ b/src/use_case/update_document_use_case.py
@@ -1,5 +1,6 @@
 from typing import List, Optional, Union
 
+from enums import SIMOS
 from fastapi import File, UploadFile
 from starlette.responses import JSONResponse
 
@@ -40,5 +41,7 @@ class UpdateDocumentUseCase(UseCase):
             files={f.filename: f.file for f in req.files} if req.files else None,
             update_uncontained=req.update_uncontained,
         )
-        document_service.invalidate_cache()
+        # Do not invalidate the blueprint cache if it was not a blueprint that was changed
+        if document["data"]["type"] == SIMOS.BLUEPRINT.value:
+            document_service.invalidate_cache()
         return JSONResponse(document)

--- a/src/utils/get_blueprint.py
+++ b/src/utils/get_blueprint.py
@@ -15,6 +15,7 @@ class BlueprintProvider:
 
     @lru_cache(maxsize=config.CACHE_MAX_SIZE)
     def get_blueprint(self, type: str) -> Blueprint:
+        logger.debug(f"Cache miss! Fetching blueprint '{type}'")
         try:
             document: DTO = get_document_by_ref(type, self.user)
             return Blueprint(document)
@@ -28,3 +29,8 @@ class BlueprintProvider:
             self.get_blueprint.cache_clear()
         except Exception as error:
             logger.warning("function is not instance of lru cache.", error)
+
+
+@lru_cache(maxsize=config.CACHE_MAX_SIZE)
+def get_blueprint_provider(user):
+    return BlueprintProvider(user)


### PR DESCRIPTION
## What does this pull request change?
- Cache on "get_blueprint_provider"
- Make User hashable
- Don't invalidate the cache that often (only if a Blueprint has been changed)

## Why is this pull request needed?

## Issues related to this change:
closes #217 