### PR TITLE
feature(lookup): allow updating/replacing recipe lookups

### DIFF
--- a/src/services/database.py
+++ b/src/services/database.py
@@ -18,6 +18,6 @@ else:
     raise ValueError("Missing credentials for the DataSource database")
 
 internal_db = mongo_client["dmss-internal"]
-data_source_collection = mongo_client["dmss-internal"]["data_sources"]
-personal_access_token_collection = mongo_client["dmss-internal"]["personal_access_tokens"]
-lookup_table_collection = mongo_client["dmss-internal"]["lookup_tables"]
+data_source_collection = internal_db["data_sources"]
+personal_access_token_collection = internal_db["personal_access_tokens"]
+lookup_table_collection = internal_db["lookup_tables"]

--- a/src/storage/internal/lookup_tables.py
+++ b/src/storage/internal/lookup_tables.py
@@ -1,8 +1,6 @@
 from functools import lru_cache
 
-from pymongo.errors import DuplicateKeyError
-
-from common.exceptions import BadRequestException, NotFoundException
+from common.exceptions import NotFoundException
 from config import config
 from domain_classes.lookup import Lookup
 from services.database import lookup_table_collection
@@ -10,13 +8,7 @@ from services.database import lookup_table_collection
 
 def insert_lookup(lookup_id: str, lookup: dict) -> None:
     lookup["_id"] = lookup_id
-    try:
-        lookup_table_collection.insert_one(lookup)
-    except DuplicateKeyError:
-        raise BadRequestException(
-            f"A lookup table with name '{lookup['_id']}' already exists."
-            + " Use a different name, or delete the old one first"
-        )
+    lookup_table_collection.update_one(filter={"_id": lookup_id}, update={"$set": lookup}, upsert=True)
 
 
 @lru_cache(maxsize=config.CACHE_MAX_SIZE)

--- a/src/tests/bdd/create_lookup.feature
+++ b/src/tests/bdd/create_lookup.feature
@@ -6,3 +6,11 @@ Feature: Create a lookup table
     Given i access the resource url "/api/application/dmss?recipe_package=system/SIMOS/recipe_links"
     When i make a "POST" request
     Then the response status should be "No Content"
+
+  Scenario: System admins want to replace an existing recipe lookup for DMSS - SIMOS/recipe_links folder
+    Given i access the resource url "/api/application/dmss?recipe_package=system/SIMOS/recipe_links"
+    When i make a "POST" request
+    Then the response status should be "No Content"
+    Given i access the resource url "/api/application/dmss?recipe_package=system/SIMOS/recipe_links"
+    When i make a "POST" request
+    Then the response status should be "No Content"


### PR DESCRIPTION
## What does this pull request change?

- allow updating/replacing recipe lookups

## Why is this pull request needed?

- Removes the need to reset entire dmss for updating a lookup

## Issues related to this change:
closes #341 
