### PR TITLE
fix: for contained lists skip invalidate cache and to_ref_dict

### DIFF
--- a/src/services/document_service.py
+++ b/src/services/document_service.py
@@ -115,19 +115,20 @@ class DocumentService:
         if node.type == SIMOS.BLOB.value:
             node.entity = self.save_blob_data(node, repository)
 
-        ref_dict = node.to_ref_dict()
-        entity_has_all_required_attributes(ref_dict, node.blueprint.get_required_attributes())
+        if isinstance(node, Node):
+            ref_dict = node.to_ref_dict()
+            entity_has_all_required_attributes(ref_dict, node.blueprint.get_required_attributes())
 
-        # If the node is not contained, and has data, save it!
-        if not node.storage_contained and ref_dict:
-            dto = DTO(ref_dict)
-            # Expand this when adding new repositories requiring PATH
-            if isinstance(repository, ZipFileClient):
-                dto.data["__path__"] = path
-            parent_uid = node.parent.node_id if node.parent else None
-            repository.update(dto, node.get_context_storage_attribute(), parent_id=parent_uid)
-            return {"_id": node.uid, "type": node.entity["type"], "name": node.name}
-        return ref_dict
+            # If the node is not contained, and has data, save it!
+            if not node.storage_contained and ref_dict:
+                dto = DTO(ref_dict)
+                # Expand this when adding new repositories requiring PATH
+                if isinstance(repository, ZipFileClient):
+                    dto.data["__path__"] = path
+                parent_uid = node.parent.node_id if node.parent else None
+                repository.update(dto, node.get_context_storage_attribute(), parent_id=parent_uid)
+                return {"_id": node.uid, "type": node.entity["type"], "name": node.name}
+            return ref_dict
 
     def get_document_by_uid(self, data_source_id: str, document_uid: str, depth: int = 999) -> dict:
         return get_complete_document(document_uid, self.repository_provider(data_source_id, self.user), depth)

--- a/src/use_case/add_file_use_case.py
+++ b/src/use_case/add_file_use_case.py
@@ -19,7 +19,7 @@ class AddFileUseCase(UseCase):
             absolute_ref=req["absolute_ref"], data=req["data"], update_uncontained=req["update_uncontained"]
         )
         # Do not invalidate the blueprint cache if it was not a blueprint that was changed
-        if req["data"]["type"] == SIMOS.BLUEPRINT.value:
+        if isinstance(req["data"], dict) and req["data"]["type"] == SIMOS.BLUEPRINT.value:
             document_service.invalidate_cache()
 
         data_source, _, _ = split_absolute_ref(req["absolute_ref"])

--- a/src/use_case/update_document_use_case.py
+++ b/src/use_case/update_document_use_case.py
@@ -41,7 +41,8 @@ class UpdateDocumentUseCase(UseCase):
             files={f.filename: f.file for f in req.files} if req.files else None,
             update_uncontained=req.update_uncontained,
         )
+
         # Do not invalidate the blueprint cache if it was not a blueprint that was changed
-        if document["data"]["type"] == SIMOS.BLUEPRINT.value:
+        if isinstance(document["data"], dict) and document["data"]["type"] == SIMOS.BLUEPRINT.value:
             document_service.invalidate_cache()
         return JSONResponse(document)


### PR DESCRIPTION
## What does this pull request change?

* Fix a bug when want to update contained lists of items.

## Why is this pull request needed?

* Only check dict types for invalidate cache (blueprints)
* to_ref_dict does not exist on NodeList, so skip it

## Issues related to this change:
