### PR TITLE
fix: update export endpoint

### DIFF
--- a/src/features/export/export_feature.py
+++ b/src/features/export/export_feature.py
@@ -54,7 +54,6 @@ def export(absolute_document_ref: str, user: User = Depends(auth_w_jwt_or_pat)):
     Download a zip-folder with one or more documents as json file(s).
 
     absolute_document_ref is on the format: 'DATASOURCE/PACKAGE/{ENTITY.name/ENTITY._id}
-    A background task is used to delete the temporary created folder after result is returned.
     """
     memory_file_path = export_use_case(user=user, document_reference=absolute_document_ref)
     directory_to_remove = Path(memory_file_path).parent

--- a/src/features/export/use_cases/export_use_case.py
+++ b/src/features/export/use_cases/export_use_case.py
@@ -1,7 +1,30 @@
+import os
+import tempfile
+import zipfile
+
 from authentication.models import User
+from domain_classes.tree_node import Node
 from services.document_service import DocumentService
+from storage.repositories.zip import ZipFileClient
+
+
+def create_zip_export(document_service: DocumentService, absolute_document_ref: str) -> str:
+    """Create a temproary folder on the host that contains a zip file with."""
+    tmpdir = tempfile.mkdtemp()
+    archive_path = os.path.join(tmpdir, "temp_zip_archive.zip")
+
+    data_source_id, document_path = absolute_document_ref.split("/", 1)
+    document: Node = document_service.get_by_path(absolute_document_ref)
+    # TODO add meta information to the document. Single document,
+    # root package and non root packages needs to be handled in different ways
+    with zipfile.ZipFile(archive_path, mode="w", compression=zipfile.ZIP_DEFLATED, compresslevel=5) as zip_file:
+        # Save the selected node, using custom ZipFile repository
+        document_service.save(document, data_source_id, ZipFileClient(zip_file), update_uncontained=True)
+    return archive_path
 
 
 def export_use_case(user: User, document_reference: str):
-    memory_file = DocumentService(user=user).create_zip_export(document_reference)
+    memory_file = create_zip_export(
+        document_service=DocumentService(user=user), absolute_document_ref=document_reference
+    )
     return memory_file

--- a/src/services/document_service.py
+++ b/src/services/document_service.py
@@ -1,5 +1,4 @@
 import pprint
-import zipfile
 from functools import lru_cache
 from typing import Dict, List, Union
 from uuid import uuid4
@@ -485,14 +484,3 @@ class DocumentService:
         logger.info(f"Removed reference for '{attribute_path}' in '{root.name}'({root.uid})")
 
         return root.to_dict()
-
-    def create_zip_export(self, absolute_document_ref: str) -> str:
-        # TODO: This is not SAFE. See; https://security.openstack.org/guidelines/dg_using-temporary-files-securely.html
-        archive_path = "/tmp/temp_zip_archive.zip"  # nosec
-        data_source_id, document_uid = absolute_document_ref.split("/", 1)
-        document: Node = self.get_node_by_uid(data_source_id, document_uid)
-        # TODO: Is this secure?
-        with zipfile.ZipFile(archive_path, mode="w", compression=zipfile.ZIP_DEFLATED, compresslevel=5) as zip_file:
-            # Save the selected node, using custom ZipFile repository
-            self.save(document, data_source_id, ZipFileClient(zip_file), update_uncontained=True)
-        return archive_path

--- a/src/tests/bdd/export_package.feature
+++ b/src/tests/bdd/export_package.feature
@@ -13,7 +13,7 @@ Feature: Exporting root packages
 
 
   Scenario: A user want's to export a root package
-    Given I access the resource url "/api/v1/export/test-DS/1"
+    Given I access the resource url "/api/v1/export/test-DS/blueprints"
     When I make a "GET" request
     Then the response status should be "OK"
     And response node should not be empty

--- a/src/tests/bdd/export_package.feature
+++ b/src/tests/bdd/export_package.feature
@@ -17,4 +17,5 @@ Feature: Exporting root packages
     When I make a "GET" request
     Then the response status should be "OK"
     And response node should not be empty
+    And response should contain a zip file with name "dmt-export.zip"
 

--- a/src/tests/bdd/steps/handle_response.py
+++ b/src/tests/bdd/steps/handle_response.py
@@ -127,3 +127,9 @@ def step_impl(context):
 def step_impl(context):
     response = context.response
     assert response.headers["content-type"] == "application/zip" and len(response.content) > 200
+
+
+@then('response should contain a zip file with name "{filename}"')
+def step_impl(context, filename: str):
+    response = context.response
+    assert response.headers["Content-Disposition"] == f"attachment; filename={filename}"


### PR DESCRIPTION
## What does this pull request change?
update the export use case (fix security issues, add create_response declarator and delete temp folders on the DMSS host with a background task)
## Why is this pull request needed?
Start to facilitate functionality for exporting documents. later, this export endpoint will handle adding meta information to exported documents.
## Issues related to this change:
closes #285 