### PR TITLE
refactor: use provided name as default value for created entity

### DIFF
--- a/src/common/utils/create_entity.py
+++ b/src/common/utils/create_entity.py
@@ -22,7 +22,7 @@ class InvalidDefaultValue(CreateEntityException):
 
 
 class CreateEntity:
-    def __init__(self, blueprint_provider: Callable, type: str):
+    def __init__(self, blueprint_provider: Callable, type: str, name: str = ""):
         if type == BuiltinDataTypes.OBJECT.value:
             type = SIMOS.ENTITY.value
         self.type = type
@@ -30,7 +30,7 @@ class CreateEntity:
         self.attribute_types = self.blueprint_provider(SIMOS.ATTRIBUTE_TYPES.value).to_dict()
         self.blueprint_attribute: Blueprint = self.blueprint_provider(SIMOS.BLUEPRINT_ATTRIBUTE.value)
         blueprint: Blueprint = self.blueprint_provider(type)
-        entity = {"type": type}
+        entity = {"type": type, "name": name}
         self._entity = self._get_entity(blueprint=blueprint, entity=entity)
 
     @staticmethod

--- a/src/features/entity/use_cases/instantiate_entity.py
+++ b/src/features/entity/use_cases/instantiate_entity.py
@@ -15,5 +15,5 @@ class BasicEntity(BaseModel, extra=Extra.allow):
 
 def instantiate_entity_use_case(basic_entity: BasicEntity, user: User) -> dict:
     document_service = DocumentService(user=user)
-    document: dict = CreateEntity(document_service.get_blueprint, basic_entity.type).entity
+    document: dict = CreateEntity(document_service.get_blueprint, basic_entity.type, basic_entity.name).entity
     return document


### PR DESCRIPTION
## What does this pull request change?

* Use name from request

## Why is this pull request needed?

* The dm-core package and `NewEntityButton` are taking the name as input, so this should be the value used when creating the entity

## Issues related to this change:
