### PR TITLE
refactor: rename yaml-view to yaml

### DIFF
--- a/src/common/utils/get_storage_recipe.py
+++ b/src/common/utils/get_storage_recipe.py
@@ -9,7 +9,7 @@ default_yaml_view = Recipe(
     **{
         "name": "Yaml",
         "type": SIMOS.UI_RECIPE.value,
-        "plugin": "yaml-view",
+        "plugin": "yaml",
         "category": "view",
     }
 )

--- a/src/home/system/SIMOS/recipe_links/blueprint.json
+++ b/src/home/system/SIMOS/recipe_links/blueprint.json
@@ -5,7 +5,7 @@
     {
       "name": "Yaml",
       "type": "dmss://system/SIMOS/UiRecipe",
-      "plugin": "yaml-view"
+      "plugin": "yaml"
     },
     {
       "type": "dmss://system/SIMOS/UiRecipe",

--- a/src/home/system/SIMOS/recipe_links/default.json
+++ b/src/home/system/SIMOS/recipe_links/default.json
@@ -5,7 +5,7 @@
     {
       "name": "Yaml",
       "type": "dmss://system/SIMOS/UiRecipe",
-      "plugin": "yaml-view",
+      "plugin": "yaml",
       "roles": [
         "dmss-admin"
       ],

--- a/src/tests/bdd/get_blueprints.feature
+++ b/src/tests/bdd/get_blueprints.feature
@@ -106,7 +106,7 @@ Feature: Get a blueprint
         {
           "name": "Yaml",
           "type": "dmss://system/SIMOS/UiRecipe",
-          "plugin": "yaml-view",
+          "plugin": "yaml",
           "roles": [
             "dmss-admin"
           ],
@@ -163,7 +163,7 @@ Feature: Get a blueprint
       {
         "name": "Yaml",
         "type": "dmss://system/SIMOS/UiRecipe",
-        "plugin": "yaml-view",
+        "plugin": "yaml",
         "category": "view"
       }
     ],


### PR DESCRIPTION
## What does this pull request change?
rename yaml-view to yaml
## Why is this pull request needed?
needed due to plugin rename, see https://github.com/equinor/dm-core-packages/pull/107/files
## Issues related to this change:
part of https://github.com/equinor/dm-core-packages/issues/96
