### PR TITLE
feature(validation): optionally validate against provided type

### DIFF
--- a/src/domain_classes/blueprint.py
+++ b/src/domain_classes/blueprint.py
@@ -70,7 +70,7 @@ class Blueprint:
     def get_attribute_type_by_key(self, key):
         return next((attr.attribute_type for attr in self.attributes if attr.name == key), None)
 
-    def get_attribute_by_name(self, key) -> BlueprintAttribute:
+    def get_attribute_by_name(self, key) -> BlueprintAttribute | None:
         return next((attr for attr in self.attributes if attr.name == key), None)
 
     def get_model_contained_by_name(self, key):

--- a/src/features/entity/entity_feature.py
+++ b/src/features/entity/entity_feature.py
@@ -4,6 +4,7 @@ from fastapi.responses import JSONResponse
 from authentication.authentication import auth_w_jwt_or_pat
 from authentication.models import User
 from common.responses import create_response, responses
+from restful.request_types.shared import common_type_constrained_string
 
 from .use_cases.instantiate_entity import BasicEntity, instantiate_entity_use_case
 from .use_cases.validate_entity import validate_entity_use_case
@@ -23,8 +24,12 @@ def instantiate(entity: BasicEntity, user: User = Depends(auth_w_jwt_or_pat)):
 
 @router.post("/validate", operation_id="validate_entity", responses=responses)
 @create_response(JSONResponse)
-def validate(entity: BasicEntity, user: User = Depends(auth_w_jwt_or_pat)):
+def validate(
+    entity: BasicEntity, as_type: common_type_constrained_string | None = None, user: User = Depends(auth_w_jwt_or_pat)
+):
     """Validate an entity.
     Will return detailed error messages and status code 422 if the entity is invalid.
+
+    "as_type": Optional. Validate the root entity against this type instead of the one defined in the entity.
     """
-    return validate_entity_use_case(entity=entity, user=user)
+    return validate_entity_use_case(entity=entity, as_type=as_type, user=user)

--- a/src/tests/unit/test_validate_entity.py
+++ b/src/tests/unit/test_validate_entity.py
@@ -245,3 +245,35 @@ class ValidateEntityTestCase(unittest.TestCase):
             validate_entity(test_entity, blueprint, self.get_blueprint)
         assert error.exception.message == "Attribute 'floatValues' should be type 'float'. Got 'str'"
         assert error.exception.debug == "Location: Entity in key '^.floatValues.1'"
+
+    def test_validate_against_base_type_not_inherited(self):
+        test_entity = {
+            "type": "something else that should not matter...",
+            "name": "MyBlueprint",
+            "description": "A descsription",
+            "attributes": [
+                {"attributeType": "string", "type": "dmss://system/SIMOS/BlueprintAttribute", "name": "name"},
+            ],
+            "anExtraParameter": {"whatEver": 123, "bla": "bla", "not validated": [[[]]]},
+        }
+
+        # Validate against the master blueprint
+        blueprint = self.get_blueprint("dmss://system/SIMOS/Blueprint")
+        validate_entity(test_entity, blueprint, self.get_blueprint, allow_extra=True)
+
+    def test_validate_against_base_type_not_inherited_invalid(self):
+        test_entity = {
+            "type": "something else that should not matter...",
+            "name": "MyBlueprint",
+            "description": "A descsription",
+            "attributes": [
+                {"attributeType": 132, "type": "dmss://system/SIMOS/BlueprintAttribute", "name": "name"},
+            ],
+            "anExtraParameter": {"whatEver": 123, "bla": "bla", "not validated": [[[]]]},
+        }
+        with self.assertRaises(ValidationException) as error:
+            # Validate against the master blueprint
+            blueprint = self.get_blueprint("dmss://system/SIMOS/Blueprint")
+            validate_entity(test_entity, blueprint, self.get_blueprint, allow_extra=True)
+        assert error.exception.message == "Attribute 'attributeType' should be type 'str'. Got 'int'"
+        assert error.exception.debug == "Location: Entity in key '^.attributes.0.attributeType'"


### PR DESCRIPTION
## What does this pull request change?
- Allow to pass "as_type" to validation endpoint and validate the entity against this type (instead of type in entity)
- Using the "as_type" argument, also implicitly enables "allow_extra". 
  - Causing the validation to allow for extra attributes. 
  - Skip "valid child type" check
 
## Why is this pull request needed?
Be able to validate an entity against a "minimum valid blueprint" (required by UI Plugin)

## Issues related to this change:
closes #351 