### PR TITLE
Fix/translate path to alias in export

### DIFF
--- a/src/common/utils/replace_reference_with_alias.py
+++ b/src/common/utils/replace_reference_with_alias.py
@@ -2,17 +2,12 @@ from common.exceptions import ApplicationException
 from domain_classes.dependency import Dependency
 
 
-def is_alias(string_to_check: str, dependencies: list[Dependency]) -> bool:
-    """Check if a given string is an alias or not.
-
-    string_to_check is an alias on the form <alias>:<path> or a document reference on the format <protocol>://<datasource>/<path>
+def has_dependency_alias(reference: str, dependencies: list[Dependency]) -> bool:
+    """Check if a given reference string on the format <protocol>://<datasource>/<path> can be
+    substituted with an alias on the format <alias>:<path>.
     """
     for dependency in dependencies:
-        if (
-            string_to_check.startswith(f"{dependency.alias}:")
-            and dependency.protocol not in string_to_check
-            and dependency.address not in string_to_check
-        ):
+        if reference.startswith(dependency.get_absolute_reference()):
             return True
     return False
 
@@ -33,19 +28,21 @@ def replace_reference_with_alias(reference: str, dependencies: list[Dependency])
 
 
 def replace_absolute_references_in_entity_with_alias(entity: dict, dependencies: list[Dependency]):
-    """Replace path in an entity with alias defined in a list of dependencies.
+    """Replace references in an entity with alias defined in a list of dependencies.
 
     (for example, replace "dmss://system/SIMOS/Package" with "CORE:Package".)
     """
     attributes_to_update = ("type", "attributeType", "_blueprintPath_")  # These keys may contain a reference
-    EXTENDS = "extends"  # extends is a special attribute in an entity that contains a list of referencences
+    EXTENDS = "extends"  # Extends is a special attribute in an entity that contains a list of references
     for attribute in entity:
+        if type(entity[attribute]) == dict:
+            replace_absolute_references_in_entity_with_alias(entity[attribute], dependencies)
         if type(entity[attribute]) == list and attribute != EXTENDS:
             for new_entity in entity[attribute]:
                 replace_absolute_references_in_entity_with_alias(new_entity, dependencies)
-        if attribute in attributes_to_update:
+        if attribute in attributes_to_update and has_dependency_alias(entity[attribute], dependencies):
             entity[attribute] = replace_reference_with_alias(entity[attribute], dependencies)
         elif attribute == EXTENDS:
             for index, reference in enumerate(entity[attribute]):
-                if not is_alias(reference, dependencies):
-                    entity[attribute][index] = replace_reference_with_alias(entity[attribute][index], dependencies)
+                if has_dependency_alias(reference, dependencies):
+                    entity[attribute][index] = replace_reference_with_alias(reference, dependencies)

--- a/src/common/utils/replace_reference_with_alias.py
+++ b/src/common/utils/replace_reference_with_alias.py
@@ -39,7 +39,8 @@ def replace_absolute_references_in_entity_with_alias(entity: dict, dependencies:
             replace_absolute_references_in_entity_with_alias(entity[attribute], dependencies)
         if type(entity[attribute]) == list and attribute != EXTENDS:
             for new_entity in entity[attribute]:
-                replace_absolute_references_in_entity_with_alias(new_entity, dependencies)
+                if type(new_entity) == dict:
+                    replace_absolute_references_in_entity_with_alias(new_entity, dependencies)
         if attribute in attributes_to_update and has_dependency_alias(entity[attribute], dependencies):
             entity[attribute] = replace_reference_with_alias(entity[attribute], dependencies)
         elif attribute == EXTENDS:

--- a/src/common/utils/replace_reference_with_alias.py
+++ b/src/common/utils/replace_reference_with_alias.py
@@ -27,7 +27,7 @@ def replace_reference_with_alias(reference: str, dependencies: list[Dependency])
     )
 
 
-def replace_absolute_references_in_entity_with_alias(entity: dict, dependencies: list[Dependency]):
+def replace_absolute_references_in_entity_with_alias(entity: dict, dependencies: list[Dependency]) -> dict:
     """Replace references in an entity with alias defined in a list of dependencies.
 
     (for example, replace "dmss://system/SIMOS/Package" with "CORE:Package".)
@@ -36,14 +36,17 @@ def replace_absolute_references_in_entity_with_alias(entity: dict, dependencies:
     EXTENDS = "extends"  # Extends is a special attribute in an entity that contains a list of references
     for attribute in entity:
         if type(entity[attribute]) == dict:
-            replace_absolute_references_in_entity_with_alias(entity[attribute], dependencies)
+            entity[attribute] = replace_absolute_references_in_entity_with_alias(entity[attribute], dependencies)
         if type(entity[attribute]) == list and attribute != EXTENDS:
-            for new_entity in entity[attribute]:
+            for index, new_entity in enumerate(entity[attribute]):
                 if type(new_entity) == dict:
-                    replace_absolute_references_in_entity_with_alias(new_entity, dependencies)
+                    entity[attribute][index] = replace_absolute_references_in_entity_with_alias(
+                        new_entity, dependencies
+                    )
         if attribute in attributes_to_update and has_dependency_alias(entity[attribute], dependencies):
             entity[attribute] = replace_reference_with_alias(entity[attribute], dependencies)
         elif attribute == EXTENDS:
             for index, reference in enumerate(entity[attribute]):
                 if has_dependency_alias(reference, dependencies):
                     entity[attribute][index] = replace_reference_with_alias(reference, dependencies)
+    return entity

--- a/src/common/utils/replace_reference_with_alias.py
+++ b/src/common/utils/replace_reference_with_alias.py
@@ -2,11 +2,17 @@ from common.exceptions import ApplicationException
 from domain_classes.dependency import Dependency
 
 
-def is_alias(path: str, dependencies: list[Dependency]):
-    NUM_SPLITS = 1
-    path_start = path.split(":", NUM_SPLITS)[0]
+def is_alias(string_to_check: str, dependencies: list[Dependency]) -> bool:
+    """Check if a given string is an alias or not.
+
+    string_to_check is an alias on the form <alias>:<path> or a document reference on the format <protocol>://<datasource>/<path>
+    """
     for dependency in dependencies:
-        if path_start == dependency.alias:
+        if (
+            string_to_check.startswith(f"{dependency.alias}:")
+            and dependency.protocol not in string_to_check
+            and dependency.address not in string_to_check
+        ):
             return True
     return False
 

--- a/src/common/utils/replace_reference_with_alias.py
+++ b/src/common/utils/replace_reference_with_alias.py
@@ -1,0 +1,36 @@
+from domain_classes.dependency import Dependency
+
+
+def is_alias(path: str, dependencies: list[Dependency]):
+    NUM_SPLITS = 1
+    path_start = path.split(":", NUM_SPLITS)[0]
+    for dependency in dependencies:
+        if path_start == dependency.alias:
+            return True
+    return False
+
+
+def replace_absolute_references_with_alias(entity: dict, dependencies: list[Dependency]):
+    """Replace path in an entity with alias defined in a list of dependencies.
+
+    (for example, replace "dmss://system/SIMOS/Package" with "CORE:Package".)
+    """
+    attribute_to_update = ("type", "attributeType", "extends", "_blueprintPath_")  # These keys may contain a reference
+    for attribute in entity:
+        if attribute == "attributes" or attribute == "content":
+            # "attributes" and "content" contain list of entities.
+            for new_entity in entity[attribute]:
+                replace_absolute_references_with_alias(new_entity, dependencies)
+        elif attribute in attribute_to_update:
+            for dependency in dependencies:
+                if attribute == "extends":
+                    # "extends" attribute contains a list of absolute references. Each list item is treated separately.
+                    for index, absolute_reference in enumerate(entity[attribute]):
+                        if not is_alias(entity[attribute][index], dependencies):
+                            path_after_alias = absolute_reference.split(dependency.get_absolute_reference())[-1]
+                            entity[attribute][index] = f"{dependency.alias}:{path_after_alias}"
+                            break
+                elif entity[attribute].startswith(dependency.get_absolute_reference()):
+                    path_after_alias = entity[attribute].split(dependency.get_absolute_reference())[-1]
+                    entity[attribute] = f"{dependency.alias}:{path_after_alias}"
+                    break

--- a/src/common/utils/replace_reference_with_alias.py
+++ b/src/common/utils/replace_reference_with_alias.py
@@ -9,7 +9,7 @@ def has_dependency_alias(reference: str, dependencies: list[Dependency]) -> bool
     substituted with an alias on the format <alias>:<path>.
     """
     for dependency in dependencies:
-        if reference.startswith(dependency.get_absolute_reference()):
+        if reference.startswith(dependency.get_prefix()):
             return True
     return False
 
@@ -37,8 +37,8 @@ def replace_reference_with_alias_if_possible(reference: str, dependencies: list[
     best_alias_match = None
     longest_path_length_after_alias = math.inf
     for dependency in dependencies:
-        if reference.startswith(dependency.get_absolute_reference()):
-            path_after_alias = reference.split(dependency.get_absolute_reference())[-1]
+        if reference.startswith(dependency.get_prefix()):
+            path_after_alias = reference.split(dependency.get_prefix())[-1]
             if len(path_after_alias) < longest_path_length_after_alias:
                 best_alias_match = f"{dependency.alias}:{path_after_alias}"
                 longest_path_length_after_alias = len(path_after_alias)

--- a/src/common/utils/replace_reference_with_alias.py
+++ b/src/common/utils/replace_reference_with_alias.py
@@ -1,4 +1,5 @@
 import math
+from typing import Optional
 
 from domain_classes.dependency import Dependency
 
@@ -13,20 +14,19 @@ def has_dependency_alias(reference: str, dependencies: list[Dependency]) -> bool
     return False
 
 
-def replace_references_in_list(reference_list: list[str], dependencies: list[Dependency]) -> list[str]:
+def replace_references_in_list(reference_list: list[str], dependencies: list[Dependency]) -> list[Optional[str]]:
     """Replace references with alias of a list with references.
 
     The reference_list contains a list of references on the format <protocol>://<datasource>/<path>.
     The returned value is a list where all references are substituted with aliases on the format <alias>:<path>.
     """
-
     list_with_alias = []
     for index, reference in enumerate(reference_list):
         list_with_alias.append(replace_reference_with_alias_if_possible(reference, dependencies))
     return list_with_alias
 
 
-def replace_reference_with_alias_if_possible(reference: str, dependencies: list[Dependency]) -> str:
+def replace_reference_with_alias_if_possible(reference: str, dependencies: list[Dependency]) -> str | None:
     """Replace the reference string with an alias.
     The reference string on the format <protocol>://<datasource>/<path>.
 

--- a/src/domain_classes/dependency.py
+++ b/src/domain_classes/dependency.py
@@ -16,5 +16,5 @@ class Dependency(BaseModel):
     address: str
     version: str = ""
 
-    def get_absolute_reference(self):
+    def get_prefix(self):
         return f"{self.protocol}://{self.address}/"

--- a/src/domain_classes/dependency.py
+++ b/src/domain_classes/dependency.py
@@ -15,3 +15,6 @@ class Dependency(BaseModel):
     protocol: TDependencyProtocol
     address: str
     version: str = ""
+
+    def get_absolute_reference(self):
+        return f"{self.protocol}://{self.address}/"

--- a/src/features/export/use_cases/export_use_case.py
+++ b/src/features/export/use_cases/export_use_case.py
@@ -21,7 +21,13 @@ def save_node_to_zipfile(
         if document_meta:
             document_node.entity["_meta_"] = document_meta
         storage_client = ZipFileClient(zip_file)
-        document_service.save(document_node, data_source_id, storage_client, update_uncontained=True)
+        document_service.save(
+            document_node,
+            data_source_id,
+            storage_client,
+            update_uncontained=True,
+            combined_document_meta=document_meta,
+        )
 
 
 def create_zip_export(document_service: DocumentService, absolute_document_ref: str, user: User) -> str:
@@ -33,10 +39,13 @@ def create_zip_export(document_service: DocumentService, absolute_document_ref: 
     document_node: Node = document_service.get_by_path(absolute_document_ref)
 
     # non-root packages and single documents will inherit the meta information from all parents.
-    document_meta = None
+    document_meta = {}
     if not (document_node.entity["type"] == SIMOS.PACKAGE.value and document_node.entity["isRoot"]):
         document_meta = export_meta_use_case(user=user, document_reference=absolute_document_ref)
+    elif "_meta_" in document_node.entity:
+        document_meta = document_node.entity["_meta_"]
 
+    # TODO fix bug: relative references are resloved (if type is CarPackage/Wheel for an entity, the exported type is "dmss://DemoApplicationDataSource/models/CarPackage/Wheel"
     save_node_to_zipfile(
         archive_path=archive_path,
         document_service=document_service,

--- a/src/storage/repositories/zip.py
+++ b/src/storage/repositories/zip.py
@@ -33,7 +33,7 @@ class ZipFileClient(RepositoryInterface):
                 dependencies: list[Dependency] = [
                     Dependency(**dependency_dict) for dependency_dict in combined_document_meta["dependencies"]
                 ]
-                replace_absolute_references_in_entity_with_alias(entity, dependencies)
+                entity = replace_absolute_references_in_entity_with_alias(entity, dependencies)
             json_data = json.dumps(entity)
             binary_data = json_data.encode()
             self.zip_file.writestr(write_to, binary_data)

--- a/src/storage/repositories/zip.py
+++ b/src/storage/repositories/zip.py
@@ -4,7 +4,7 @@ from zipfile import ZipFile
 
 from common.utils.logging import logger
 from common.utils.replace_reference_with_alias import (
-    replace_absolute_references_with_alias,
+    replace_absolute_references_in_entity_with_alias,
 )
 from domain_classes.dependency import Dependency
 from enums import SIMOS
@@ -33,7 +33,7 @@ class ZipFileClient(RepositoryInterface):
                 dependencies: list[Dependency] = [
                     Dependency(**dependency_dict) for dependency_dict in combined_document_meta["dependencies"]
                 ]
-                replace_absolute_references_with_alias(entity, dependencies)
+                replace_absolute_references_in_entity_with_alias(entity, dependencies)
             json_data = json.dumps(entity)
             binary_data = json_data.encode()
             self.zip_file.writestr(write_to, binary_data)

--- a/src/storage/repositories/zip.py
+++ b/src/storage/repositories/zip.py
@@ -3,6 +3,10 @@ from pathlib import Path
 from zipfile import ZipFile
 
 from common.utils.logging import logger
+from common.utils.replace_reference_with_alias import (
+    replace_absolute_references_with_alias,
+)
+from domain_classes.dependency import Dependency
 from enums import SIMOS
 from storage.repository_interface import RepositoryInterface
 
@@ -12,15 +16,26 @@ class ZipFileClient(RepositoryInterface):
         self.zip_file = zip_file
 
     def update(self, entity: dict, storage_recipe=None, **kwargs):
+        """
+        Saves entity to zip file.
+
+        By default, absolute references are resolved to aliases using the dependencies from entity["__combined_document_meta__"].
+        """
         entity.pop("_id", None)
         entity.pop("uid", None)
         entity["__path__"] = entity["__path__"].rstrip("/")
         write_to = f"{entity['__path__']}/{entity['name']}.json"
         entity.pop("__path__")
-        json_data = json.dumps(entity)
-        binary_data = json_data.encode()
+        combined_document_meta = entity.pop("__combined_document_meta__")
         logger.debug(f"Writing: {entity['type']} to {write_to}")
         if entity["type"] != SIMOS.PACKAGE.value:
+            if combined_document_meta:
+                dependencies: list[Dependency] = [
+                    Dependency(**dependency_dict) for dependency_dict in combined_document_meta["dependencies"]
+                ]
+                replace_absolute_references_with_alias(entity, dependencies)
+            json_data = json.dumps(entity)
+            binary_data = json_data.encode()
             self.zip_file.writestr(write_to, binary_data)
         elif "_meta_" in entity:
             self.zip_file.writestr(f"{Path(write_to).parent}/package.json", json.dumps(entity["_meta_"]).encode())

--- a/src/tests/unit/test_replace_absolute_references_with_alias.py
+++ b/src/tests/unit/test_replace_absolute_references_with_alias.py
@@ -2,6 +2,7 @@ import unittest
 
 from common.utils.replace_reference_with_alias import (
     replace_absolute_references_in_entity_with_alias,
+    replace_reference_with_alias_if_possible,
 )
 from domain_classes.dependency import Dependency
 
@@ -79,7 +80,29 @@ entity_with_aliases: dict = {
 
 
 class ReplaceWithAliasTest(unittest.TestCase):
-    def test_replace_absolute_references_with_alias(self):
+    def test_replace_ref_with_alias(self):
+        car_package_dependency = {
+            "alias": "CAR_PACKAGE",
+            "address": "DemoApplicationDataSource/models/CarPackage",
+            "version": "0.0.1",
+            "protocol": "dmss",
+        }
+        wheel_package_dependency = {
+            "alias": "WHEEL",
+            "address": "DemoApplicationDataSource/models/CarPackage/Wheel",
+            "version": "0.0.1",
+            "protocol": "dmss",
+        }
+        dependencies: list[Dependency] = [Dependency(**car_package_dependency), Dependency(**wheel_package_dependency)]
+        reference = "dmss://DemoApplicationDataSource/models/CarPackage/Wheel/SubPackage/Pressure"
+        alias = replace_reference_with_alias_if_possible(reference=reference, dependencies=dependencies)
+        assert alias == "WHEEL:SubPackage/Pressure"
+
+        reference = "dmss://DemoApplicationDataSource/models"
+        alias = replace_reference_with_alias_if_possible(reference=reference, dependencies=dependencies)
+        assert alias == reference
+
+    def test_replace_absolute_references_in_entity_with_alias(self):
 
         core_dependency = {"alias": "CORE", "address": "system/SIMOS", "version": "0.0.1", "protocol": "dmss"}
         car_package_dependency = {

--- a/src/tests/unit/test_replace_absolute_references_with_alias.py
+++ b/src/tests/unit/test_replace_absolute_references_with_alias.py
@@ -1,7 +1,7 @@
 import unittest
 
 from common.utils.replace_reference_with_alias import (
-    replace_absolute_references_with_alias,
+    replace_absolute_references_in_entity_with_alias,
 )
 from domain_classes.dependency import Dependency
 
@@ -52,5 +52,5 @@ class ReplaceWithAliasTest(unittest.TestCase):
         }
         dependencies: list[Dependency] = [Dependency(**core_dependency), Dependency(**car_package_dependency)]
 
-        replace_absolute_references_with_alias(entity=example_entity, dependencies=dependencies)
+        replace_absolute_references_in_entity_with_alias(entity=example_entity, dependencies=dependencies)
         assert example_entity == entity_with_aliases

--- a/src/tests/unit/test_replace_absolute_references_with_alias.py
+++ b/src/tests/unit/test_replace_absolute_references_with_alias.py
@@ -8,6 +8,7 @@ from domain_classes.dependency import Dependency
 example_entity: dict = {
     "_id": "25cdcef6-ee7c-4377-9487-2f4b8496e7c9",
     "name": "Car",
+    "_blueprintPath_": "dmss://system/SIMOS/Blueprint",
     "type": "dmss://system/SIMOS/Blueprint",
     "extends": ["dmss://system/SIMOS/NamedEntity", "dmss://DemoApplicationDataSource/models/CarPackage/Vehicle"],
     "description": "",
@@ -28,6 +29,17 @@ example_entity: dict = {
             "attributeType": "dmss://DemoApplicationDataSource/models/CarPackage/Wheel",
             "dimensions": "*",
         },
+        {
+            "name": "wheelPressures",
+            "type": "dmss://system/SIMOS/BlueprintAttribute",
+            "attributeType": "dmss://DemoApplicationDataSource/models/CarPackage/Wheel/WheelProperties/Pressures",
+            "dimensions": "*",
+        },
+        {
+            "name": "owner",
+            "type": "dmss://system/SIMOS/BlueprintAttribute",
+            "attributeType": "dmss://DemoApplicationDataSource/models/Person",
+        },
     ],
 }
 
@@ -35,6 +47,7 @@ example_entity: dict = {
 entity_with_aliases: dict = {
     "_id": "25cdcef6-ee7c-4377-9487-2f4b8496e7c9",
     "name": "Car",
+    "_blueprintPath_": "CORE:Blueprint",
     "type": "CORE:Blueprint",
     "extends": ["CORE:NamedEntity", "CAR_PACKAGE:Vehicle"],
     "description": "",
@@ -50,6 +63,17 @@ entity_with_aliases: dict = {
             },
         },
         {"name": "wheels", "type": "CORE:BlueprintAttribute", "attributeType": "CAR_PACKAGE:Wheel", "dimensions": "*"},
+        {
+            "name": "wheelPressures",
+            "type": "CORE:BlueprintAttribute",
+            "attributeType": "WHEEL:WheelProperties/Pressures",
+            "dimensions": "*",
+        },
+        {
+            "name": "owner",
+            "type": "CORE:BlueprintAttribute",
+            "attributeType": "dmss://DemoApplicationDataSource/models/Person",
+        },
     ],
 }
 
@@ -64,8 +88,17 @@ class ReplaceWithAliasTest(unittest.TestCase):
             "version": "0.0.1",
             "protocol": "dmss",
         }
-        dependencies: list[Dependency] = [Dependency(**core_dependency), Dependency(**car_package_dependency)]
-
+        wheel_package_dependency = {
+            "alias": "WHEEL",
+            "address": "DemoApplicationDataSource/models/CarPackage/Wheel",
+            "version": "0.0.1",
+            "protocol": "dmss",
+        }
+        dependencies: list[Dependency] = [
+            Dependency(**core_dependency),
+            Dependency(**car_package_dependency),
+            Dependency(**wheel_package_dependency),
+        ]
         new_entity_with_alias = replace_absolute_references_in_entity_with_alias(
             entity=example_entity, dependencies=dependencies
         )

--- a/src/tests/unit/test_replace_absolute_references_with_alias.py
+++ b/src/tests/unit/test_replace_absolute_references_with_alias.py
@@ -16,6 +16,11 @@ example_entity: dict = {
             "name": "color",
             "type": "dmss://system/SIMOS/BlueprintAttribute",
             "attributeType": "dmss://system/SIMOS/string",
+            "blob": {
+                "name": "color_profile.txt",
+                "type": "dmss://system/SIMOS/Blob",
+                "_blob_id": "04cf2783-6118-4bfd-a427-9485b00fa9da",
+            },
         },
         {
             "name": "wheels",
@@ -34,7 +39,16 @@ entity_with_aliases: dict = {
     "extends": ["CORE:NamedEntity", "CAR_PACKAGE:Vehicle"],
     "description": "",
     "attributes": [
-        {"name": "color", "type": "CORE:BlueprintAttribute", "attributeType": "CORE:string"},
+        {
+            "name": "color",
+            "type": "CORE:BlueprintAttribute",
+            "attributeType": "CORE:string",
+            "blob": {
+                "name": "color_profile.txt",
+                "type": "CORE:Blob",
+                "_blob_id": "04cf2783-6118-4bfd-a427-9485b00fa9da",
+            },
+        },
         {"name": "wheels", "type": "CORE:BlueprintAttribute", "attributeType": "CAR_PACKAGE:Wheel", "dimensions": "*"},
     ],
 }

--- a/src/tests/unit/test_replace_absolute_references_with_alias.py
+++ b/src/tests/unit/test_replace_absolute_references_with_alias.py
@@ -66,5 +66,7 @@ class ReplaceWithAliasTest(unittest.TestCase):
         }
         dependencies: list[Dependency] = [Dependency(**core_dependency), Dependency(**car_package_dependency)]
 
-        replace_absolute_references_in_entity_with_alias(entity=example_entity, dependencies=dependencies)
-        assert example_entity == entity_with_aliases
+        new_entity_with_alias = replace_absolute_references_in_entity_with_alias(
+            entity=example_entity, dependencies=dependencies
+        )
+        assert new_entity_with_alias == entity_with_aliases

--- a/src/tests/unit/test_replace_absolute_references_with_alias.py
+++ b/src/tests/unit/test_replace_absolute_references_with_alias.py
@@ -1,0 +1,56 @@
+import unittest
+
+from common.utils.replace_reference_with_alias import (
+    replace_absolute_references_with_alias,
+)
+from domain_classes.dependency import Dependency
+
+example_entity: dict = {
+    "_id": "25cdcef6-ee7c-4377-9487-2f4b8496e7c9",
+    "name": "Car",
+    "type": "dmss://system/SIMOS/Blueprint",
+    "extends": ["dmss://system/SIMOS/NamedEntity", "dmss://DemoApplicationDataSource/models/CarPackage/Vehicle"],
+    "description": "",
+    "attributes": [
+        {
+            "name": "color",
+            "type": "dmss://system/SIMOS/BlueprintAttribute",
+            "attributeType": "dmss://system/SIMOS/string",
+        },
+        {
+            "name": "wheels",
+            "type": "dmss://system/SIMOS/BlueprintAttribute",
+            "attributeType": "dmss://DemoApplicationDataSource/models/CarPackage/Wheel",
+            "dimensions": "*",
+        },
+    ],
+}
+
+
+entity_with_aliases: dict = {
+    "_id": "25cdcef6-ee7c-4377-9487-2f4b8496e7c9",
+    "name": "Car",
+    "type": "CORE:Blueprint",
+    "extends": ["CORE:NamedEntity", "CAR_PACKAGE:Vehicle"],
+    "description": "",
+    "attributes": [
+        {"name": "color", "type": "CORE:BlueprintAttribute", "attributeType": "CORE:string"},
+        {"name": "wheels", "type": "CORE:BlueprintAttribute", "attributeType": "CAR_PACKAGE:Wheel", "dimensions": "*"},
+    ],
+}
+
+
+class ReplaceWithAliasTest(unittest.TestCase):
+    def test_replace_absolute_references_with_alias(self):
+
+        core_dependency = {"alias": "CORE", "address": "system/SIMOS", "version": "0.0.1", "protocol": "dmss"}
+        car_package_dependency = {
+            "alias": "CAR_PACKAGE",
+            "address": "DemoApplicationDataSource/models/CarPackage",
+            "version": "0.0.1",
+            "protocol": "dmss",
+        }
+        dependencies: list[Dependency] = [Dependency(**core_dependency), Dependency(**car_package_dependency)]
+
+        replace_absolute_references_with_alias(entity=example_entity, dependencies=dependencies)
+        assert example_entity == entity_with_aliases


### PR DESCRIPTION
## What does this pull request change?
in export, translate path to alias, for example "dmss://system/SIMOS/Package" is translated to "CORE:Package" if the the document's meta has an alias that matches adress = "system/SIMOS" and protocol = "dmss"
## Why is this pull request needed?
part of export functionality
## Issues related to this change:
closes #310 
