### PR TITLE
feature: lookup and getBlueprint serves 'initialRecipe's

### DIFF
--- a/src/domain_classes/lookup.py
+++ b/src/domain_classes/lookup.py
@@ -31,6 +31,7 @@ class Lookup(BaseModel):
     storage_recipes: dict[str, list[StorageRecipe]] = Field(
         default_factory=lambda: defaultdict(list), alias="storageRecipes"
     )
+    initial_ui_recipes: dict[str, Recipe | None] = Field(default_factory=lambda: {}, alias="initialUiRecipes")
     extends: dict[str, list[str]] = {}
 
     def realize_extends(self):

--- a/src/features/blueprint/use_cases/get_blueprint_use_case.py
+++ b/src/features/blueprint/use_cases/get_blueprint_use_case.py
@@ -40,6 +40,7 @@ def get_blueprint_use_case(type: common_type_constrained_string, context: str | 
 
     return {
         "blueprint": blueprint.to_dict(),
+        "initialUiRecipe": lookup.initial_ui_recipes[type].dict() if lookup.initial_ui_recipes.get(type) else None,
         "uiRecipes": [ur.dict(by_alias=True) for ur in ui_recipes],
         "storageRecipes": [sr.dict(by_alias=True) for sr in storage_recipes],
     }

--- a/src/features/lookup_table/use_cases/create_lookup_table.py
+++ b/src/features/lookup_table/use_cases/create_lookup_table.py
@@ -26,6 +26,9 @@ def create_lookup_table_use_case(
         if node.type == SIMOS.RECIPE_LINK.value:
             blueprint_path = node.entity["_blueprintPath_"]
             ui_recipes = [Recipe(**r) for r in node.entity.get("uiRecipes", [])]
+            initial_ui_recipe = (
+                Recipe(**node.entity["initialUiRecipe"]) if node.entity.get("initialUiRecipe") else None
+            )
 
             storage_recipes = [
                 StorageRecipe(
@@ -41,6 +44,7 @@ def create_lookup_table_use_case(
 
             lookup.storage_recipes[blueprint_path].extend(storage_recipes)
             lookup.ui_recipes[blueprint_path].extend(ui_recipes)
+            lookup.initial_ui_recipes[blueprint_path] = initial_ui_recipe
 
     lookup.extends = recipes_to_extend
     lookup.realize_extends()

--- a/src/home/system/SIMOS/RecipeLink.json
+++ b/src/home/system/SIMOS/RecipeLink.json
@@ -13,6 +13,14 @@
     {
       "attributeType": "dmss://system/SIMOS/UiRecipe",
       "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "name": "initialUiRecipe",
+      "contained": true,
+      "optional": true,
+      "dimensions": ""
+    },
+    {
+      "attributeType": "dmss://system/SIMOS/UiRecipe",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
       "name": "uiRecipes",
       "contained": true,
       "optional": true,


### PR DESCRIPTION
## What does this pull request change?
- RecipeLinks and Lookups now support "initialRecipe"

## Why is this pull request needed?
- Initial recipe can be used to select a single plugin as a entrypoint for the UI

## Issues related to this change:
closes #335 