### PR TITLE
update input to AzureBlobStorageClient

### DIFF
--- a/src/restful/request_types/create_data_source.py
+++ b/src/restful/request_types/create_data_source.py
@@ -15,8 +15,7 @@ class Repository(BaseModel, use_enum_values=True):
     password: Optional[str] = None
     database: Optional[str] = None
     collection: Optional[str] = None
-    account_name: Optional[str] = None
-    account_key: Optional[str] = None
+    account_url: Optional[str] = None  # URL to blob storage account, with SAS token included as a query parameter
     container: Optional[str] = None
     tls: Optional[bool] = True
 
@@ -24,7 +23,7 @@ class Repository(BaseModel, use_enum_values=True):
         return {
             **{k: v for k, v in self},
             "password": encrypt(self.password) if self.password else None,
-            "account_key": encrypt(self.account_key) if self.account_key else None,
+            "account_url": encrypt(self.account_url) if self.account_url else None,
         }
 
 

--- a/src/storage/repositories/azure_blob.py
+++ b/src/storage/repositories/azure_blob.py
@@ -7,8 +7,8 @@ from utils.encryption import decrypt
 
 
 class AzureBlobStorageClient(RepositoryInterface):
-    def __init__(self, account_name: str, account_key: str, container: str, **kwargs):
-        blob_service_client = BlobServiceClient(account_name=account_name, account_key=decrypt(account_key))
+    def __init__(self, account_url: str, container: str, **kwargs):
+        blob_service_client = BlobServiceClient(account_url=decrypt(account_url))
         self.blob_service_client = blob_service_client
         self.container = container
 

--- a/src/tests/bdd/data_source/crud.feature
+++ b/src/tests/bdd/data_source/crud.feature
@@ -84,8 +84,7 @@ Feature: Data Sources
         },
         "myAzureRepo": {
           "type": "azure-blob-storage",
-          "account_name": "dmssfilestorage",
-          "account_key": "a-long-key",
+          "account_url": "an-azure-blob-storage-url-with-sas-token",
           "name": "myAzureRepo",
           "collection": "dmss",
           "documentType": "blueprints"


### PR DESCRIPTION
## What does this pull request change?
* update input to AzureBlobStorageClient. The initialization broke after some packages were updated. BlobServiceClient uses account_url instead of account_key and account_name
(https://docs.microsoft.com/en-us/python/api/azure-storage-blob/azure.storage.blob.blobserviceclient?view=azure-python)
## Why is this pull request needed?
failing to use Demo DS in radix deployment, and failing to reset app locally.
## Issues related to this change:
