### PR TITLE
feature: generate recipe lookup from imported folders

### DIFF
--- a/src/common/utils/package_import.py
+++ b/src/common/utils/package_import.py
@@ -19,7 +19,7 @@ def _add_documents(path, documents, data_source) -> List[Dict]:
         logger.debug(f"Working on {file}...")
         with open(f"{path}/{file}") as json_file:
             document = json.load(json_file)
-        if not url_safe_name(document["name"]):
+        if document.get("name") and not url_safe_name(document["name"]):
             raise BadRequestException(
                 message=f"'{document['name']}' is a invalid document name. "
                 f"Only alphanumeric, underscore, and dash are allowed characters"

--- a/src/domain_classes/lookup.py
+++ b/src/domain_classes/lookup.py
@@ -1,3 +1,5 @@
+from collections import defaultdict
+
 from pydantic import BaseModel, Field
 
 from domain_classes.storage_recipe import StorageRecipe
@@ -6,5 +8,7 @@ from domain_classes.ui_recipe import Recipe
 
 class Lookup(BaseModel):
     # TODO: When openapi-generator supports OpenAPI v3.1, replace dict[str.. -> dict[common_type_constrained_string
-    ui_recipes: dict[str, list[Recipe]] = Field({}, alias="uiRecipes")
-    storage_recipes: dict[str, list[StorageRecipe]] = Field({}, alias="storageRecipes")
+    ui_recipes: dict[str, list[Recipe]] = Field(default_factory=lambda: defaultdict(list), alias="uiRecipes")
+    storage_recipes: dict[str, list[StorageRecipe]] = Field(
+        default_factory=lambda: defaultdict(list), alias="storageRecipes"
+    )

--- a/src/enums.py
+++ b/src/enums.py
@@ -53,6 +53,7 @@ class SIMOS(Enum):
     BLUEPRINT_ATTRIBUTE = "sys://system/SIMOS/BlueprintAttribute"
     ATTRIBUTE_TYPES = "sys://system/SIMOS/AttributeTypes"
     BLOB = "sys://system/SIMOS/Blob"
+    RECIPE_LINK = "sys://system/SIMOS/RecipeLink"
     DATASOURCE = "datasource"
 
 

--- a/src/features/lookup_table/lookup_table_feature.py
+++ b/src/features/lookup_table/lookup_table_feature.py
@@ -8,21 +8,21 @@ from features.lookup_table.use_cases.create_lookup_table import (
     create_lookup_table_use_case,
 )
 
-router = APIRouter(tags=["default", "lookup-table"], prefix="/lookup")
+router = APIRouter(tags=["default", "lookup-table"])
 
 
 @router.post(
-    "/{recipe_package_path:path}",
+    "/application/{application}",
     operation_id="create_lookup",
     status_code=204,
     response_class=Response,
     responses={**responses},
 )
 @create_response()
-def create_lookup(recipe_package_path: str, application: str, user: User = Depends(auth_w_jwt_or_pat)):
+def create_lookup(recipe_package: str, application: str, user: User = Depends(auth_w_jwt_or_pat)):
     """
     Create a recipe lookup table from a package containing RecipeLinks.
     Associate it with an application.
     This can be used for setting Ui- and StorageRecipes for specific applications.
     """
-    return create_lookup_table_use_case(recipe_package_path, application, user)
+    return create_lookup_table_use_case(recipe_package, application, user)

--- a/src/features/lookup_table/lookup_table_feature.py
+++ b/src/features/lookup_table/lookup_table_feature.py
@@ -4,26 +4,25 @@ from starlette.responses import Response
 from authentication.authentication import auth_w_jwt_or_pat
 from authentication.models import User
 from common.responses import create_response, responses
-from domain_classes.lookup import Lookup
-from features.lookup_table.use_cases.create_lookup_table import create_lookup_table_use_case
-from restful.request_types.shared import common_name_constrained_string
+from features.lookup_table.use_cases.create_lookup_table import (
+    create_lookup_table_use_case,
+)
 
 router = APIRouter(tags=["default", "lookup-table"], prefix="/lookup")
 
 
 @router.post(
-    "/{lookup_name:str}",
+    "/{recipe_package_path:path}",
     operation_id="create_lookup",
     status_code=204,
     response_class=Response,
     responses={**responses},
 )
 @create_response()
-def create_lookup(
-    lookup_name: common_name_constrained_string, content: Lookup, user: User = Depends(auth_w_jwt_or_pat)
-):
+def create_lookup(recipe_package_path: str, application: str, user: User = Depends(auth_w_jwt_or_pat)):
     """
-    Create a named lookup table.
+    Create a recipe lookup table from a package containing RecipeLinks.
+    Associate it with an application.
     This can be used for setting Ui- and StorageRecipes for specific applications.
     """
-    return create_lookup_table_use_case(lookup_name, content, user)
+    return create_lookup_table_use_case(recipe_package_path, application, user)

--- a/src/features/lookup_table/use_cases/create_lookup_table.py
+++ b/src/features/lookup_table/use_cases/create_lookup_table.py
@@ -1,9 +1,39 @@
 from authentication.access_control import DEFAULT_ACL, access_control
 from authentication.models import AccessLevel, User
 from domain_classes.lookup import Lookup
+from domain_classes.storage_recipe import StorageAttribute, StorageRecipe
+from domain_classes.ui_recipe import Recipe
+from enums import SIMOS, StorageDataTypes
+from services.document_service import DocumentService
+from storage.internal.data_source_repository import get_data_source
 from storage.internal.lookup_tables import insert_lookup
 
 
-def create_lookup_table_use_case(name: str, table: Lookup, user: User) -> None:
+def create_lookup_table_use_case(
+    recipe_package_path: str, name: str, user: User, repository_provider=get_data_source
+) -> None:
     access_control(DEFAULT_ACL, AccessLevel.WRITE, user)
-    insert_lookup(name, table.dict())
+
+    document_service = DocumentService(repository_provider=repository_provider, user=user)
+
+    recipe_package = document_service.get_by_path(recipe_package_path)
+
+    lookup: Lookup = Lookup()
+
+    for node in recipe_package.traverse():
+        if node.type == SIMOS.RECIPE_LINK.value:
+            ui_recipes = [Recipe(**r) for r in node.entity.get("uiRecipes", [])]
+
+            storage_recipes = [
+                StorageRecipe(
+                    name=r["name"],
+                    storage_affinity=r.get("storageAffinity", StorageDataTypes.DEFAULT),
+                    attributes={attribute["name"]: StorageAttribute(**attribute) for attribute in r["attributes"]},
+                )
+                for r in node.entity.get("storageRecipes", [])
+            ]
+
+            lookup.storage_recipes[node.entity["_blueprintPath_"]].extend(storage_recipes)
+            lookup.ui_recipes[node.entity["_blueprintPath_"]].extend(ui_recipes)
+
+    insert_lookup(name, lookup.dict())

--- a/src/home/system/SIMOS/RecipeLink.json
+++ b/src/home/system/SIMOS/RecipeLink.json
@@ -1,0 +1,30 @@
+{
+  "type": "sys://system/SIMOS/Blueprint",
+  "name": "RecipeLink",
+  "description": "Blueprint for a RecipeLink. Used to associate types with a set of Storage- and UiRecipes",
+  "attributes": [
+    {
+      "attributeType": "string",
+      "type": "sys://system/SIMOS/BlueprintAttribute",
+      "name": "type",
+      "contained": true,
+      "optional": false
+    },
+    {
+      "attributeType": "sys://system/SIMOS/UiRecipe",
+      "type": "sys://system/SIMOS/BlueprintAttribute",
+      "name": "uiRecipes",
+      "contained": true,
+      "optional": true,
+      "dimensions": "*"
+    },
+    {
+      "attributeType": "sys://system/SIMOS/StorageRecipe",
+      "type": "sys://system/SIMOS/BlueprintAttribute",
+      "name": "storageRecipes",
+      "contained": true,
+      "optional": true,
+      "dimensions": "*"
+    }
+  ]
+}

--- a/src/home/system/SIMOS/recipe_links/blueprint.json
+++ b/src/home/system/SIMOS/recipe_links/blueprint.json
@@ -1,0 +1,49 @@
+{
+  "type": "sys://system/SIMOS/RecipeLink",
+  "_blueprintPath_": "sys://system/SIMOS/Blueprint",
+  "uiRecipes": [
+    {
+      "name": "Yaml",
+      "type": "sys://system/SIMOS/UiRecipe",
+      "plugin": "yaml-view"
+    },
+    {
+      "type": "sys://system/SIMOS/UiRecipe",
+      "name": "Edit",
+      "description": "Default blueprint edit",
+      "plugin": "edit-blueprint"
+    },
+    {
+      "name": "Diagram",
+      "type": "sys://system/SIMOS/UiRecipe",
+      "plugin": "mermaid"
+    }
+  ],
+  "storageRecipes": [
+        {
+      "type": "sys://system/SIMOS/StorageRecipe",
+      "name": "DefaultStorageRecipe",
+      "description": "",
+      "attributes": [
+        {
+          "name": "attributes",
+          "type": "sys://system/SIMOS/StorageAttribute",
+          "dimensions": "*",
+          "contained": true
+        },
+        {
+          "name": "storageRecipes",
+          "type": "sys://system/SIMOS/StorageAttribute",
+          "dimensions": "*",
+          "contained": true
+        },
+        {
+          "name": "uiRecipes",
+          "type": "sys://system/SIMOS/StorageAttribute",
+          "dimensions": "*",
+          "contained": true
+        }
+      ]
+    }
+  ]
+}

--- a/src/storage/internal/lookup_tables.py
+++ b/src/storage/internal/lookup_tables.py
@@ -13,7 +13,7 @@ def insert_lookup(lookup_id: str, lookup: dict) -> None:
         lookup_table_collection.insert_one(lookup)
     except DuplicateKeyError:
         raise BadRequestException(
-            f"A lookup table with name '{lookup['name']}' already exists."
+            f"A lookup table with name '{lookup['_id']}' already exists."
             + " Use a different name, or delete the old one first"
         )
 

--- a/src/tests/bdd/create_lookup.feature
+++ b/src/tests/bdd/create_lookup.feature
@@ -3,6 +3,6 @@ Feature: Create a lookup table
     Given the system data source and SIMOS core package are available
 
   Scenario: System admins want to create a recipe lookup for the DMSS - SIMOS/recipe_links folder
-    Given i access the resource url "/api/v1/lookup/system/SIMOS/recipe_links?application=dmss"
+    Given i access the resource url "/api/v1/application/dmss?recipe_package=system/SIMOS/recipe_links"
     When i make a "POST" request
     Then the response status should be "No Content"

--- a/src/tests/bdd/create_lookup.feature
+++ b/src/tests/bdd/create_lookup.feature
@@ -1,19 +1,8 @@
 Feature: Create a lookup table
+    Background: There are data sources in the system
+    Given the system data source and SIMOS core package are available
 
-  Scenario: Create a lookup table
-    Given i access the resource url "/api/v1/lookup/my-new-lookup"
+  Scenario: System admins want to create a recipe lookup for the DMSS - SIMOS/recipe_links folder
+    Given i access the resource url "/api/v1/lookup/system/SIMOS/recipe_links?application=dmss"
     When i make a "POST" request
-    """
-    {
-      "uiRecipes": {
-        "someDS/aPackage/myBlueprint": [
-          {
-            "type": "sys://system/SIMOS/UiRecipe",
-            "name": "MySignalView",
-            "plugin": "signal-plot"
-          }
-        ]
-      }
-    }
-    """
     Then the response status should be "No Content"


### PR DESCRIPTION
## What does this pull request change?
- New feature: Create a lookup table by pointing to a package and giving it a name.
  - DMSS will go through that package, gathering all "RecipeLinks", and generate a recipe lookup stored in a internal database
 - Fixed a bug in import causing a "name" attribute requirement for all documents 

## Why is this pull request needed?
- Recipes will be moved out of blueprints. A lookup per. application is needed.

## Issues related to this change:
fixes #292 
