### PR TITLE
refactor: tree node serializer to separate file, and no longer a class

### DIFF
--- a/src/common/tree_node_serializer.py
+++ b/src/common/tree_node_serializer.py
@@ -1,0 +1,204 @@
+from copy import deepcopy
+from typing import Callable
+
+from common.exceptions import BadRequestException
+from common.utils.logging import logger
+from config import config
+from domain_classes.blueprint import Blueprint
+from domain_classes.blueprint_attribute import BlueprintAttribute
+from domain_classes.storage_recipe import StorageRecipe
+from domain_classes.tree_node import ListNode, Node
+from enums import SIMOS
+
+
+def tree_node_to_dict(node: Node | ListNode) -> dict:
+    data = {}
+
+    # If it's an empty node, just return the empty object.
+    if not node.entity:
+        return node.entity
+
+    if node.uid:
+        data["_id"] = node.uid
+
+    # Always add 'type'
+    try:
+        data["type"] = node.entity["type"]
+    except KeyError:
+        raise BadRequestException(f"The node '{node.uid}' is missing the 'type' attributes")
+    # Primitive
+    # if complex attribute name is renamed in blueprint, then the blueprint is None in the entity.
+    if node.blueprint is not None:
+        for attribute in node.blueprint.get_primitive_types():
+            if attribute.name in node.entity:
+                data[attribute.name] = node.entity[attribute.name]
+
+    # Complex
+    for node in node.children:
+        if node.is_array():
+            data[node.key] = [tree_node_to_dict(child) for child in node.children]
+        else:
+            data[node.key] = tree_node_to_dict(node)
+
+    return data
+
+
+def tree_node_to_ref_dict(node: Node | ListNode) -> dict:
+    """
+    Rebuilds the entity as it should be stored based on the passed child entities that can be either contained
+    documents, or references.
+    """
+    if node.is_empty():
+        return node.entity
+    data = {}
+    if node.uid:
+        data = {"_id": node.uid}
+
+    # Always add 'type', regardless of blueprint
+    try:
+        data["type"] = node.type
+    except KeyError:
+        raise BadRequestException(f"The node '{node.uid}' is missing the 'type' attributes")
+
+    # Primitive
+    # if complex attribute name is renamed in blueprint, then the blueprint is None in the entity.
+    if node.blueprint is not None:
+        for attribute in node.blueprint.get_primitive_types():
+            if attribute.name in node.entity:
+                data[attribute.name] = node.entity[attribute.name]
+
+    # Add _meta_ attribute if it exists in the entity
+    if "_meta_" in node.entity:
+        data["_meta_"] = node.entity["_meta_"]
+
+    # Complex
+    for child in node.children:
+        if child.is_array():
+            # If the content of the list is not contained, i.e. references.
+            if not child.storage_contained:
+                data[child.key] = [
+                    {"_id": child.uid, "type": child.type, "name": child.name, "contained": child.contained}
+                    for child in child.children
+                ]
+            else:
+                data[child.key] = [tree_node_to_ref_dict(list_child) for list_child in child.children]
+        else:
+            if not child.contained and child.entity:
+                data[child.key] = {
+                    "_id": child.uid,
+                    "type": child.type,
+                    "name": child.name,
+                    "contained": child.contained,
+                }
+            else:
+                data[child.key] = tree_node_to_ref_dict(child)
+    return data
+
+
+def tree_node_from_dict(
+    entity: dict,
+    uid: str | None,
+    key,
+    blueprint_provider: Callable[[str], Blueprint],
+    node_attribute: BlueprintAttribute | None = None,
+    recursion_depth: int = 0,
+    recipe_provider: Callable[..., list[StorageRecipe]] | None = None,
+) -> Node | ListNode:
+
+    if recursion_depth >= config.MAX_ENTITY_RECURSION_DEPTH:
+        message = (
+            f"Reached maximum recursion depth while creating NodeTree ({recursion_depth}).\n"
+            f'If your blueprints contains recursion, set the attribute as "optional". '
+        )
+        logger.error(message)
+        raise RecursionError(message)
+
+    # If no attribute, that means this was a "top-level" entity. We create an Attribute based on the Blueprint
+    if not node_attribute:
+        bp = blueprint_provider(entity["type"])
+        node_attribute = BlueprintAttribute(name=bp.name, attributeType=entity["type"], description=bp.description)
+
+    # If there is data in the entity, load attribute type from the entity
+    if entity:
+        if not entity.get("type"):
+            raise ValueError(f"Entity is missing required attribute 'type'.\n{key}\n{entity}")
+        node_attribute = deepcopy(node_attribute)  # If you don't copy, we modify the blueprint in the BP Cache...
+        node_attribute.attribute_type = entity["type"]
+
+    key = key if key else node_attribute.name
+    node = Node(
+        key=key,
+        uid=uid,
+        entity=entity,
+        blueprint_provider=blueprint_provider,
+        attribute=node_attribute,
+        recipe_provider=recipe_provider,
+    )
+
+    for child_attribute in node.blueprint.get_none_primitive_types():
+        if child_attribute.name == "_meta_":
+            continue
+        child_contained = node.storage_recipes[0].is_contained(child_attribute.name)
+        # This will stop creation of recursive blueprints (only if they are optional)
+        if child_attribute.is_optional and not entity:
+            continue
+
+        if child_attribute.is_array:
+            children = entity.get(child_attribute.name, [])
+
+            if not isinstance(children, list):
+                raise ValueError(
+                    f"The attribute '{child_attribute.name}' on blueprint '{node.type}' "
+                    + f"should be a list, but was '{str(type(children))}'"
+                )
+
+            list_node = ListNode(
+                key=child_attribute.name,
+                uid="",
+                entity=children,
+                blueprint_provider=blueprint_provider,
+                recipe_provider=recipe_provider,
+                attribute=child_attribute,
+            )
+
+            for i, child in enumerate(children):
+                list_child_attribute = child_attribute
+
+                # If the node is of type DMT/Package, we need to override the attribute_type "Entity",
+                # and get it from the child.
+                if node.type == SIMOS.PACKAGE.value:
+                    content_attribute: BlueprintAttribute = deepcopy(child_attribute)
+                    content_attribute.attribute_type = child["type"]
+                    list_child_attribute = content_attribute
+
+                list_child_node = tree_node_from_dict(
+                    uid=child.get("_id", ""),
+                    entity=child,
+                    key=str(i),
+                    blueprint_provider=blueprint_provider,
+                    recipe_provider=recipe_provider,
+                    node_attribute=list_child_attribute,
+                    recursion_depth=recursion_depth + 1,
+                )
+                list_node.add_child(list_child_node)
+            node.add_child(list_node)
+        else:
+            attribute_data = entity.get(child_attribute.name, {})
+            if not isinstance(attribute_data, dict):
+                raise ValueError(
+                    f"The attribute '{child_attribute.name}' on blueprint '{node.type}' "
+                    + f"should be a dict, but was '{str(type(attribute_data))}'"
+                )
+            child_node = tree_node_from_dict(
+                # If the child is not contained, get or create it's _id
+                uid="" if child_contained or not attribute_data else attribute_data.get("_id", ""),
+                entity=attribute_data,
+                key=child_attribute.name,
+                blueprint_provider=blueprint_provider,
+                recipe_provider=recipe_provider,
+                node_attribute=child_attribute,
+                recursion_depth=recursion_depth + 1,
+            )
+            node.add_child(child_node)
+
+    return node

--- a/src/common/tree_node_serializer.py
+++ b/src/common/tree_node_serializer.py
@@ -97,12 +97,12 @@ def tree_node_to_ref_dict(node: Node | ListNode) -> dict:
 
 def tree_node_from_dict(
     entity: dict,
-    uid: str | None,
-    key,
     blueprint_provider: Callable[[str], Blueprint],
     node_attribute: BlueprintAttribute | None = None,
     recursion_depth: int = 0,
     recipe_provider: Callable[..., list[StorageRecipe]] | None = None,
+    uid: str | None = None,
+    key: str | None = None,
 ) -> Node | ListNode:
 
     if recursion_depth >= config.MAX_ENTITY_RECURSION_DEPTH:
@@ -191,7 +191,7 @@ def tree_node_from_dict(
                 )
             child_node = tree_node_from_dict(
                 # If the child is not contained, get or create it's _id
-                uid="" if child_contained or not attribute_data else attribute_data.get("_id", ""),
+                uid=None if child_contained or not attribute_data else attribute_data.get("_id", ""),
                 entity=attribute_data,
                 key=child_attribute.name,
                 blueprint_provider=blueprint_provider,

--- a/src/domain_classes/tree_node.py
+++ b/src/domain_classes/tree_node.py
@@ -1,226 +1,12 @@
-from copy import deepcopy
 from typing import Callable, List, Union
 from uuid import uuid4
 
 from common.exceptions import BadRequestException
-from common.utils.logging import logger
 from common.utils.validators import valid_extended_type
-from config import config
 from domain_classes.blueprint import Blueprint
 from domain_classes.blueprint_attribute import BlueprintAttribute
 from domain_classes.storage_recipe import StorageAttribute, StorageRecipe
 from enums import SIMOS, BuiltinDataTypes, StorageDataTypes
-
-
-class DictExporter:
-    @staticmethod
-    def to_dict(node):
-        data = {}
-
-        # If it's an empty node, just return the empty object.
-        if not node.entity:
-            return node.entity
-
-        if node.uid:
-            data["_id"] = node.uid
-
-        # Always add 'type'
-        try:
-            data["type"] = node.entity["type"]
-        except KeyError:
-            raise BadRequestException(f"The node '{node.uid}' is missing the 'type' attributes")
-        # Primitive
-        # if complex attribute name is renamed in blueprint, then the blueprint is None in the entity.
-        if node.blueprint is not None:
-            for attribute in node.blueprint.get_primitive_types():
-                if attribute.name in node.entity:
-                    data[attribute.name] = node.entity[attribute.name]
-
-        # Complex
-        for node in node.children:
-            if node.is_array():
-                data[node.key] = [child.to_dict() for child in node.children]
-            else:
-                data[node.key] = node.to_dict()
-
-        return data
-
-    @staticmethod
-    def to_ref_dict(node):
-        """
-        Rebuilds the entity as it should be stored based on the passed child entities that can be either contained
-        documents, or references.
-        """
-        if node.is_empty():
-            return node.entity
-        data = {}
-        if node.uid:
-            data = {"_id": node.uid}
-
-        # Always add 'type', regardless of blueprint
-        try:
-            data["type"] = node.type
-        except KeyError:
-            raise BadRequestException(f"The node '{node.uid}' is missing the 'type' attributes")
-
-        # Primitive
-        # if complex attribute name is renamed in blueprint, then the blueprint is None in the entity.
-        if node.blueprint is not None:
-            for attribute in node.blueprint.get_primitive_types():
-                if attribute.name in node.entity:
-                    data[attribute.name] = node.entity[attribute.name]
-
-        # Add _meta_ attribute if it exists in the entity
-        if "_meta_" in node.entity:
-            data["_meta_"] = node.entity["_meta_"]
-
-        # Complex
-        for child in node.children:
-            if child.is_array():
-                # If the content of the list is not contained, i.e. references.
-                if not child.storage_contained:
-                    data[child.key] = [
-                        {"_id": child.uid, "type": child.type, "name": child.name, "contained": child.contained}
-                        for child in child.children
-                    ]
-                else:
-                    data[child.key] = [list_child.to_ref_dict() for list_child in child.children]
-            else:
-                if not child.contained and child.entity:
-                    data[child.key] = {
-                        "_id": child.uid,
-                        "type": child.type,
-                        "name": child.name,
-                        "contained": child.contained,
-                    }
-                else:
-                    data[child.key] = child.to_ref_dict()
-        return data
-
-
-class DictImporter:
-    @classmethod
-    def from_dict(
-        cls,
-        entity,
-        uid,
-        blueprint_provider,
-        key=None,
-        node_attribute: BlueprintAttribute = None,
-        recipe_provider: Callable[..., list[StorageRecipe]] | None = None,
-    ):
-        return cls._from_dict(entity, uid, key, blueprint_provider, node_attribute, recipe_provider=recipe_provider)
-
-    @classmethod
-    def _from_dict(
-        cls,
-        entity: dict,
-        uid: str,
-        key,
-        blueprint_provider: Callable,
-        node_attribute: BlueprintAttribute,
-        recursion_depth: int = 0,
-        recipe_provider: Callable[..., list[StorageRecipe]] | None = None,
-    ):
-
-        if recursion_depth >= config.MAX_ENTITY_RECURSION_DEPTH:
-            message = (
-                f"Reached maximum recursion depth while creating NodeTree ({recursion_depth}).\n"
-                f"Node: {node_attribute.name}, Type: {node_attribute.attribute_type}\n"
-                f'If your blueprints contains recursion, set the attribute as "optional". '
-            )
-            logger.error(message)
-            raise RecursionError(message)
-
-        # If no attribute, that means this was a "top-level" entity. We create an Attribute based on the Blueprint
-        if not node_attribute:
-            bp = blueprint_provider(entity["type"])
-            node_attribute = BlueprintAttribute(name=bp.name, attributeType=entity["type"], description=bp.description)
-
-        # If there is data in the entity, load attribute type from the entity
-        if entity:
-            if not entity.get("type"):
-                raise ValueError(f"Entity is missing required attribute 'type'.\n{key}\n{entity}")
-            node_attribute = deepcopy(node_attribute)  # If you don't copy, we modify the blueprint in the BP Cache...
-            node_attribute.attribute_type = entity["type"]
-
-        key = key if key else node_attribute.name
-        node = Node(
-            key=key,
-            uid=uid,
-            entity=entity,
-            blueprint_provider=blueprint_provider,
-            attribute=node_attribute,
-            recipe_provider=recipe_provider,
-        )
-
-        for child_attribute in node.blueprint.get_none_primitive_types():
-            if child_attribute.name == "_meta_":
-                continue
-            child_contained = node.storage_recipes[0].is_contained(child_attribute.name)
-            # This will stop creation of recursive blueprints (only if they are optional)
-            if child_attribute.is_optional and not entity:
-                continue
-
-            if child_attribute.is_array:
-                children = entity.get(child_attribute.name, [])
-
-                if not isinstance(children, list):
-                    raise ValueError(
-                        f"The attribute '{child_attribute.name}' on blueprint '{node.type}' "
-                        + f"should be a list, but was '{str(type(children))}'"
-                    )
-
-                list_node = ListNode(
-                    key=child_attribute.name,
-                    uid="",
-                    entity=children,
-                    blueprint_provider=blueprint_provider,
-                    recipe_provider=recipe_provider,
-                    attribute=child_attribute,
-                )
-
-                for i, child in enumerate(children):
-                    list_child_attribute = child_attribute
-
-                    # If the node is of type DMT/Package, we need to override the attribute_type "Entity",
-                    # and get it from the child.
-                    if node.type == SIMOS.PACKAGE.value:
-                        content_attribute: BlueprintAttribute = deepcopy(child_attribute)
-                        content_attribute.attribute_type = child["type"]
-                        list_child_attribute = content_attribute
-
-                    list_child_node = cls._from_dict(
-                        uid=child.get("_id", ""),
-                        entity=child,
-                        key=str(i),
-                        blueprint_provider=blueprint_provider,
-                        recipe_provider=recipe_provider,
-                        node_attribute=list_child_attribute,
-                        recursion_depth=recursion_depth + 1,
-                    )
-                    list_node.add_child(list_child_node)
-                node.add_child(list_node)
-            else:
-                attribute_data = entity.get(child_attribute.name, {})
-                if not isinstance(attribute_data, dict):
-                    raise ValueError(
-                        f"The attribute '{child_attribute.name}' on blueprint '{node.type}' "
-                        + f"should be a dict, but was '{str(type(attribute_data))}'"
-                    )
-                child_node = cls._from_dict(
-                    # If the child is not contained, get or create it's _id
-                    uid="" if child_contained or not attribute_data else attribute_data.get("_id", ""),
-                    entity=attribute_data,
-                    key=child_attribute.name,
-                    blueprint_provider=blueprint_provider,
-                    recipe_provider=recipe_provider,
-                    node_attribute=child_attribute,
-                    recursion_depth=recursion_depth + 1,
-                )
-                node.add_child(child_node)
-
-        return node
 
 
 class NodeBase:
@@ -245,7 +31,7 @@ class NodeBase:
         self.parent: Union[Node, ListNode] = parent
         if parent:
             parent.add_child(self)
-        self.children: list[NodeBase] = []
+        self.children: list[Node | ListNode] = []
         if children is not None:
             for child in children:
                 self.add_child(child)
@@ -485,27 +271,9 @@ class Node(NodeBase):
     def is_root(self):
         return super().is_root()
 
-    def to_dict(self):
-        return DictExporter.to_dict(self)
-
-    def to_ref_dict(self):
-        return DictExporter.to_ref_dict(self)
-
     @property
     def name(self):
         return self.entity.get("name", self.attribute.name)
-
-    @staticmethod
-    def from_dict(
-        entity,
-        uid,
-        blueprint_provider,
-        node_attribute: BlueprintAttribute = None,
-        recipe_provider: Callable[..., list[StorageRecipe]] | None = None,
-    ):
-        return DictImporter.from_dict(
-            entity, uid, blueprint_provider, "", node_attribute, recipe_provider=recipe_provider
-        )
 
     # Replace the entire data of the node with the input dict. If it matches the blueprint...
     def update(self, data: dict):
@@ -624,9 +392,6 @@ class ListNode(NodeBase):
             recipe_provider=recipe_provider,
         )
 
-    def to_dict(self):
-        return [child.to_dict() for child in self.children]
-
     @property
     def name(self):
         return self.attribute.name
@@ -636,6 +401,7 @@ class ListNode(NodeBase):
         return self.parent.blueprint
 
     def update(self, data: list):
+        # Replaces the whole list with the new one
         self.children = []
         for i, item in enumerate(data):
             # Set self.type from posted type, and validate against parent blueprint
@@ -645,12 +411,13 @@ class ListNode(NodeBase):
             # Set uid base on containment and existing(lack of) uid
             # This requires the existing _id to be posted
             uid = "" if self.storage_contained else item.get("_id", str(uuid4()))
-            self.add_child(
-                DictImporter.from_dict(
-                    entity=item,
-                    uid=uid,
-                    blueprint_provider=self.blueprint_provider,
-                    key=str(i),
-                    recipe_provider=self.recipe_provider,
-                )
+            child = Node(
+                entity={},
+                uid=uid,
+                blueprint_provider=self.blueprint_provider,
+                key=str(i),
+                recipe_provider=self.recipe_provider,
+                attribute=BlueprintAttribute(name=self.name, attributeType=self.type),
+                parent=self,
             )
+            child.update(item)  # This will handle updating of children recursively

--- a/src/features/document/use_cases/get_document_by_path_use_case.py
+++ b/src/features/document/use_cases/get_document_by_path_use_case.py
@@ -1,4 +1,5 @@
 from authentication.models import User
+from common.tree_node_serializer import tree_node_to_dict
 from common.utils.get_document_by_path import get_document_by_absolute_path
 from common.utils.string_helpers import split_dmss_ref
 from services.document_service import DocumentService
@@ -29,4 +30,4 @@ def get_document_by_path_use_case(
     if attribute:
         document = document.get_by_path(attribute.split("."))
 
-    return document.to_dict()
+    return tree_node_to_dict(document)

--- a/src/services/document_service.py
+++ b/src/services/document_service.py
@@ -180,8 +180,7 @@ class DocumentService:
         )
         return tree_node_from_dict(
             complete_document,
-            complete_document.get("_id"),
-            key="",
+            uid=complete_document.get("_id"),
             blueprint_provider=self.get_blueprint,
             recipe_provider=self.get_storage_recipes,
         )
@@ -318,8 +317,6 @@ class DocumentService:
         new_node_attribute = BlueprintAttribute(name=leaf_attribute, attribute_type=type)
         new_node = tree_node_from_dict(
             entity,
-            uid=None,
-            key="",
             blueprint_provider=self.get_blueprint,
             node_attribute=new_node_attribute,
             recipe_provider=self.get_storage_recipes,
@@ -350,7 +347,7 @@ class DocumentService:
             raise BadRequestException("Only root packages may be added without a parent.")
 
         new_node = tree_node_from_dict(
-            data, uid=None, key="", blueprint_provider=self.get_blueprint, recipe_provider=self.get_storage_recipes
+            data, blueprint_provider=self.get_blueprint, recipe_provider=self.get_storage_recipes
         )
 
         exisiting_root_package = get_data_source(data_source, self.user).find(
@@ -410,8 +407,6 @@ class DocumentService:
 
         new_node = tree_node_from_dict(
             {**document.to_dict()},
-            uid=None,
-            key="",
             blueprint_provider=self.get_blueprint,
             node_attribute=BlueprintAttribute(name=new_node_attr, attribute_type=document.type),
             recipe_provider=self.get_storage_recipes,
@@ -513,7 +508,6 @@ class DocumentService:
                 tree_node_from_dict(
                     entity={**reference.dict(by_alias=True), "_id": str(reference.uid)},
                     uid=str(reference.uid),
-                    key="",
                     blueprint_provider=self.get_blueprint,
                     recipe_provider=self.get_storage_recipes,
                     node_attribute=attribute_node.attribute,

--- a/src/tests/unit/test_add_file_to_package_use_case.py
+++ b/src/tests/unit/test_add_file_to_package_use_case.py
@@ -2,6 +2,7 @@ from unittest import mock, skip
 from uuid import uuid4
 
 from authentication.models import User
+from common.tree_node_serializer import tree_node_to_dict
 from features.document.use_cases.add_file_use_case import add_file_use_case
 
 
@@ -28,6 +29,6 @@ def test_without_parameters():
     assert bool(use_case_result) is True
     document_repository.get.assert_called_with(parent_id)
 
-    result = use_case_result.value.to_dict()
+    result = tree_node_to_dict(use_case_result.value)
 
     assert result["filename"] == data["filename"]

--- a/src/tests/unit/test_data_source_and_repositories.py
+++ b/src/tests/unit/test_data_source_and_repositories.py
@@ -2,6 +2,7 @@ import unittest
 from unittest import mock
 
 from authentication.models import User
+from common.tree_node_serializer import tree_node_from_dict
 from config import config
 from domain_classes.tree_node import Node
 from enums import StorageDataTypes
@@ -70,8 +71,8 @@ class DataSourceTestCase(unittest.TestCase):
 
         document_service = get_mock_document_service(lambda x, y: data_source, user=test_user)
 
-        node: Node = Node.from_dict(
-            uncontained_doc, "1", document_service.get_blueprint, recipe_provider=mock_storage_recipe_provider
+        node: Node = tree_node_from_dict(
+            uncontained_doc, "1", "", document_service.get_blueprint, recipe_provider=mock_storage_recipe_provider
         )
 
         document_service.save(node, "testing", update_uncontained=True)
@@ -128,8 +129,12 @@ class DataSourceTestCase(unittest.TestCase):
 
         document_service = get_mock_document_service(lambda x, y: data_source, user=test_user)
 
-        node: Node = Node.from_dict(
-            blob_doc, "1", document_service.get_blueprint, recipe_provider=mock_storage_recipe_provider
+        node: Node = tree_node_from_dict(
+            blob_doc,
+            "1",
+            key="",
+            blueprint_provider=document_service.get_blueprint,
+            recipe_provider=mock_storage_recipe_provider,
         )
 
         document_service.save(node, "testing")
@@ -191,8 +196,8 @@ class DataSourceTestCase(unittest.TestCase):
 
         document_service = get_mock_document_service(lambda x, y: data_source, user=test_user)
 
-        node: Node = Node.from_dict(
-            blob_doc, "1", document_service.get_blueprint, recipe_provider=mock_storage_recipe_provider
+        node: Node = tree_node_from_dict(
+            blob_doc, "1", "", document_service.get_blueprint, recipe_provider=mock_storage_recipe_provider
         )
 
         document_service.save(node, "testing", update_uncontained=True)

--- a/src/tests/unit/test_data_source_and_repositories.py
+++ b/src/tests/unit/test_data_source_and_repositories.py
@@ -72,7 +72,10 @@ class DataSourceTestCase(unittest.TestCase):
         document_service = get_mock_document_service(lambda x, y: data_source, user=test_user)
 
         node: Node = tree_node_from_dict(
-            uncontained_doc, "1", "", document_service.get_blueprint, recipe_provider=mock_storage_recipe_provider
+            uncontained_doc,
+            uid="1",
+            blueprint_provider=document_service.get_blueprint,
+            recipe_provider=mock_storage_recipe_provider,
         )
 
         document_service.save(node, "testing", update_uncontained=True)
@@ -131,8 +134,7 @@ class DataSourceTestCase(unittest.TestCase):
 
         node: Node = tree_node_from_dict(
             blob_doc,
-            "1",
-            key="",
+            uid="1",
             blueprint_provider=document_service.get_blueprint,
             recipe_provider=mock_storage_recipe_provider,
         )
@@ -197,10 +199,10 @@ class DataSourceTestCase(unittest.TestCase):
         document_service = get_mock_document_service(lambda x, y: data_source, user=test_user)
 
         node: Node = tree_node_from_dict(
-            blob_doc, "1", "", document_service.get_blueprint, recipe_provider=mock_storage_recipe_provider
+            blob_doc, document_service.get_blueprint, uid="1", recipe_provider=mock_storage_recipe_provider
         )
 
         document_service.save(node, "testing", update_uncontained=True)
 
-        # Test that both repos get's written into
+        # Test that both repos gets written into
         assert blob_doc_storage and default_doc_storage

--- a/src/tests/unit/test_get.py
+++ b/src/tests/unit/test_get.py
@@ -1,6 +1,7 @@
 import unittest
 from unittest import mock
 
+from common.tree_node_serializer import tree_node_to_dict
 from common.utils.data_structure.compare import pretty_eq
 from tests.unit.mock_utils import get_mock_document_service
 
@@ -39,7 +40,7 @@ class DocumentServiceTestCase(unittest.TestCase):
         document_repository.get = mock_get
 
         document_service = get_mock_document_service(lambda x, y: document_repository)
-        root = document_service.get_node_by_uid("datasource", "1").to_dict()
+        root = tree_node_to_dict(document_service.get_node_by_uid("datasource", "1"))
 
         assert isinstance(root, dict)
 
@@ -93,7 +94,7 @@ class DocumentServiceTestCase(unittest.TestCase):
         document_repository.get = mock_get
 
         document_service = get_mock_document_service(lambda x, y: document_repository)
-        root = document_service.get_node_by_uid("datasource", "1").to_dict()
+        root = tree_node_to_dict(document_service.get_node_by_uid("datasource", "1"))
 
         assert isinstance(root, dict)
 

--- a/src/tests/unit/test_save.py
+++ b/src/tests/unit/test_save.py
@@ -3,6 +3,7 @@ from copy import deepcopy
 from unittest import mock
 
 from authentication.models import User
+from common.tree_node_serializer import tree_node_from_dict
 from domain_classes.blueprint_attribute import BlueprintAttribute
 from domain_classes.tree_node import Node
 from tests.unit.mock_utils import (
@@ -198,8 +199,8 @@ class DocumentServiceTestCase(unittest.TestCase):
 
         document_service = get_mock_document_service(lambda x, y: repository)
 
-        node: Node = Node.from_dict(
-            doc_storage["1"], "1", document_service.get_blueprint, recipe_provider=mock_storage_recipe_provider
+        node: Node = tree_node_from_dict(
+            doc_storage["1"], "1", "", document_service.get_blueprint, recipe_provider=mock_storage_recipe_provider
         )
         document_service.save(node, "testing", update_uncontained=True)
 

--- a/src/tests/unit/test_save.py
+++ b/src/tests/unit/test_save.py
@@ -200,7 +200,7 @@ class DocumentServiceTestCase(unittest.TestCase):
         document_service = get_mock_document_service(lambda x, y: repository)
 
         node: Node = tree_node_from_dict(
-            doc_storage["1"], "1", "", document_service.get_blueprint, recipe_provider=mock_storage_recipe_provider
+            doc_storage["1"], document_service.get_blueprint, uid="1", recipe_provider=mock_storage_recipe_provider
         )
         document_service.save(node, "testing", update_uncontained=True)
 

--- a/src/tests/unit/test_tree_error_node.py
+++ b/src/tests/unit/test_tree_error_node.py
@@ -39,6 +39,6 @@ class ErrorTreenodeTestCase(unittest.TestCase):
             def get_blueprint(type: str):
                 raise Exception("fix me")
 
-        root = tree_node_from_dict(document_1, uid=None, key="", blueprint_provider=BlueprintProvider(), recipe_provider=mock_storage_recipe_provider)  # type: ignore
+        root = tree_node_from_dict(document_1, blueprint_provider=BlueprintProvider(), recipe_provider=mock_storage_recipe_provider)  # type: ignore
         error_msg = root.children[0].error_message
         assert error_msg is not None

--- a/src/tests/unit/test_tree_error_node.py
+++ b/src/tests/unit/test_tree_error_node.py
@@ -1,7 +1,7 @@
 import unittest
 from unittest import skip
 
-from domain_classes.tree_node import Node
+from common.tree_node_serializer import tree_node_from_dict
 from tests.unit.mock_utils import mock_storage_recipe_provider
 
 all_contained_cases_blueprint = {
@@ -39,6 +39,6 @@ class ErrorTreenodeTestCase(unittest.TestCase):
             def get_blueprint(type: str):
                 raise Exception("fix me")
 
-        root = Node.from_dict(document_1, BlueprintProvider(), recipe_provider=mock_storage_recipe_provider)
+        root = tree_node_from_dict(document_1, uid=None, key="", blueprint_provider=BlueprintProvider(), recipe_provider=mock_storage_recipe_provider)  # type: ignore
         error_msg = root.children[0].error_message
         assert error_msg is not None

--- a/src/tests/unit/test_tree_node_helpers.py
+++ b/src/tests/unit/test_tree_node_helpers.py
@@ -1,9 +1,10 @@
 import unittest
 
+from common.tree_node_serializer import tree_node_from_dict, tree_node_to_dict
 from common.utils.data_structure.compare import pretty_eq
 from domain_classes.blueprint import Blueprint
 from domain_classes.blueprint_attribute import BlueprintAttribute
-from domain_classes.tree_node import DictExporter, DictImporter, ListNode, Node
+from domain_classes.tree_node import ListNode, Node
 from tests.unit.mock_utils import flatten_dict, mock_storage_recipe_provider
 
 all_contained_cases_blueprint = {
@@ -179,7 +180,7 @@ class TreenodeTestCase(unittest.TestCase):
             "nested": {"name": "Nested1", "description": "", "type": "basic_blueprint"},
         }
 
-        assert actual_before == root.to_dict()
+        assert actual_before == tree_node_to_dict(root)
 
         root.replace("1.nested", nested_2)
 
@@ -191,7 +192,7 @@ class TreenodeTestCase(unittest.TestCase):
             "nested": {"name": "Nested2", "description": "", "type": "basic_blueprint"},
         }
 
-        assert actual_after_replaced == root.to_dict()
+        assert actual_after_replaced == tree_node_to_dict(root)
 
     def test_delete_root_child(self):
         root_data = {"_id": 1, "name": "root", "description": "", "type": "all_contained_cases_blueprint"}
@@ -223,13 +224,13 @@ class TreenodeTestCase(unittest.TestCase):
             "nested": {"name": "Nested1", "description": "", "type": "basic_blueprint"},
         }
 
-        assert actual_before == root.to_dict()
+        assert actual_before == tree_node_to_dict(root)
 
         root.remove_by_path(["nested"])
 
         actual_after_delete = {"_id": "1", "name": "root", "description": "", "type": "all_contained_cases_blueprint"}
 
-        assert actual_after_delete == root.to_dict()
+        assert actual_after_delete == tree_node_to_dict(root)
 
     def test_delete_nested_child(self):
         root_data = {"_id": 1, "name": "root", "description": "", "type": "all_contained_cases_blueprint"}
@@ -276,7 +277,7 @@ class TreenodeTestCase(unittest.TestCase):
             },
         }
 
-        assert actual_before == root.to_dict()
+        assert actual_before == tree_node_to_dict(root)
 
         root.remove_by_path(["nested", "nested2"])
 
@@ -288,7 +289,7 @@ class TreenodeTestCase(unittest.TestCase):
             "nested": {"name": "Nested1", "description": "", "type": "basic_blueprint"},
         }
 
-        assert actual_after_delete == root.to_dict()
+        assert actual_after_delete == tree_node_to_dict(root)
 
     def test_delete_list_element_of_nested_child(self):
         document = {
@@ -308,8 +309,8 @@ class TreenodeTestCase(unittest.TestCase):
                 }
             ],
         }
-        root = Node.from_dict(
-            document, document.get("_id"), get_blueprint, recipe_provider=mock_storage_recipe_provider
+        root = tree_node_from_dict(
+            document, document.get("_id"), "", get_blueprint, recipe_provider=mock_storage_recipe_provider
         )
 
         actual_before = {
@@ -330,7 +331,7 @@ class TreenodeTestCase(unittest.TestCase):
             ],
         }
 
-        assert actual_before == root.to_dict()
+        assert actual_before == tree_node_to_dict(root)
 
         root.remove_by_path(["a_list", "0", "a_list", "1"])
 
@@ -349,7 +350,7 @@ class TreenodeTestCase(unittest.TestCase):
             ],
         }
 
-        assert actual_after_delete == root.to_dict()
+        assert actual_after_delete == tree_node_to_dict(root)
 
     def test_depth(self):
         root_data = {"_id": 1, "name": "root", "description": "", "type": "all_contained_cases_blueprint"}
@@ -395,8 +396,8 @@ class TreenodeTestCase(unittest.TestCase):
             },
         }
 
-        root = Node.from_dict(
-            document_1, document_1.get("_id"), get_blueprint, recipe_provider=mock_storage_recipe_provider
+        root = tree_node_from_dict(
+            document_1, document_1.get("_id"), "", get_blueprint, recipe_provider=mock_storage_recipe_provider
         )
         result = [node.name for node in root.traverse()]
         # with error nodes
@@ -536,8 +537,8 @@ class TreenodeTestCase(unittest.TestCase):
             },
         }
 
-        root = Node.from_dict(
-            document_1, document_1.get("_id"), get_blueprint, recipe_provider=mock_storage_recipe_provider
+        root = tree_node_from_dict(
+            document_1, document_1.get("_id"), "", get_blueprint, recipe_provider=mock_storage_recipe_provider
         )
 
         child_1 = root.search("1.nested.nested")
@@ -567,8 +568,8 @@ class TreenodeTestCase(unittest.TestCase):
             },
         }
 
-        root = Node.from_dict(
-            document_1, document_1.get("_id"), get_blueprint, recipe_provider=mock_storage_recipe_provider
+        root = tree_node_from_dict(
+            document_1, document_1.get("_id"), "", get_blueprint, recipe_provider=mock_storage_recipe_provider
         )
 
         child_1 = root.get_by_path(["nested", "nested"])
@@ -600,8 +601,8 @@ class TreenodeTestCase(unittest.TestCase):
             "references": [],
         }
 
-        root = Node.from_dict(
-            document_1, document_1.get("_id"), get_blueprint, recipe_provider=mock_storage_recipe_provider
+        root = tree_node_from_dict(
+            document_1, document_1.get("_id"), "", get_blueprint, recipe_provider=mock_storage_recipe_provider
         )
 
         update_0 = {
@@ -625,7 +626,7 @@ class TreenodeTestCase(unittest.TestCase):
 
         root.update(update_0)
 
-        assert pretty_eq(update_0, root.to_dict()) is None
+        assert pretty_eq(update_0, tree_node_to_dict(root)) is None
 
         update_1 = {
             "name": "New-name",
@@ -648,7 +649,7 @@ class TreenodeTestCase(unittest.TestCase):
 
         root.update(update_1)
 
-        assert pretty_eq(update_1, root.to_dict()) is None
+        assert pretty_eq(update_1, tree_node_to_dict(root)) is None
 
         update_2 = {
             "name": "New-name",
@@ -671,7 +672,7 @@ class TreenodeTestCase(unittest.TestCase):
 
         root.update(update_2)
 
-        assert pretty_eq(update_2, root.to_dict()) is None
+        assert pretty_eq(update_2, tree_node_to_dict(root)) is None
 
         expected = {
             "_id": "1",
@@ -697,7 +698,7 @@ class TreenodeTestCase(unittest.TestCase):
         # nodes when attributes are missing, needed for having error nodes in the index.
 
         expected_flat = flatten_dict(expected)
-        actual_flat = flatten_dict(root.to_dict())
+        actual_flat = flatten_dict(tree_node_to_dict(root))
         # less than only works on flat dictionaries.
         assert expected_flat.items() <= actual_flat.items()
 
@@ -752,8 +753,8 @@ class TreenodeTestCase(unittest.TestCase):
             "_blueprint": all_contained_cases_blueprint,
         }
 
-        root = Node.from_dict(
-            document_1, document_1.get("_id"), get_blueprint, recipe_provider=mock_storage_recipe_provider
+        root = tree_node_from_dict(
+            document_1, document_1.get("_id"), "", get_blueprint, recipe_provider=mock_storage_recipe_provider
         )
 
         actual = {
@@ -779,14 +780,14 @@ class TreenodeTestCase(unittest.TestCase):
             ],
         }
 
-        assert pretty_eq(actual, root.to_dict()) is None
+        assert pretty_eq(actual, tree_node_to_dict(root)) is None
 
     def test_recursive_from_dict(self):
         document_1 = {"_id": "1", "name": "Parent", "description": "", "type": "recursive_blueprint", "im_me!": {}}
 
         with self.assertRaises(RecursionError):
-            Node.from_dict(
-                document_1, document_1.get("_id"), get_blueprint, recipe_provider=mock_storage_recipe_provider
+            tree_node_from_dict(
+                document_1, document_1.get("_id"), "", get_blueprint, recipe_provider=mock_storage_recipe_provider
             )
 
     def test_from_dict_using_dict_importer(self):
@@ -863,11 +864,11 @@ class TreenodeTestCase(unittest.TestCase):
             ],
         }
 
-        root = DictImporter.from_dict(
-            document_1, document_1.get("_id"), get_blueprint, recipe_provider=mock_storage_recipe_provider
+        root = tree_node_from_dict(
+            document_1, document_1.get("_id"), "", get_blueprint, recipe_provider=mock_storage_recipe_provider
         )
 
-        assert pretty_eq(actual, root.to_dict()) is None
+        assert pretty_eq(actual, tree_node_to_dict(root)) is None
 
     def test_to_dict(self):
         root_data = {"_id": 1, "name": "root", "description": "", "type": "all_contained_cases_blueprint"}
@@ -954,7 +955,7 @@ class TreenodeTestCase(unittest.TestCase):
             "list": [{"name": "Item1", "description": "", "type": "basic_blueprint"}],
         }
 
-        self.assertEqual(actual_root, DictExporter.to_dict(root))
+        self.assertEqual(actual_root, tree_node_to_dict(root))
 
         actual_nested = {
             "name": "Nested",
@@ -968,8 +969,8 @@ class TreenodeTestCase(unittest.TestCase):
             },
         }
 
-        self.assertEqual(actual_nested, nested.to_dict())
+        self.assertEqual(actual_nested, tree_node_to_dict(nested))
 
         item_1_actual = {"name": "Item1", "description": "", "type": "basic_blueprint"}
 
-        self.assertEqual(item_1_actual, item_1.to_dict())
+        self.assertEqual(item_1_actual, tree_node_to_dict(item_1))

--- a/src/tests/unit/test_tree_node_helpers.py
+++ b/src/tests/unit/test_tree_node_helpers.py
@@ -310,7 +310,7 @@ class TreenodeTestCase(unittest.TestCase):
             ],
         }
         root = tree_node_from_dict(
-            document, document.get("_id"), "", get_blueprint, recipe_provider=mock_storage_recipe_provider
+            document, get_blueprint, uid=document.get("_id"), recipe_provider=mock_storage_recipe_provider
         )
 
         actual_before = {
@@ -397,7 +397,7 @@ class TreenodeTestCase(unittest.TestCase):
         }
 
         root = tree_node_from_dict(
-            document_1, document_1.get("_id"), "", get_blueprint, recipe_provider=mock_storage_recipe_provider
+            document_1, get_blueprint, uid=document_1.get("_id"), recipe_provider=mock_storage_recipe_provider
         )
         result = [node.name for node in root.traverse()]
         # with error nodes
@@ -538,7 +538,7 @@ class TreenodeTestCase(unittest.TestCase):
         }
 
         root = tree_node_from_dict(
-            document_1, document_1.get("_id"), "", get_blueprint, recipe_provider=mock_storage_recipe_provider
+            document_1, get_blueprint, uid=document_1.get("_id"), recipe_provider=mock_storage_recipe_provider
         )
 
         child_1 = root.search("1.nested.nested")
@@ -569,7 +569,7 @@ class TreenodeTestCase(unittest.TestCase):
         }
 
         root = tree_node_from_dict(
-            document_1, document_1.get("_id"), "", get_blueprint, recipe_provider=mock_storage_recipe_provider
+            document_1, get_blueprint, uid=document_1.get("_id"), recipe_provider=mock_storage_recipe_provider
         )
 
         child_1 = root.get_by_path(["nested", "nested"])
@@ -602,7 +602,7 @@ class TreenodeTestCase(unittest.TestCase):
         }
 
         root = tree_node_from_dict(
-            document_1, document_1.get("_id"), "", get_blueprint, recipe_provider=mock_storage_recipe_provider
+            document_1, get_blueprint, uid=document_1.get("_id"), recipe_provider=mock_storage_recipe_provider
         )
 
         update_0 = {
@@ -754,7 +754,7 @@ class TreenodeTestCase(unittest.TestCase):
         }
 
         root = tree_node_from_dict(
-            document_1, document_1.get("_id"), "", get_blueprint, recipe_provider=mock_storage_recipe_provider
+            document_1, get_blueprint, uid=document_1.get("_id"), recipe_provider=mock_storage_recipe_provider
         )
 
         actual = {
@@ -787,7 +787,7 @@ class TreenodeTestCase(unittest.TestCase):
 
         with self.assertRaises(RecursionError):
             tree_node_from_dict(
-                document_1, document_1.get("_id"), "", get_blueprint, recipe_provider=mock_storage_recipe_provider
+                document_1, get_blueprint, uid=document_1.get("_id"), recipe_provider=mock_storage_recipe_provider
             )
 
     def test_from_dict_using_dict_importer(self):
@@ -865,7 +865,7 @@ class TreenodeTestCase(unittest.TestCase):
         }
 
         root = tree_node_from_dict(
-            document_1, document_1.get("_id"), "", get_blueprint, recipe_provider=mock_storage_recipe_provider
+            document_1, get_blueprint, uid=document_1.get("_id"), recipe_provider=mock_storage_recipe_provider
         )
 
         assert pretty_eq(actual, tree_node_to_dict(root)) is None


### PR DESCRIPTION
## What does this pull request change?
- Move the logic from "DictImporter" and "DictExporter" to simple functions in a separate file
- Remove the Node.to_dict() functions  - To avoid circular dependencies and simpler to have ONE way to serialize Nodes

## Why is this pull request needed?

- More maintainable code base

## Issues related to this change:
closes #313 
