### PR TITLE
fix: include package json file with package meta info when exporting

### DIFF
--- a/src/domain_classes/tree_node.py
+++ b/src/domain_classes/tree_node.py
@@ -70,6 +70,10 @@ class DictExporter:
                 if attribute.name in node.entity:
                     data[attribute.name] = node.entity[attribute.name]
 
+        # Add _meta_ attribute if it exists in the entity
+        if "_meta_" in node.entity:
+            data["_meta_"] = node.entity["_meta_"]
+
         # Complex
         for child in node.children:
             if child.is_array():
@@ -135,6 +139,8 @@ class DictImporter:
         node = Node(key=key, uid=uid, entity=entity, blueprint_provider=blueprint_provider, attribute=node_attribute)
 
         for child_attribute in node.blueprint.get_none_primitive_types():
+            if child_attribute.name == "_meta_":
+                continue
             child_contained = node.blueprint.storage_recipes[0].is_contained(child_attribute.name)
             # This will stop creation of recursive blueprints (only if they are optional)
             if child_attribute.is_optional and not entity:

--- a/src/features/export/use_cases/export_use_case.py
+++ b/src/features/export/use_cases/export_use_case.py
@@ -3,28 +3,35 @@ import tempfile
 import zipfile
 
 from authentication.models import User
+from common.exceptions import ApplicationException
 from domain_classes.tree_node import Node
+from enums import SIMOS
 from services.document_service import DocumentService
 from storage.repositories.zip import ZipFileClient
 
 
-def create_zip_export(document_service: DocumentService, absolute_document_ref: str) -> str:
-    """Create a temproary folder on the host that contains a zip file with."""
+def create_zip_export(document_service: DocumentService, absolute_document_ref: str, user: User) -> str:
+    """Create a temporary folder on the host that contains a zip file with."""
     tmpdir = tempfile.mkdtemp()
     archive_path = os.path.join(tmpdir, "temp_zip_archive.zip")
 
     data_source_id, document_path = absolute_document_ref.split("/", 1)
     document: Node = document_service.get_by_path(absolute_document_ref)
-    # TODO add meta information to the document. Single document,
-    # root package and non root packages needs to be handled in different ways
-    with zipfile.ZipFile(archive_path, mode="w", compression=zipfile.ZIP_DEFLATED, compresslevel=5) as zip_file:
-        # Save the selected node, using custom ZipFile repository
-        document_service.save(document, data_source_id, ZipFileClient(zip_file), update_uncontained=True)
-    return archive_path
+    if document.entity["type"] == SIMOS.PACKAGE.value and document.entity["isRoot"]:
+        # TODO handle root package
+        raise ApplicationException(message="Create zip export is only supported for a single document (not a package)")
+    elif document.entity["type"] == SIMOS.PACKAGE.value and not document.entity["isRoot"]:
+        # TODO handle non root pacakge
+        raise ApplicationException(message="Create zip export is only supported for a single document (not a package)")
+    else:
+        with zipfile.ZipFile(archive_path, mode="w", compression=zipfile.ZIP_DEFLATED, compresslevel=5) as zip_file:
+            # Save the selected node, using custom ZipFile repository
+            document_service.save(document, data_source_id, ZipFileClient(zip_file), update_uncontained=True)
+        return archive_path
 
 
 def export_use_case(user: User, document_reference: str):
     memory_file = create_zip_export(
-        document_service=DocumentService(user=user), absolute_document_ref=document_reference
+        document_service=DocumentService(user=user), absolute_document_ref=document_reference, user=user
     )
     return memory_file

--- a/src/features/export/use_cases/export_use_case.py
+++ b/src/features/export/use_cases/export_use_case.py
@@ -4,10 +4,42 @@ import zipfile
 
 from authentication.models import User
 from common.exceptions import ApplicationException
-from domain_classes.tree_node import Node
+from domain_classes.tree_node import ListNode, Node
 from enums import SIMOS
 from services.document_service import DocumentService
 from storage.repositories.zip import ZipFileClient
+
+
+def get_package_structure_from_node(node: Node | ListNode, document_structure: dict, path: str = ""):
+    """Returns a dict on the format:
+    {
+        "path": document
+    }
+    where document contains _meta_ information about package.
+    """
+    if node.type == SIMOS.PACKAGE.value and "_meta_" in node.entity and len(node.entity["_meta_"]) > 0:
+        if node.is_root():
+            path = node.name
+        else:
+            path += f"/{node.name}"
+        package_document = {"name": node.name, "type": SIMOS.PACKAGE.value, "_meta_": node.entity["_meta_"]}
+
+        document_path = path
+        document_structure[document_path] = package_document
+    for child in node.children:
+        get_package_structure_from_node(child, document_structure, path)
+    return document_structure
+
+
+def store_package_meta_as_files(document_node: Node, storage_client: ZipFileClient):
+    """
+    When exporting a package, the meta information for the package
+    (since a package is exported as a folder in the zip file).
+    Therefore, we must add a package.json file inside the package folder to store meta information.
+    """
+    meta_documents = get_package_structure_from_node(document_node, {})
+    for path, document in meta_documents.items():
+        storage_client.add(document=document, path=path, filename="package")
 
 
 def create_zip_export(document_service: DocumentService, absolute_document_ref: str, user: User) -> str:
@@ -16,17 +48,23 @@ def create_zip_export(document_service: DocumentService, absolute_document_ref: 
     archive_path = os.path.join(tmpdir, "temp_zip_archive.zip")
 
     data_source_id, document_path = absolute_document_ref.split("/", 1)
-    document: Node = document_service.get_by_path(absolute_document_ref)
-    if document.entity["type"] == SIMOS.PACKAGE.value and document.entity["isRoot"]:
-        # TODO handle root package
-        raise ApplicationException(message="Create zip export is only supported for a single document (not a package)")
-    elif document.entity["type"] == SIMOS.PACKAGE.value and not document.entity["isRoot"]:
+    document_node: Node = document_service.get_by_path(absolute_document_ref)
+    if document_node.entity["type"] == SIMOS.PACKAGE.value and document_node.entity["isRoot"]:
+        with zipfile.ZipFile(archive_path, mode="w", compression=zipfile.ZIP_DEFLATED, compresslevel=5) as zip_file:
+            # Save the selected node, using custom ZipFile repository
+            storage_client = ZipFileClient(zip_file)
+            document_service.save(document_node, data_source_id, storage_client, update_uncontained=True)
+            store_package_meta_as_files(document_node=document_node, storage_client=storage_client)
+
+        return archive_path
+    elif document_node.entity["type"] == SIMOS.PACKAGE.value and not document_node.entity["isRoot"]:
         # TODO handle non root pacakge
         raise ApplicationException(message="Create zip export is only supported for a single document (not a package)")
+        # TODO add package.json file when exporting
     else:
         with zipfile.ZipFile(archive_path, mode="w", compression=zipfile.ZIP_DEFLATED, compresslevel=5) as zip_file:
             # Save the selected node, using custom ZipFile repository
-            document_service.save(document, data_source_id, ZipFileClient(zip_file), update_uncontained=True)
+            document_service.save(document_node, data_source_id, ZipFileClient(zip_file), update_uncontained=True)
         return archive_path
 
 

--- a/src/features/export/use_cases/export_use_case.py
+++ b/src/features/export/use_cases/export_use_case.py
@@ -11,7 +11,7 @@ from storage.repositories.zip import ZipFileClient
 
 
 def create_zip_export(document_service: DocumentService, absolute_document_ref: str, user: User) -> str:
-    """Create a temporary folder on the host that contains a zip file with."""
+    """Create a temporary folder on the host that contains a zip file.s"""
     tmpdir = tempfile.mkdtemp()
     archive_path = os.path.join(tmpdir, "temp_zip_archive.zip")
 
@@ -24,15 +24,16 @@ def create_zip_export(document_service: DocumentService, absolute_document_ref: 
             document_service.save(document_node, data_source_id, storage_client, update_uncontained=True)
 
         return archive_path
-    elif document_node.entity["type"] == SIMOS.PACKAGE.value and not document_node.entity["isRoot"]:
-        # TODO handle non root pacakge
-        raise ApplicationException(message="Create zip export is only supported for a single document (not a package)")
-        # TODO add package.json file when exporting
-    else:
-        with zipfile.ZipFile(archive_path, mode="w", compression=zipfile.ZIP_DEFLATED, compresslevel=5) as zip_file:
-            # Save the selected node, using custom ZipFile repository
-            document_service.save(document_node, data_source_id, ZipFileClient(zip_file), update_uncontained=True)
-        return archive_path
+    if document_node.entity["type"] == SIMOS.PACKAGE.value and not document_node.entity["isRoot"]:
+        # TODO handle non root package
+        raise ApplicationException(
+            message="Create zip export is only supported for a single document and root package"
+        )
+
+    with zipfile.ZipFile(archive_path, mode="w", compression=zipfile.ZIP_DEFLATED, compresslevel=5) as zip_file:
+        # Save the selected node, using custom ZipFile repository
+        document_service.save(document_node, data_source_id, ZipFileClient(zip_file), update_uncontained=True)
+    return archive_path
 
 
 def export_use_case(user: User, document_reference: str):

--- a/src/storage/repositories/zip.py
+++ b/src/storage/repositories/zip.py
@@ -1,6 +1,7 @@
 import json
 from zipfile import ZipFile
 
+from common.exceptions import ValidationException
 from common.utils.logging import logger
 from enums import SIMOS
 from storage.repository_interface import RepositoryInterface
@@ -24,8 +25,19 @@ class ZipFileClient(RepositoryInterface):
     def get(self, uid: str):
         return "Not implemented on ZipFile repository!"
 
-    def add(self, uid: str, document: dict):
-        return "Not implemented on ZipFile repository!"
+    def add(self, document: dict, path: str, filename: str = None):
+        """Add the provided document as a  json file to the zip file"""
+        if path[-1] == "/":
+            raise ValidationException(message=f"When adding file to Zip, path ({path}) should not end with a '/'")
+        json_data = json.dumps(document)
+        binary_data = json_data.encode()
+
+        if filename:
+            write_path = f"{path}/{filename}.json"
+        else:
+            write_path = f"{path}/{document['name']}.json"
+        logger.debug(f"Writing: {document['type']} to {write_path}")
+        self.zip_file.writestr(write_path, binary_data)
 
     def delete(self, uid: str):
         return "Not implemented on ZipFile repository!"

--- a/src/storage/repositories/zip.py
+++ b/src/storage/repositories/zip.py
@@ -1,7 +1,7 @@
 import json
+from pathlib import Path
 from zipfile import ZipFile
 
-from common.exceptions import ValidationException
 from common.utils.logging import logger
 from enums import SIMOS
 from storage.repository_interface import RepositoryInterface
@@ -14,6 +14,8 @@ class ZipFileClient(RepositoryInterface):
     def update(self, entity: dict, storage_recipe=None, **kwargs):
         entity.pop("_id", None)
         entity.pop("uid", None)
+        if "/" in entity["__path__"][-1]:
+            entity["__path__"] = entity["__path__"][:-1]
         write_to = f"{entity['__path__']}/{entity['name']}.json"
         entity.pop("__path__")
         json_data = json.dumps(entity)
@@ -21,23 +23,14 @@ class ZipFileClient(RepositoryInterface):
         logger.debug(f"Writing: {entity['type']} to {write_to}")
         if entity["type"] != SIMOS.PACKAGE.value:
             self.zip_file.writestr(write_to, binary_data)
+        else:
+            self.zip_file.writestr(f"{Path(write_to).parent}/package.json", json.dumps(entity["_meta_"]).encode())
 
     def get(self, uid: str):
         return "Not implemented on ZipFile repository!"
 
     def add(self, document: dict, path: str, filename: str = None):
-        """Add the provided document as a  json file to the zip file"""
-        if path[-1] == "/":
-            raise ValidationException(message=f"When adding file to Zip, path ({path}) should not end with a '/'")
-        json_data = json.dumps(document)
-        binary_data = json_data.encode()
-
-        if filename:
-            write_path = f"{path}/{filename}.json"
-        else:
-            write_path = f"{path}/{document['name']}.json"
-        logger.debug(f"Writing: {document['type']} to {write_path}")
-        self.zip_file.writestr(write_path, binary_data)
+        return "Not implemented on ZipFile repository!"
 
     def delete(self, uid: str):
         return "Not implemented on ZipFile repository!"

--- a/src/storage/repositories/zip.py
+++ b/src/storage/repositories/zip.py
@@ -14,8 +14,7 @@ class ZipFileClient(RepositoryInterface):
     def update(self, entity: dict, storage_recipe=None, **kwargs):
         entity.pop("_id", None)
         entity.pop("uid", None)
-        if "/" in entity["__path__"][-1]:
-            entity["__path__"] = entity["__path__"][:-1]
+        entity["__path__"] = entity["__path__"].rstrip("/")
         write_to = f"{entity['__path__']}/{entity['name']}.json"
         entity.pop("__path__")
         json_data = json.dumps(entity)
@@ -29,7 +28,7 @@ class ZipFileClient(RepositoryInterface):
     def get(self, uid: str):
         return "Not implemented on ZipFile repository!"
 
-    def add(self, document: dict, path: str, filename: str = None):
+    def add(self, uid: str, document: dict):
         return "Not implemented on ZipFile repository!"
 
     def delete(self, uid: str):

--- a/src/storage/repositories/zip.py
+++ b/src/storage/repositories/zip.py
@@ -22,7 +22,7 @@ class ZipFileClient(RepositoryInterface):
         logger.debug(f"Writing: {entity['type']} to {write_to}")
         if entity["type"] != SIMOS.PACKAGE.value:
             self.zip_file.writestr(write_to, binary_data)
-        else:
+        elif "_meta_" in entity:
             self.zip_file.writestr(f"{Path(write_to).parent}/package.json", json.dumps(entity["_meta_"]).encode())
 
     def get(self, uid: str):


### PR DESCRIPTION
## What does this pull request change?
 include package json file with package meta info when exporting.
handle 3 cases when exporting:
1) single file
2) root package
3) non root package

non root pacakge is not yet supported. will add functionality for this later

## Why is this pull request needed?
support export feature
## Issues related to this change:
closes #286 