### PR TITLE
feature: extend RecipeLinks on lookup creation

### DIFF
--- a/src/domain_classes/lookup.py
+++ b/src/domain_classes/lookup.py
@@ -1,9 +1,28 @@
 from collections import defaultdict
+from typing import Tuple
 
 from pydantic import BaseModel, Field
 
 from domain_classes.storage_recipe import StorageRecipe
 from domain_classes.ui_recipe import Recipe
+
+
+def resolve_extended_recipe_links_recursive(
+    blueprint_path: str, lookup: "Lookup", extends: dict[str, list[str]]
+) -> Tuple[list[StorageRecipe], list[Recipe]]:
+    if not extends.get(blueprint_path):  # It does not extend anything, just return its own recipes
+        return lookup.storage_recipes[blueprint_path], lookup.ui_recipes[blueprint_path]
+
+    inherited_ui_recipes: list[Recipe] = []
+    inherited_storage_recipes: list[StorageRecipe] = []
+    for type in extends[blueprint_path]:
+        new_storage_recipe, new_ui_recipes = resolve_extended_recipe_links_recursive(type, lookup, extends)
+        inherited_ui_recipes = inherited_ui_recipes + new_ui_recipes
+        inherited_storage_recipes = inherited_storage_recipes + new_storage_recipe
+
+    own_and_inherited_ui = lookup.ui_recipes[blueprint_path] + inherited_ui_recipes
+    own_and_inherited_storage = lookup.storage_recipes[blueprint_path] + inherited_storage_recipes
+    return own_and_inherited_storage, own_and_inherited_ui
 
 
 class Lookup(BaseModel):
@@ -12,6 +31,19 @@ class Lookup(BaseModel):
     storage_recipes: dict[str, list[StorageRecipe]] = Field(
         default_factory=lambda: defaultdict(list), alias="storageRecipes"
     )
+    extends: dict[str, list[str]] = {}
+
+    def realize_extends(self):
+        new_ui_recipes = {}
+        new_storage_recipes = {}
+
+        for blueprint_path in self.extends:
+            resolved_storage, resolved_ui = resolve_extended_recipe_links_recursive(blueprint_path, self, self.extends)
+            new_ui_recipes[blueprint_path] = resolved_ui
+            new_storage_recipes[blueprint_path] = resolved_storage
+
+        self.ui_recipes.update(new_ui_recipes)
+        self.storage_recipes.update(new_storage_recipes)
 
     class Config:
         allow_population_by_field_name = True

--- a/src/home/system/SIMOS/recipe_links/pdf.json
+++ b/src/home/system/SIMOS/recipe_links/pdf.json
@@ -1,6 +1,7 @@
 {
   "type": "dmss://system/SIMOS/RecipeLink",
   "_blueprintPath_": "dmss://system/SIMOS/blob_types/PDF",
+  "extends": ["dmss://system/SIMOS/Entity", "_default_"],
   "uiRecipes": [
     {
       "type": "dmss://system/SIMOS/UiRecipe",

--- a/src/tests/unit/test_extend_recipe_links.py
+++ b/src/tests/unit/test_extend_recipe_links.py
@@ -1,0 +1,81 @@
+import unittest
+
+from domain_classes.lookup import Lookup
+
+
+class ExtendRecipeLinksTestCase(unittest.TestCase):
+    def test_get_recipes_not_extended(self):
+        lookup = Lookup(
+            **{
+                "ui_recipes": {
+                    "_default_": [
+                        {"name": "Yaml", "type": "dmss://system/SIMOS/UiRecipe"},
+                        {"name": "Edit", "type": "dmss://system/SIMOS/UiRecipe"},
+                    ],
+                    "dmss://system/SIMOS/Entity": [{"name": "DEFAULT_CREATE", "type": "dmss://system/SIMOS/UiRecipe"}],
+                    "dmss://system/SIMOS/blob_types/PDF": [
+                        {"name": "PDFView", "type": "dmss://system/SIMOS/UiRecipe"}
+                    ],
+                }
+            }
+        )
+
+        lookup.realize_extends()
+
+        assert len(lookup.ui_recipes["dmss://system/SIMOS/blob_types/PDF"]) == 1
+
+    def test_get_recipes_2_levels_extended(self):
+        lookup = Lookup(
+            **{
+                "ui_recipes": {
+                    "some_other_base": [{"name": "FROM-BASE", "type": "dmss://system/SIMOS/UiRecipe"}],
+                    "_default_": [
+                        {"name": "Yaml", "type": "dmss://system/SIMOS/UiRecipe"},
+                        {"name": "Edit", "type": "dmss://system/SIMOS/UiRecipe"},
+                    ],
+                    "dmss://system/SIMOS/Entity": [{"name": "DEFAULT_CREATE", "type": "dmss://system/SIMOS/UiRecipe"}],
+                    "dmss://system/SIMOS/blob_types/PDF": [
+                        {"name": "PDFView", "type": "dmss://system/SIMOS/UiRecipe"}
+                    ],
+                }
+            }
+        )
+
+        lookup.extends = {
+            "dmss://system/SIMOS/blob_types/PDF": ["dmss://system/SIMOS/Entity", "_default_"],
+            "dmss://system/SIMOS/Entity": ["some_other_base"],
+        }
+
+        lookup.realize_extends()
+
+        assert len(lookup.ui_recipes["dmss://system/SIMOS/Entity"]) == 2
+        assert len(lookup.ui_recipes["dmss://system/SIMOS/blob_types/PDF"]) == 5
+
+    def test_get_storage_recipes_2_levels_extended(self):
+        lookup = Lookup(
+            **{
+                "storage_recipes": {
+                    "some_other_base": [{"name": "FROM-BASE", "type": "dmss://system/SIMOS/StorageRecipe"}],
+                    "_default_": [
+                        {"name": "Yaml", "type": "dmss://system/SIMOS/StorageRecipe"},
+                        {"name": "Edit", "type": "dmss://system/SIMOS/StorageRecipe"},
+                    ],
+                    "dmss://system/SIMOS/Entity": [
+                        {"name": "DEFAULT_CREATE", "type": "dmss://system/SIMOS/StorageRecipe"}
+                    ],
+                    "dmss://system/SIMOS/blob_types/PDF": [
+                        {"name": "PDFView", "type": "dmss://system/SIMOS/StorageRecipe"}
+                    ],
+                }
+            }
+        )
+
+        lookup.extends = {
+            "dmss://system/SIMOS/blob_types/PDF": ["dmss://system/SIMOS/Entity", "_default_"],
+            "dmss://system/SIMOS/Entity": ["some_other_base"],
+        }
+
+        lookup.realize_extends()
+
+        assert len(lookup.storage_recipes["dmss://system/SIMOS/Entity"]) == 2
+        assert len(lookup.storage_recipes["dmss://system/SIMOS/blob_types/PDF"]) == 5


### PR DESCRIPTION
## What does this pull request change?
- Adds "realize_extends" functionality to the "Lookup" class
- Call this once when a new lookup is created, before it is saved

## Issues related to this change:
closes #302 