### PR TITLE
feature: endpoint for fetching an entities meta data

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# Each line is a file pattern followed by one or more owners.
+# Order matter. If two rules match the same file, only the last one is used
+
+# Repo owners
+*       @KristianKjerstad @netr0m @soofstad @eoaksnes

--- a/src/common/utils/get_document_by_path.py
+++ b/src/common/utils/get_document_by_path.py
@@ -1,18 +1,31 @@
 from typing import List, Union
 
+from authentication.models import User
 from common.exceptions import (
     ApplicationException,
     BadRequestException,
     NotFoundException,
 )
-from common.utils.string_helpers import get_package_and_path, split_dmss_ref
-from storage.data_source_class import DataSource
+from common.utils.string_helpers import split_dmss_ref
+from domain_classes.repository import Repository
 from storage.internal.data_source_repository import get_data_source
 
 
-def _find_document_in_package_by_path(
-    package: dict, path_elements: List[str], data_source: DataSource
-) -> Union[str, dict, None]:
+def get_root_package(root_package_name: str, repository: Repository) -> dict:
+    root_package: [dict] = repository.find({"name": root_package_name, "isRoot": True})
+    if not root_package:
+        raise NotFoundException(
+            f"No root package with name '{root_package_name}', in data source '{repository.name}' could be found."
+        )
+    if len(root_package) > 2:
+        raise ApplicationException(
+            f"More than 1 root package with name '{root_package_name}' "
+            + "was returned from DataSource. That should not happen..."
+        )
+    return root_package[0]
+
+
+def _get_document_uid_by_path(package: dict, path_elements: List[str], data_source: Repository) -> str:
     """
     :param package: A Package object to search down into
     :param path_elements: A list representation of the path to the document. Starting from _this_ package
@@ -25,41 +38,31 @@ def _find_document_in_package_by_path(
         if not file:
             raise NotFoundException(f"The document {target} could not be found in the package {package['name']}")
         return file["_id"]
-    else:
-        next_package_ref = next((p for p in package["content"] if p["name"] == path_elements[0]), None)
-        if not next_package_ref:
-            raise NotFoundException(
-                f"The package {path_elements[0]} could not be found in the package {package['name']}"
-            )
-        next_package: dict = data_source.get(next_package_ref["_id"])
-        if not next_package:
-            raise NotFoundException(
-                f"Could not find a package '{next_package_ref['_id']}' in datasource {data_source.name}"
-            )
-        del path_elements[0]
-        return _find_document_in_package_by_path(next_package, path_elements, data_source)
 
-
-def get_document_uid_by_path(dotted_path: str, repository) -> Union[str, None]:
-    root_package_name, path_elements = get_package_and_path(dotted_path)
-    root_package: [dict] = repository.find({"name": root_package_name, "isRoot": True})
-    if not root_package:
+    next_package_ref = next((p for p in package["content"] if p["name"] == path_elements[0]), None)
+    if not next_package_ref:
+        raise NotFoundException(f"The package {path_elements[0]} could not be found in the package {package['name']}")
+    next_package: dict = data_source.get(next_package_ref["_id"])
+    if not next_package:
         raise NotFoundException(
-            f"No root package with name '{root_package_name}', in data source '{repository.name}' could be found."
+            f"Could not find a package '{next_package_ref['_id']}' in datasource {data_source.name}"
         )
-    if len(root_package) > 2:
-        raise ApplicationException(
-            f"More than 1 root package with name '{root_package_name}' "
-            + "was returned from DataSource. That should not happen..."
-        )
+    del path_elements[0]
+    return _get_document_uid_by_path(next_package, path_elements, data_source)
+
+
+def get_document_uid_by_path(dotted_path: str, repository: Repository) -> Union[str, None]:
+    path_elements = dotted_path.split("/")
+    root_package_name = path_elements.pop(0)
+    root_package = get_root_package(root_package_name, repository)
     # Check if it's a root-package
     if not path_elements:
-        return root_package[0]["_id"]
-    uid = _find_document_in_package_by_path(root_package[0], path_elements, repository)
+        return root_package["_id"]
+    uid = _get_document_uid_by_path(root_package, path_elements, repository)
     return uid
 
 
-def get_document_by_absolute_path(absolute_path: str, user) -> dict:
+def get_document_by_absolute_path(absolute_path: str, user: User) -> dict:
     """Fetches the document from any supported protocol by the absolute path which must be on the format
     PROTOCOL://ADDRESS"""
 

--- a/src/common/utils/string_helpers.py
+++ b/src/common/utils/string_helpers.py
@@ -31,14 +31,6 @@ def split_dotted_id(dotted_id: str) -> Tuple[str, Union[str, None]]:
     return dotted_id.split(".", 1)
 
 
-def get_package_and_path(dotted_path: str) -> Tuple[str, Union[list, None]]:
-    elements = dotted_path.split("/")
-    package = elements.pop(0)
-    if len(elements) == 0:
-        return package, None
-    return package, elements
-
-
 # Convert dmt attribute_types to python types. If complex, return type as string.
 def get_data_type_from_dmt_type(attribute_type: str):
     try:

--- a/src/domain_classes/dependency.py
+++ b/src/domain_classes/dependency.py
@@ -1,11 +1,11 @@
-from dataclasses import dataclass
 from typing import Literal, NewType
+
+from pydantic import BaseModel
 
 TDependencyProtocol = NewType("TDependencyProtocol", Literal["sys", "http"])
 
 
-@dataclass(frozen=True)
-class Dependency:
+class Dependency(BaseModel):
     """Class for any dependencies (external types) a entity references"""
 
     alias: str

--- a/src/features/blueprint/blueprint_feature.py
+++ b/src/features/blueprint/blueprint_feature.py
@@ -26,6 +26,6 @@ def get_blueprint(type_ref: str, user: User = Depends(auth_w_jwt_or_pat)):
 @create_response(PlainTextResponse)
 def resolve_blueprint_id(absolute_id: str, user: User = Depends(auth_w_jwt_or_pat)):
     """
-    Resolve the data_source/uuid form of a blueprint to it's type path
+    Resolve the data_source/uuid form of a blueprint to its type path
     """
     return resolve_blueprint_use_case(user=user, absolute_id=absolute_id)

--- a/src/features/export/export_feature.py
+++ b/src/features/export/export_feature.py
@@ -1,13 +1,42 @@
+from typing import List
+
 from fastapi import APIRouter, Depends
-from starlette.responses import FileResponse
+from pydantic import BaseModel
+from starlette.responses import FileResponse, JSONResponse
 
 from authentication.authentication import auth_w_jwt_or_pat
 from authentication.models import User
-from common.responses import responses
-
-from .use_cases.export_use_case import export_use_case
+from common.responses import create_response, responses
+from domain_classes.dependency import Dependency
+from features.export.use_cases.export_meta_use_case import export_meta_use_case
+from features.export.use_cases.export_use_case import export_use_case
 
 router = APIRouter(tags=["default", "export"], prefix="/export")
+
+
+class ExportMetaResponse(BaseModel):
+    type: str = "CORE:Meta"
+    version: str = "0.0.0"
+    dependencies: List[Dependency] = []
+
+
+@router.get(
+    "/meta/{absolute_document_ref:path}",
+    operation_id="export-meta",
+    response_class=JSONResponse,
+    responses={**responses, 200: {"content": {"application/json": {}}}},
+)
+@create_response(JSONResponse)
+def export_meta(absolute_document_ref: str, user: User = Depends(auth_w_jwt_or_pat)):
+    """
+    Export only the metadata of an entity.
+    Entities must be specified on the format 'DATASOURCE/PACKAGE/{ENTITY.name/ENTITY._id}
+    An entities metadata is concatenated from the "top down". Inheriting parents meta, and overriding for any
+    specified further down.
+
+    If no metadata is defined anywhere in the tree, an empty object is returned.
+    """
+    return ExportMetaResponse(**export_meta_use_case(user=user, document_reference=absolute_document_ref)).dict()
 
 
 # TODO use create_response declarator. Must be able to handle FileResponse.

--- a/src/features/export/use_cases/export_meta_use_case.py
+++ b/src/features/export/use_cases/export_meta_use_case.py
@@ -1,0 +1,62 @@
+from typing import List
+
+from authentication.models import User
+from common.exceptions import NotFoundException
+from common.utils.get_document_by_path import get_root_package
+from common.utils.string_helpers import split_dmss_ref
+from storage.data_source_class import DataSource
+from storage.internal.data_source_repository import get_data_source
+
+
+def concat_meta_data(meta: dict | None, new_meta: dict | None) -> dict:
+    if not meta and not new_meta:
+        return {}
+    if not meta:
+        return new_meta
+    if not new_meta:
+        return meta
+
+    meta["version"] = new_meta.get("version", meta["version"])
+    meta["type"] = new_meta.get("type", meta["type"])
+    dependencies = {value["alias"]: value for value in meta["dependencies"]}
+
+    dependencies.update({value["alias"]: value for value in new_meta["dependencies"]})
+    meta["dependencies"] = [v for v in dependencies.values()]
+    return meta
+
+
+def _collect_entity_meta_by_path(
+    package: dict, path_elements: List[str], data_source: DataSource, existing_meta: dict
+) -> dict:
+    # TODO: Handle dotted attribute path
+    if len(path_elements) == 1:
+        target = path_elements[0]
+        file = next((f for f in package["content"] if f.get("name", f.get("_id")) == target), None)
+        if not file:
+            raise NotFoundException(f"The document '{target}' could not be found in the package '{package['name']}'")
+        entity: dict = data_source.get(file["_id"])
+        return concat_meta_data(existing_meta, entity.get("_meta_"))
+
+    next_package_ref = next((p for p in package["content"] if p["name"] == path_elements[0]), None)
+    if not next_package_ref:
+        raise NotFoundException(f"The package {path_elements[0]} could not be found in the package {package['name']}")
+    next_package: dict = data_source.get(next_package_ref["_id"])
+    if not next_package:
+        raise NotFoundException(
+            f"Could not find package '{next_package_ref['_id']}' in '{data_source.name}/{package['name']}'"
+        )
+    del path_elements[0]
+    collected_meta = concat_meta_data(existing_meta, next_package.get("_meta_"))
+    return _collect_entity_meta_by_path(next_package, path_elements, data_source, collected_meta)
+
+
+def export_meta_use_case(user: User, document_reference: str) -> dict:
+    data_source_id, path, attribute = split_dmss_ref(document_reference)
+    repository = get_data_source(data_source_id, user)
+
+    path_elements = path.split("/")
+    root_package_name = path_elements.pop(0)
+    root_package = get_root_package(root_package_name, repository)
+
+    meta = _collect_entity_meta_by_path(root_package, path_elements, repository, root_package.get("_meta_"))
+    return meta

--- a/src/tests/bdd/export_meta.feature
+++ b/src/tests/bdd/export_meta.feature
@@ -1,0 +1,120 @@
+Feature: Export an entity's meta data
+
+  Background: There are data sources in the system
+    Given the system data source and SIMOS core package are available
+    Given there are basic data sources with repositories
+      |   name  |
+      | test-DS |
+
+  Scenario: Fetch the meta of an entity with some meta info in root_package and some in the entity itself
+    Given there exist document with id "1" in data source "test-DS"
+    """
+    {
+      "name": "TestData",
+      "description": "",
+      "type": "sys://system/SIMOS/Package",
+      "_meta_": {
+        "type": "CORE:Meta",
+        "version": "0.0.1",
+        "dependencies": [
+          {
+            "alias": "CORE",
+            "address": "system/SIMOS",
+            "version": "0.0.1",
+            "protocol": "sys"
+          }
+        ]
+      },
+      "content": [
+        {
+          "name": "some-entity",
+          "type": "sys://system/SIMOS/Blueprint",
+          "_id": "3f9ff99f-9cb5-4afc-947b-a3224eee341f"
+        }
+      ],
+      "isRoot": true
+    }
+    """
+
+    Given there exist document with id "3f9ff99f-9cb5-4afc-947b-a3224eee341f" in data source "test-DS"
+    """
+    {
+      "type": "sys://system/SIMOS/Blueprint",
+      "name": "some-entity",
+      "_meta_": {
+        "type": "CORE:Meta",
+        "version": "0.0.1",
+        "dependencies": [
+          {
+            "alias": "TEST-MODELS",
+            "address": "DemoApplicationDataSource/models",
+            "version": "0.0.1",
+            "protocol": "sys"
+          }
+        ]
+      },
+      "extends": ["sys://system/SIMOS/NamedEntity"],
+      "description": "just some blueprint",
+      "attributes": []
+    }
+    """
+    Given i access the resource url "/api/v1/export/meta/test-DS/TestData/some-entity"
+    When i make a "GET" request
+    Then the response status should be "OK"
+    And the response should contain
+    """
+    {
+      "type": "CORE:Meta",
+      "version": "0.0.1",
+      "dependencies": [
+        {
+          "alias": "CORE",
+          "address": "system/SIMOS",
+          "version": "0.0.1",
+          "protocol": "sys"
+        },
+        {
+          "alias": "TEST-MODELS",
+          "address": "DemoApplicationDataSource/models",
+          "version": "0.0.1",
+          "protocol": "sys"
+        }
+      ]
+    }
+    """
+
+  Scenario: Fetch the meta of an entity with no meta data defined
+    Given there exist document with id "1" in data source "test-DS"
+    """
+    {
+      "name": "TestData",
+      "description": "",
+      "type": "sys://system/SIMOS/Package",
+      "content": [
+        {
+          "name": "some-entity",
+          "type": "sys://system/SIMOS/Blueprint",
+          "_id": "3f9ff99f-9cb5-4afc-947b-a3224eee341f"
+        }
+      ],
+      "isRoot": true
+    }
+    """
+
+    Given there exist document with id "3f9ff99f-9cb5-4afc-947b-a3224eee341f" in data source "test-DS"
+    """
+    {
+      "type": "sys://system/SIMOS/Blueprint",
+      "name": "some-entity",
+      "extends": ["sys://system/SIMOS/NamedEntity"],
+      "description": "just some blueprint",
+      "attributes": []
+    }
+    """
+    Given i access the resource url "/api/v1/export/meta/test-DS/TestData/some-entity"
+    When i make a "GET" request
+    Then the response status should be "OK"
+    And the response should contain
+    """
+    {}
+    """

--- a/src/tests/unit/test_concat_meta_data.py
+++ b/src/tests/unit/test_concat_meta_data.py
@@ -1,0 +1,75 @@
+import unittest
+
+from common.utils.data_structure.compare import pretty_eq
+from features.export.use_cases.export_meta_use_case import concat_meta_data
+
+
+class ConcatMetaTestCase(unittest.TestCase):
+    def test_concat_entity(self):
+        existing_meta = {
+            "type": "CORE:Meta",
+            "version": "0.0.1",
+            "dependencies": [
+                {"alias": "CORE", "address": "system/SIMOS", "version": "0.0.1", "protocol": "sys"},
+            ],
+        }
+        new_meta = {
+            "type": "CORE:Meta",
+            "version": "0.0.1",
+            "dependencies": [
+                {
+                    "alias": "TEST-MODELS",
+                    "address": "DemoApplicationDataSource/models",
+                    "version": "0.0.1",
+                    "protocol": "sys",
+                }
+            ],
+        }
+
+        concat_meta = concat_meta_data(existing_meta, new_meta)
+        expected = {
+            "type": "CORE:Meta",
+            "version": "0.0.1",
+            "dependencies": [
+                {"alias": "CORE", "address": "system/SIMOS", "version": "0.0.1", "protocol": "sys"},
+                {
+                    "alias": "TEST-MODELS",
+                    "address": "DemoApplicationDataSource/models",
+                    "version": "0.0.1",
+                    "protocol": "sys",
+                },
+            ],
+        }
+
+        result = pretty_eq(expected, concat_meta)
+        self.assertEqual(result, None)
+
+    def test_concat_entity_with_override(self):
+        existing_meta = {
+            "type": "CORE:Meta",
+            "version": "0.0.1",
+            "dependencies": [
+                {"alias": "CORE", "address": "system/SIMOS", "version": "0.0.1", "protocol": "sys"},
+                {"alias": "EXISTING-ALIAS", "address": "system/SIMOS", "version": "0.0.1", "protocol": "sys"},
+            ],
+        }
+        new_meta = {
+            "type": "dmss://system/SIMOS/Meta",
+            "version": "3.3.3",
+            "dependencies": [
+                {"alias": "EXISTING-ALIAS", "address": "an/address", "version": "2.2.2", "protocol": "http"}
+            ],
+        }
+
+        concat_meta = concat_meta_data(existing_meta, new_meta)
+        expected = {
+            "type": "dmss://system/SIMOS/Meta",
+            "version": "3.3.3",
+            "dependencies": [
+                {"alias": "CORE", "address": "system/SIMOS", "version": "0.0.1", "protocol": "sys"},
+                {"alias": "EXISTING-ALIAS", "address": "an/address", "version": "2.2.2", "protocol": "http"},
+            ],
+        }
+
+        result = pretty_eq(expected, concat_meta)
+        self.assertEqual(result, None)


### PR DESCRIPTION
## What does this pull request change?
- New endpoint for fetching an entity's meta data ("/export/meta/{path}")
- Some refactor to reduce duplicated code
 
## Why is this pull request needed?
- users need a simple way to get meta data

## Issues related to this change:
closes #278 
