### PR TITLE
bug: use 'by_alias' when converting BaseModels with _id to dict

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ repos:
   rev: v2.5.0
   hooks:
     - id: check-ast
-      language_version: python3.8
+      language_version: python3.10
     - id: check-merge-conflict
     - id: check-json
     - id: check-yaml
@@ -12,7 +12,7 @@ repos:
   rev: 22.3.0
   hooks:
     - id: black
-      language_version: python3.8
+      language_version: python3.10
       files: ^src/.*\.py$
 
 - repo: https://github.com/PyCQA/bandit

--- a/src/restful/request_types/shared.py
+++ b/src/restful/request_types/shared.py
@@ -44,7 +44,7 @@ class UncontainedEntity(EntityType, OptionalEntityName, EntityUUID, extra=Extra.
 
     def to_dict(self):
         if self.name is not None:
-            return self.dict()
+            return self.dict(by_alias=True)
         else:
             return self.dict(exclude={"name"})
 
@@ -60,6 +60,6 @@ class BlueprintEntity(EntityType, EntityName, EntityUUID, extra=Extra.allow):
 class Entity(EntityType, OptionalEntityName, extra=Extra.allow):
     def to_dict(self):
         if self.name is not None:
-            return self.dict()
+            return self.dict(by_alias=True)
         else:
             return self.dict(exclude={"name"})


### PR DESCRIPTION
## What does this pull request change?
- Add the "by_alias" param to some pydantic models "to_dict" function, so not to return both "uid" and "_id"
- Update python language version on some pre-commit hooks

## Why is this pull request needed?
Avoid unwanted attribute in documents

## Issues related to this change:
closes #234 
