### PR TITLE
fix: raise exception if blueprint path not found when creating lookup table

### DIFF
--- a/src/features/lookup_table/use_cases/create_lookup_table.py
+++ b/src/features/lookup_table/use_cases/create_lookup_table.py
@@ -25,6 +25,11 @@ def create_lookup_table_use_case(
     for node in recipe_package.traverse():
         if node.type == SIMOS.RECIPE_LINK.value:
             blueprint_path = node.entity["_blueprintPath_"]
+
+            # Check if blueprint exists. If not, exception is raised
+            if blueprint_path != "_default_":
+                document_service.get_blueprint(blueprint_path)
+
             ui_recipes = [Recipe(**r) for r in node.entity.get("uiRecipes", [])]
             initial_ui_recipe = (
                 Recipe(**node.entity["initialUiRecipe"]) if node.entity.get("initialUiRecipe") else None


### PR DESCRIPTION

## What does this pull request change?
check if blueprint from _blueprintPath_ exists when creating lookup table
## Why is this pull request needed?
fail quickly if a user creates an invalid recipe link entity
## Issues related to this change:
closes #342 