### PR TITLE
refactor: update document uses id_reference in path

### DIFF
--- a/src/common/responses.py
+++ b/src/common/responses.py
@@ -1,4 +1,5 @@
 import functools
+import logging
 import traceback
 from inspect import iscoroutinefunction
 from typing import Callable, Type, TypeVar
@@ -76,6 +77,8 @@ def create_response(
                 logger.error(e)
                 return JSONResponse(e.dict(), status_code=status.HTTP_422_UNPROCESSABLE_ENTITY)
             except NotFoundException as e:
+                if logger.level == logging.DEBUG:
+                    traceback.print_exc()
                 logger.error(e)
                 return JSONResponse(e.dict(), status_code=status.HTTP_404_NOT_FOUND)
             except BadRequestException as e:

--- a/src/features/document/document_feature.py
+++ b/src/features/document/document_feature.py
@@ -57,13 +57,11 @@ def get_by_path(
     return get_document_by_path_use_case(user=user, absolute_path=absolute_path)
 
 
-@router.put("/{data_source_id}/{document_id}", operation_id="document_update", responses=responses)
+@router.put("/{id_reference:path}", operation_id="document_update", responses=responses)
 @create_response(JSONResponse)
 def update(
-    data_source_id: str,
-    document_id: str,
+    id_reference: str,
     data: Json = Form(...),
-    attribute: Optional[str] = Form(None),
     files: Optional[List[UploadFile]] = File(None),
     update_uncontained: Optional[bool] = False,
     user: User = Depends(auth_w_jwt_or_pat),
@@ -71,10 +69,8 @@ def update(
     """Update document"""
     return update_document_use_case(
         user=user,
-        document_id=document_id,
-        data_source_id=data_source_id,
+        id_reference=id_reference,
         data=data,
-        attribute=attribute,
         files=files,
         update_uncontained=update_uncontained,
     )

--- a/src/features/document/document_feature.py
+++ b/src/features/document/document_feature.py
@@ -66,7 +66,9 @@ def update(
     update_uncontained: Optional[bool] = False,
     user: User = Depends(auth_w_jwt_or_pat),
 ):
-    """Update document"""
+    """Update document
+        - **id_reference**: <data_source>/<document_uuid> (can also include an optional .<attribute> after <document_uuid>)
+     """
     return update_document_use_case(
         user=user,
         id_reference=id_reference,

--- a/src/services/document_service.py
+++ b/src/services/document_service.py
@@ -24,7 +24,7 @@ from common.utils.get_resolved_document_by_id import get_complete_sys_document
 from common.utils.get_storage_recipe import storage_recipe_provider
 from common.utils.logging import logger
 from common.utils.sort_entities_by_attribute import sort_dtos_by_attribute
-from common.utils.string_helpers import split_dmss_ref, split_dotted_id
+from common.utils.string_helpers import split_dmss_ref
 from common.utils.validators import entity_has_all_required_attributes
 from config import config, default_user
 from domain_classes.blueprint import Blueprint
@@ -265,12 +265,12 @@ class DocumentService:
     def update_document(
         self,
         data_source_id: str,
-        dotted_id: str,
+        document_id: str,
         data: Union[dict, list],
+        attribute: str | None = None,
         files: dict = None,
         update_uncontained: bool = True,
     ):
-        document_id, attribute = split_dotted_id(dotted_id)
         # TODO: Since we are only fetching 1 lvl here, any updates on nested uncontained attributes by dott reference
         # TODO: will fail, as they are not a node on the root node. For example; '123-456.contAttr.someUncontainedAttr'
         # TODO: We should update 'node.get_by_path()' do fetch documents as needed
@@ -282,7 +282,7 @@ class DocumentService:
             target_node = root.get_by_path(attribute.split("."))
 
         if not target_node:
-            raise NotFoundException(dotted_id)
+            raise NotFoundException(f"{data_source_id}/{document_id}.{attribute}")
 
         target_node.update(data)
         if files:

--- a/src/tests/unit/test_complex_arrays.py
+++ b/src/tests/unit/test_complex_arrays.py
@@ -263,7 +263,7 @@ class ArraysDocumentServiceTestCase(unittest.TestCase):
         # fmt: off
         document_service.update_document(
             data_source_id="testing",
-            dotted_id="1",
+            document_id="1",
             data={
                 "_id": "1",
                 "name": "complexArraysEntity",

--- a/src/tests/unit/test_save.py
+++ b/src/tests/unit/test_save.py
@@ -256,7 +256,7 @@ class DocumentServiceTestCase(unittest.TestCase):
         document_service.update_document(
             "test",
             "1",
-            {
+            data={
                 "_id": "1",
                 "name": "Root",
                 "description": "I'm the root document",
@@ -325,7 +325,7 @@ class DocumentServiceTestCase(unittest.TestCase):
             "nested": {},
             "references": [],
         }
-        document_service.update_document("testing", "1.a", new_data, update_uncontained=True)
+        document_service.update_document("testing", "1", new_data, attribute="a", update_uncontained=True)
 
         assert doc_storage["1"]["a"]["description"] == "SOME DESCRIPTION"
         assert doc_storage["1"]["a"]["reference"]["description"] == "A NEW DESCRIPTION HERE"

--- a/src/tests/unit/test_tree_node_update.py
+++ b/src/tests/unit/test_tree_node_update.py
@@ -239,7 +239,8 @@ class DocumentServiceTestCase(unittest.TestCase):
         with self.assertRaises(BadRequestException):
             document_service.update_document(
                 data_source_id="testing",
-                dotted_id="1.SomeChild",
+                document_id="1",
+                attribute="SomeChild",
                 data={"name": "whatever", "type": "special_child_no_inherit", "AnExtraValue": "Hallo there!"},
             )
         assert not doc_storage["1"]["SomeChild"]
@@ -352,7 +353,8 @@ class DocumentServiceTestCase(unittest.TestCase):
         )
         document_service.update_document(
             data_source_id="testing",
-            dotted_id="1.SomeChild",
+            document_id="1",
+            attribute="SomeChild",
             data={"name": "whatever", "type": "special_child", "AnExtraValue": "Hallo there!", "AValue": 13},
         )
         assert doc_storage["1"]["SomeChild"] == {
@@ -380,7 +382,8 @@ class DocumentServiceTestCase(unittest.TestCase):
         )
         document_service.update_document(
             data_source_id="testing",
-            dotted_id="1.SomeChild",
+            document_id="1",
+            attribute="SomeChild",
             data={
                 "name": "whatever",
                 "type": "extra_special_child",
@@ -417,7 +420,8 @@ class DocumentServiceTestCase(unittest.TestCase):
         )
         document_service.update_document(
             data_source_id="testing",
-            dotted_id="1.SomeChild",
+            document_id="1",
+            attribute="SomeChild",
             data=[
                 {"name": "whatever", "type": "special_child", "AnExtraValue": "Hallo there!", "AValue": 13},
                 {
@@ -462,7 +466,8 @@ class DocumentServiceTestCase(unittest.TestCase):
         with self.assertRaises(BadRequestException) as error:
             document_service.update_document(
                 data_source_id="testing",
-                dotted_id="1.SomeChild",
+                document_id="1",
+                attribute="SomeChild",
                 data=[
                     {"name": "whatever", "type": "special_child", "AnExtraValue": "Hallo there!", "AValue": 13},
                     {
@@ -496,7 +501,7 @@ class DocumentServiceTestCase(unittest.TestCase):
 
         document_service.update_document(
             data_source_id="testing",
-            dotted_id="1",
+            document_id="1",
             data={
                 "_id": "1",
                 "name": "parent",


### PR DESCRIPTION
## What does this pull request change?
- Refactor the "/document/" PUT (update) endpoint to be consistent with GET. That is moving "attribute" from a form param to be a part of the reference path parameter.

- Also; small change to make "NotFound" exceptions print stack in debug mode

## Why is this pull request needed?
- Endpoints should have one consistent way to reference documents

## Issues related to this change:
closes #373 
