### PR TITLE
feature: create lookup tables

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -17,4 +17,4 @@ jobs:
       - name: "Flake8"
         run: docker run devimage flake8
       - name: "Generate API"
-        run: docker run -d -p "8000:5000" devimage && ./generate-python-package.sh
+        run: docker run -d -p "5000:5000" devimage && ./generate-python-package.sh

--- a/generate-python-package.sh
+++ b/generate-python-package.sh
@@ -1,13 +1,16 @@
 #!/usr/bin/env bash
 
+# DMSS must be running locally on port 5000
+# Must be run from repository root, and will create folder 'gen'
+
 PACKAGE_VERSION=${PACKAGE_VERSION:="0.0.1"}
 
 echo "Creating DMSS Python package version $PACKAGE_VERSION"
 docker run --rm \
     --network="host" \
     -v ${PWD}:/local \
-    openapitools/openapi-generator-cli:v5.2.1 generate \
-    -i http://localhost:8000/openapi.json  \
+    openapitools/openapi-generator-cli:v6.2.1 generate \
+    -i http://localhost:5000/openapi.json  \
     -g python \
     -o /local/gen/dmss_api \
     --additional-properties=packageName=dmss_api,packageVersion=${PACKAGE_VERSION}

--- a/src/app.py
+++ b/src/app.py
@@ -38,6 +38,7 @@ def create_app() -> FastAPI:
     from features.entity import entity_feature
     from features.export import export_feature
     from features.health_check import health_check_feature
+    from features.lookup_table import lookup_table_feature
     from features.personal_access_token import personal_access_token_feature
     from features.reference import reference_feature
     from features.search import search_feature
@@ -57,6 +58,7 @@ def create_app() -> FastAPI:
     authenticated_routes.include_router(search_feature.router)
     authenticated_routes.include_router(whoami_feature.router)
     authenticated_routes.include_router(entity_feature.router)
+    authenticated_routes.include_router(lookup_table_feature.router)
 
     # Some routes a PAT can not be used to authenticate. For example, to get new access tokens. That would be bad...
     jwt_only_routes = APIRouter()

--- a/src/common/responses.py
+++ b/src/common/responses.py
@@ -45,7 +45,7 @@ If the execution fails, it will return a JSONResponse with a standardized error 
 """
 
 
-def create_response(response_class: Type[TResponse]) -> Callable[..., Callable[..., TResponse | JSONResponse]]:
+def create_response(response_class: Type[TResponse] = None) -> Callable[..., Callable[..., TResponse | JSONResponse]]:
     def func_wrapper(func) -> Callable[..., TResponse | JSONResponse]:
         @functools.wraps(func)
         async def wrapper_decorator(*args, **kwargs) -> TResponse | JSONResponse:
@@ -55,6 +55,8 @@ def create_response(response_class: Type[TResponse]) -> Callable[..., Callable[.
                     result = func(*args, **kwargs)
                 else:
                     result = await func(*args, **kwargs)
+                if not response_class:  # If there is no response class, we create a 204 response (OK - no content)
+                    return Response(status_code=status.HTTP_204_NO_CONTENT)
                 return response_class(result, status_code=200)
             except HTTPError as http_error:
                 error_response = ErrorResponse(

--- a/src/domain_classes/blueprint.py
+++ b/src/domain_classes/blueprint.py
@@ -5,20 +5,24 @@ from pydantic import ValidationError
 
 from domain_classes.blueprint_attribute import BlueprintAttribute
 from domain_classes.dependency import Dependency
-from domain_classes.storage_recipe import DefaultStorageRecipe, StorageRecipe
+from domain_classes.storage_recipe import (
+    DefaultStorageRecipe,
+    StorageAttribute,
+    StorageRecipe,
+)
 from domain_classes.ui_recipe import DefaultRecipe, Recipe
 from enums import PRIMITIVES, StorageDataTypes
 
 
-def get_storage_recipes(recipes: List[Dict], attributes: List[BlueprintAttribute]):
+def get_storage_recipes(recipes: list[dict], attributes: list[BlueprintAttribute]):
     if not recipes:
-        return [DefaultStorageRecipe(attributes)]
+        return [DefaultStorageRecipe(attributes=attributes)]
     else:
         return [
             StorageRecipe(
                 name=recipe["name"],
-                storageAffinity=recipe.get("storageAffinity", StorageDataTypes.DEFAULT.value),
-                attributes=recipe["attributes"],
+                storage_affinity=recipe.get("storageAffinity", StorageDataTypes.DEFAULT),
+                attributes={attribute["name"]: StorageAttribute(**attribute) for attribute in recipe["attributes"]},
             )
             for recipe in recipes
         ]
@@ -56,7 +60,7 @@ class Blueprint:
         instance = cls(adict)
         instance.attributes = [BlueprintAttribute(**attr) for attr in adict.get("attributes", [])]
         instance.storage_recipes = get_storage_recipes(adict.get("storageRecipes", []), instance.attributes)
-        instance.ui_recipes = [Recipe.from_dict(recipe_dict) for recipe_dict in adict.get("uiRecipes", [])]
+        instance.ui_recipes = [Recipe(**recipe_dict) for recipe_dict in adict.get("uiRecipes", [])]
         return instance
 
     def get_required_attributes(self):

--- a/src/domain_classes/lookup.py
+++ b/src/domain_classes/lookup.py
@@ -1,0 +1,10 @@
+from pydantic import BaseModel, Field
+
+from domain_classes.storage_recipe import StorageRecipe
+from domain_classes.ui_recipe import Recipe
+
+
+class Lookup(BaseModel):
+    # TODO: When openapi-generator supports OpenAPI v3.1, replace dict[str.. -> dict[common_type_constrained_string
+    ui_recipes: dict[str, list[Recipe]] = Field({}, alias="uiRecipes")
+    storage_recipes: dict[str, list[StorageRecipe]] = Field({}, alias="storageRecipes")

--- a/src/domain_classes/tree_node.py
+++ b/src/domain_classes/tree_node.py
@@ -514,15 +514,15 @@ class Node(NodeBase):
             nodes_attribute_on_parent = (
                 self.attribute.name if not self.parent.type == BuiltinDataTypes.OBJECT.value else "content"
             )
-            storage_attribute = self.parent.blueprint.storage_recipes[0].storage_attributes[nodes_attribute_on_parent]
+            storage_attribute = self.parent.blueprint.storage_recipes[0].attributes[nodes_attribute_on_parent]
 
             # If the attribute has default StorageAffinity in the parent, get it from the nodes own storageRecipe
-            if storage_attribute.storage_type_affinity is StorageDataTypes.DEFAULT:
-                storage_attribute.storage_type_affinity = self.blueprint.storage_recipes[0].storage_affinity
+            if storage_attribute.storage_affinity is StorageDataTypes.DEFAULT:
+                storage_attribute.storage_affinity = self.blueprint.storage_recipes[0].storage_affinity
             return storage_attribute
         # If no parent, the node is always contained, and get storageAffinity from the nodes own storageRecipe
         return StorageAttribute(
-            name=self.type, contained=True, storageTypeAffinity=self.blueprint.storage_recipes[0].storage_affinity
+            name=self.type, contained=True, storage_affinity=self.blueprint.storage_recipes[0].storage_affinity
         )
 
     def set_uid(self, new_id: str = None):

--- a/src/domain_classes/ui_recipe.py
+++ b/src/domain_classes/ui_recipe.py
@@ -4,7 +4,7 @@ from typing import List
 from pydantic import BaseModel
 
 from domain_classes.blueprint_attribute import BlueprintAttribute
-from enums import PRIMITIVES
+from enums import PRIMITIVES, SIMOS
 
 
 class RecipePlugin(Enum):
@@ -24,6 +24,7 @@ class RecipeAttribute(BaseModel):
 
 class Recipe(BaseModel):
     name: str
+    type: str = SIMOS.UI_RECIPE.value
     attributes: List[RecipeAttribute] = []
     description: str = ""
     plugin: str = "Default"
@@ -60,5 +61,5 @@ class Recipe(BaseModel):
 
 class DefaultRecipe(Recipe):
     def __init__(self, attributes: List[BlueprintAttribute]):
-        recipe_attributes = [RecipeAttribute(name=attr.name, contained=True) for attr in attributes]
+        recipe_attributes = [RecipeAttribute(name=attr.name) for attr in attributes]
         super().__init__("Default", attributes=recipe_attributes)

--- a/src/enums.py
+++ b/src/enums.py
@@ -44,6 +44,9 @@ class StorageDataTypes(str, Enum):
 
 class SIMOS(Enum):
     BLUEPRINT = "sys://system/SIMOS/Blueprint"
+    STORAGE_RECIPE = "sys://system/SIMOS/StorageRecipe"
+    STORAGE_ATTRIBUTE = "sys://system/SIMOS/StorageAttribute"
+    UI_RECIPE = "sys://system/SIMOS/UiRecipe"
     ENTITY = "sys://system/SIMOS/Entity"
     NAMED_ENTITY = "sys://system/SIMOS/NamedEntity"
     PACKAGE = "sys://system/SIMOS/Package"

--- a/src/features/lookup_table/lookup_table_feature.py
+++ b/src/features/lookup_table/lookup_table_feature.py
@@ -1,0 +1,29 @@
+from fastapi import APIRouter, Depends
+from starlette.responses import Response
+
+from authentication.authentication import auth_w_jwt_or_pat
+from authentication.models import User
+from common.responses import create_response, responses
+from domain_classes.lookup import Lookup
+from features.lookup_table.use_cases.create_lookup_table import create_lookup_table_use_case
+from restful.request_types.shared import common_name_constrained_string
+
+router = APIRouter(tags=["default", "lookup-table"], prefix="/lookup")
+
+
+@router.post(
+    "/{lookup_name:str}",
+    operation_id="create_lookup",
+    status_code=204,
+    response_class=Response,
+    responses={**responses},
+)
+@create_response()
+def create_lookup(
+    lookup_name: common_name_constrained_string, content: Lookup, user: User = Depends(auth_w_jwt_or_pat)
+):
+    """
+    Create a named lookup table.
+    This can be used for setting Ui- and StorageRecipes for specific applications.
+    """
+    return create_lookup_table_use_case(lookup_name, content, user)

--- a/src/features/lookup_table/use_cases/create_lookup_table.py
+++ b/src/features/lookup_table/use_cases/create_lookup_table.py
@@ -1,0 +1,9 @@
+from authentication.access_control import DEFAULT_ACL, access_control
+from authentication.models import AccessLevel, User
+from domain_classes.lookup import Lookup
+from storage.internal.lookup_tables import insert_lookup
+
+
+def create_lookup_table_use_case(name: str, table: Lookup, user: User) -> None:
+    access_control(DEFAULT_ACL, AccessLevel.WRITE, user)
+    insert_lookup(name, table.dict())

--- a/src/home/system/SIMOS/StorageAttribute.json
+++ b/src/home/system/SIMOS/StorageAttribute.json
@@ -22,7 +22,7 @@
     {
       "attributeType": "string",
       "type": "sys://system/SIMOS/BlueprintAttribute",
-      "name": "storageTypeAffinity",
+      "name": "storageAffinity",
       "default": "default",
       "enumType": "sys://system/SIMOS/enums/StorageTypes",
       "description": "Will be used to decide how the data will be stored",

--- a/src/restful/request_types/shared.py
+++ b/src/restful/request_types/shared.py
@@ -4,28 +4,32 @@ from pydantic import UUID4, Field, constr, root_validator
 from pydantic.main import BaseModel, Extra
 
 # Only allow characters a-9 and '_' + '-'
-name_regex = "^[A-Za-z0-9_-]*$"
+common_name_constrained_string = constr(min_length=1, max_length=128, regex="^[A-Za-z0-9_-]*$", strip_whitespace=True)
+
+# Regex only allow characters a-9 and '_' + '-' + '/' for paths
+common_type_constrained_string = constr(
+    min_length=3, max_length=128, regex=r"^[A-Z:a-z0-9_\/-]*$", strip_whitespace=True
+)  # noqa
 
 
 class EntityName(BaseModel):
-    name: constr(min_length=1, max_length=128, regex=name_regex, strip_whitespace=True)
+    name: common_name_constrained_string
 
 
 class OptionalEntityName(BaseModel):
-    name: Optional[constr(min_length=1, max_length=128, regex=name_regex, strip_whitespace=True)]
+    name: Optional[common_name_constrained_string]
 
 
 class EntityType(BaseModel):
-    # Regex only allow characters a-9 and '_' + '-' + '/' for paths
-    type: constr(min_length=3, max_length=128, regex=r"^[A-Z:a-z0-9_\/-]*$", strip_whitespace=True)  # noqa
+    type: common_type_constrained_string
 
 
 class DataSource(BaseModel):
-    data_source_id: constr(min_length=3, max_length=128, regex=name_regex, strip_whitespace=True)
+    data_source_id: common_name_constrained_string
 
 
 class DataSourceList(BaseModel):
-    data_sources: list[constr(min_length=3, max_length=128, regex=name_regex, strip_whitespace=True)]
+    data_sources: list[common_name_constrained_string]
 
 
 class EntityUUID(BaseModel):

--- a/src/services/database.py
+++ b/src/services/database.py
@@ -14,3 +14,4 @@ else:
 internal_db = mongo_client["dmss-internal"]
 data_source_collection = mongo_client["dmss-internal"]["data_sources"]
 personal_access_token_collection = mongo_client["dmss-internal"]["personal_access_tokens"]
+lookup_table_collection = mongo_client["dmss-internal"]["lookup_tables"]

--- a/src/storage/data_source_class.py
+++ b/src/storage/data_source_class.py
@@ -54,10 +54,10 @@ class DataSource:
         # Returns the first repo with a matching "dataType" value, or the first Repo if no match
         if storage_attribute:
             for r in self.repositories.values():
-                if storage_attribute.storage_type_affinity in r.data_types:
+                if storage_attribute.storage_affinity in r.data_types:
                     return r
         if strict:
-            raise ValueError(f"No repository for '{storage_attribute.storage_type_affinity}' data configured")
+            raise ValueError(f"No repository for '{storage_attribute.storage_affinity}' data configured")
         return self.get_default_repository()
 
     # TODO: Read default attribute from DataSource spec
@@ -168,7 +168,8 @@ class DataSource:
 
     def update_blob(self, uid, file) -> None:
         repo = self._get_repo_from_storage_attribute(
-            StorageAttribute("generic_blob", False, StorageDataTypes.BLOB.value), strict=True
+            StorageAttribute(name="generic_blob", contained=False, storage_affinity=StorageDataTypes.BLOB),
+            strict=True,
         )
         lookup = DocumentLookUp(lookup_id=uid, repository=repo.name, database_id=uid, acl=create_acl(self.user))
         access_control(lookup.acl, AccessLevel.WRITE, self.user)

--- a/src/storage/internal/lookup_tables.py
+++ b/src/storage/internal/lookup_tables.py
@@ -1,0 +1,33 @@
+from functools import lru_cache
+
+from pymongo.errors import DuplicateKeyError
+
+from common.exceptions import BadRequestException, NotFoundException
+from config import config
+from services.database import lookup_table_collection
+
+
+def insert_lookup(lookup_id: str, lookup: dict) -> None:
+    lookup["_id"] = lookup_id
+    try:
+        lookup_table_collection.insert_one(lookup)
+    except DuplicateKeyError:
+        raise BadRequestException(
+            f"A lookup table with name '{lookup['name']}' already exists."
+            + " Use a different name, or delete the old one first"
+        )
+
+
+@lru_cache(maxsize=config.CACHE_MAX_SIZE)
+def get_lookup(lookup_id: str) -> dict:
+    lookup = lookup_table_collection.find_one(filter={"_id": lookup_id})
+    if not lookup:
+        raise NotFoundException(f"No lookup table with name '{lookup_id}' exists.")
+    return lookup
+
+
+def delete_lookup(lookup_id: str) -> None:
+    try:
+        lookup_table_collection.remove(filter={"_id": lookup_id})
+    except NotFoundException:  # TODO: replace with actual exception from pymongo
+        pass

--- a/src/tests/bdd/create_lookup.feature
+++ b/src/tests/bdd/create_lookup.feature
@@ -1,0 +1,19 @@
+Feature: Create a lookup table
+
+  Scenario: Create a lookup table
+    Given i access the resource url "/api/v1/lookup/my-new-lookup"
+    When i make a "POST" request
+    """
+    {
+      "uiRecipes": {
+        "someDS/aPackage/myBlueprint": [
+          {
+            "type": "sys://system/SIMOS/UiRecipe",
+            "name": "MySignalView",
+            "plugin": "signal-plot"
+          }
+        ]
+      }
+    }
+    """
+    Then the response status should be "No Content"

--- a/src/tests/unit/mock_blueprint_provider.py
+++ b/src/tests/unit/mock_blueprint_provider.py
@@ -141,7 +141,7 @@ uncontained_blueprint = {
                     "name": "uncontained_in_every_way",
                     "type": "does_this_matter?",
                     "contained": False,
-                    "storageTypeAffinity": "blob",
+                    "storageAffinity": "blob",
                 }
             ],
         }

--- a/src/tests/unit/test_data_source_and_repositories.py
+++ b/src/tests/unit/test_data_source_and_repositories.py
@@ -74,7 +74,7 @@ class DataSourceTestCase(unittest.TestCase):
 
         document_service.save(node, "testing", update_uncontained=True)
 
-        # Test that both repos get's written into
+        # Test that both repos gets written into
         assert blob_doc_storage and default_doc_storage
 
     def test_save_based_on_root_storageRecipe(self):


### PR DESCRIPTION
## What does this pull request change?
- New endpoint `POST lookup/myNewLookup`
- Update `create_response` to accept no response_class. Needed for responses with no content
- Refactor StorageRecipe and StorageAttribute to be pydantic classes. Needed for use in validation.
- Rename "StorageAttribute" `storageTypeAffinity` -> `storageAffintiy` to be consistent with "StorageRecipes"

## Why is this pull request needed?
- Recipes should be taken out of the Blueprints, must be available for DMSS, and are application specific. 

## Issues related to this change:
closes #282 
