### PR TITLE
refactor: remove unused application attributes

### DIFF
--- a/src/home/system/SIMOS/Application.json
+++ b/src/home/system/SIMOS/Application.json
@@ -4,36 +4,5 @@
   "name": "Application",
   "description": "This describes an application",
   "attributes": [
-    {
-      "attributeType": "string",
-      "type": "sys://system/SIMOS/BlueprintAttribute",
-      "name": "packages",
-      "dimensions": "*",
-      "description": "Blueprint Packages to be internalized. Only supports packages within same DataSource",
-      "label": "Packages"
-    },
-    {
-      "attributeType": "string",
-      "type": "sys://system/SIMOS/BlueprintAttribute",
-      "name": "entities",
-      "dimensions": "*",
-      "description": "Entity Packages to be internalized. Only supports packages within same DataSource",
-      "label": "Entities"
-    },
-    {
-      "attributeType": "string",
-      "type": "sys://system/SIMOS/BlueprintAttribute",
-      "name": "models",
-      "dimensions": "*",
-      "description": "Models to create in application. Only supports packages within same DataSource",
-      "label": "Models"
-    },
-    {
-      "attributeType": "sys://system/SIMOS/Action",
-      "type": "sys://system/SIMOS/BlueprintAttribute",
-      "name": "actions",
-      "description": "Runnable actions",
-      "dimensions": "*"
-    }
   ]
 }


### PR DESCRIPTION
## What does this pull request change?

* Remove unused application attributes 
 
## Why is this pull request needed?

* Just removes old unused attributes from `application.json` blueprint

## Issues related to this change:

resolves #270 