### PR TITLE
fix: include protocol in path returned from resolve blueprint use case

### DIFF
--- a/src/features/blueprint/use_cases/resolve_blueprint_use_case.py
+++ b/src/features/blueprint/use_cases/resolve_blueprint_use_case.py
@@ -20,6 +20,7 @@ def find_package_with_document(data_source: str, document_id: str, user) -> dict
 def resolve_blueprint_use_case(user: User, absolute_id: str):
     data_source_id, document_id, attr = split_dmss_ref(absolute_id)
     path_elements = []
+    protocol_prefix = "dmss://"
     package = find_package_with_document(data_source_id, document_id, user)
     root_package_found = package["isRoot"]
     blueprint_name = next((c["name"] for c in package["content"] if c["_id"] == document_id))
@@ -32,4 +33,4 @@ def resolve_blueprint_use_case(user: User, absolute_id: str):
         root_package_found = package["isRoot"]
         next_document_id = package["_id"]
     path_elements.reverse()
-    return data_source_id + "/" + "/".join(path_elements)
+    return protocol_prefix + data_source_id + "/" + "/".join(path_elements)

--- a/src/tests/bdd/blueprint/resolve_path_to_document.feature
+++ b/src/tests/bdd/blueprint/resolve_path_to_document.feature
@@ -24,7 +24,7 @@ Feature: Blueprint - Resolve path to document use case
       Then the response status should be "OK"
       And the response should be
       """
-      data-source-name/blueprints/sub_package_1/document_1
+      dmss://data-source-name/blueprints/sub_package_1/document_1
       """
 
     Scenario: resolve path to document fails when document with id does not exist


### PR DESCRIPTION
## What does this pull request change?
include protocol in path returned
## Why is this pull request needed?

## Issues related to this change:
https://github.com/equinor/dm-core-packages/issues/106