### PR TITLE
chore: roll back openapi generator version

### DIFF
--- a/generate-python-package.sh
+++ b/generate-python-package.sh
@@ -9,7 +9,7 @@ echo "Creating DMSS Python package version $PACKAGE_VERSION"
 docker run --rm \
     --network="host" \
     -v ${PWD}:/local \
-    openapitools/openapi-generator-cli:v6.2.1 generate \
+    openapitools/openapi-generator-cli:v5.2.1 generate \
     -i http://localhost:5000/openapi.json  \
     -g python \
     -o /local/gen/dmss_api \


### PR DESCRIPTION
## What does this pull request change?
roll back openapi generator version, since V6 caused some breaking changes
## Why is this pull request needed?

## Issues related to this change:
