### PR TITLE
fix: builtin default ui recipes not used if there is a context

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,4 @@
 # Order matter. If two rules match the same file, only the last one is used
 
 # Repo owners
-*       @KristianKjerstad @netr0m @soofstad @eoaksnes
+*       @KristianKjerstad @netr0m @soofstad @eoaksnes @ingeridhellen

--- a/src/common/utils/get_storage_recipe.py
+++ b/src/common/utils/get_storage_recipe.py
@@ -1,19 +1,20 @@
 from common.exceptions import NotFoundException
 from domain_classes.lookup import Lookup
 from domain_classes.storage_recipe import StorageRecipe
+from domain_classes.ui_recipe import Recipe
 from enums import SIMOS
 from storage.internal.lookup_tables import get_lookup
 
-default_ui_recipes = [
-    {
+default_yaml_view = Recipe(
+    **{
         "name": "Yaml",
         "type": SIMOS.UI_RECIPE.value,
         "plugin": "yaml-view",
-        "roles": ["dmss-admin"],
         "category": "view",
-    },
-    {"name": "Edit", "type": SIMOS.UI_RECIPE.value, "plugin": "form", "category": "edit"},
-]
+    }
+)
+default_form_edit = Recipe(**{"name": "Edit", "type": SIMOS.UI_RECIPE.value, "plugin": "form", "category": "edit"})
+default_ui_recipes = [default_form_edit, default_yaml_view]
 
 
 def storage_recipe_provider(type: str, context: str | None = None) -> list[StorageRecipe]:

--- a/src/domain_classes/ui_recipe.py
+++ b/src/domain_classes/ui_recipe.py
@@ -63,9 +63,3 @@ class Recipe(BaseModel):
                 return array_contained
             else:
                 return single_contained
-
-
-class DefaultRecipe(Recipe):
-    def __init__(self, attributes: List[BlueprintAttribute]):
-        recipe_attributes = [RecipeAttribute(name=attr.name) for attr in attributes]
-        super().__init__(name="Default", attributes=recipe_attributes)

--- a/src/features/blueprint/use_cases/get_blueprint_use_case.py
+++ b/src/features/blueprint/use_cases/get_blueprint_use_case.py
@@ -21,7 +21,7 @@ def get_blueprint_use_case(type: common_type_constrained_string, context: str | 
     if not context:
         return {
             "blueprint": blueprint.to_dict(),
-            "uiRecipes": default_ui_recipes,
+            "uiRecipes": [ur.dict(by_alias=True) for ur in default_ui_recipes],
             # TODO: Generate default storage recipe
             "storageRecipes": [],
         }
@@ -30,9 +30,9 @@ def get_blueprint_use_case(type: common_type_constrained_string, context: str | 
     # Get type specific recipes
     ui_recipes = lookup.ui_recipes.get(type, [])
 
-    # If no recipe link exists for the type, use the contexts default
+    # If no recipe link exists for the type, use the contexts default. If none, use builtin default
     if not ui_recipes:
-        ui_recipes = lookup.ui_recipes.get("_default_", [])
+        ui_recipes = lookup.ui_recipes.get("_default_", default_ui_recipes)
 
     storage_recipes = lookup.storage_recipes.get(type, [])
     if not storage_recipes:

--- a/src/tests/bdd/get_blueprints.feature
+++ b/src/tests/bdd/get_blueprints.feature
@@ -155,19 +155,16 @@ Feature: Get a blueprint
     },
     "uiRecipes": [
       {
-        "name": "Yaml",
-        "type": "dmss://system/SIMOS/UiRecipe",
-        "plugin": "yaml-view",
-        "roles": [
-          "dmss-admin"
-        ],
-        "category": "view"
-      },
-      {
         "name": "Edit",
         "type": "dmss://system/SIMOS/UiRecipe",
         "plugin": "form",
         "category": "edit"
+      },
+      {
+        "name": "Yaml",
+        "type": "dmss://system/SIMOS/UiRecipe",
+        "plugin": "yaml-view",
+        "category": "view"
       }
     ],
     "storageRecipes": []


### PR DESCRIPTION
Fix a bug where builtin default ui-recipes where not used if a context were specified and no recipes found.