### PR TITLE
refactor: standardize document 'by-path' endpoints parameters

### DIFF
--- a/src/common/responses.py
+++ b/src/common/responses.py
@@ -77,7 +77,7 @@ def create_response(
                 logger.error(e)
                 return JSONResponse(e.dict(), status_code=status.HTTP_422_UNPROCESSABLE_ENTITY)
             except NotFoundException as e:
-                if logger.level == logging.DEBUG:
+                if logger.level <= logging.DEBUG:
                     traceback.print_exc()
                 logger.error(e)
                 return JSONResponse(e.dict(), status_code=status.HTTP_404_NOT_FOUND)

--- a/src/features/document/document_feature.py
+++ b/src/features/document/document_feature.py
@@ -67,8 +67,8 @@ def update(
     user: User = Depends(auth_w_jwt_or_pat),
 ):
     """Update document
-        - **id_reference**: <data_source>/<document_uuid> (can also include an optional .<attribute> after <document_uuid>)
-     """
+    - **id_reference**: <data_source>/<document_uuid> (can also include an optional .<attribute> after <document_uuid>)
+    """
     return update_document_use_case(
         user=user,
         id_reference=id_reference,
@@ -78,23 +78,20 @@ def update(
     )
 
 
-@router.delete(
-    "/{data_source_id}/{dotted_id}", operation_id="document_remove", response_model=str, responses=responses
-)
+@router.delete("/{id_reference:path}", operation_id="document_remove", response_model=str, responses=responses)
 @create_response(PlainTextResponse)
-def remove(data_source_id: str, dotted_id: str, user: User = Depends(auth_w_jwt_or_pat)):
+def remove(id_reference: str, user: User = Depends(auth_w_jwt_or_pat)):
     """Remove document
+    - **id_reference**: <data_source>/<document_uuid>.<attribute_path>
 
-    - **dotted_id**: can have value <document_id> or <document_id>.<attribute_path>
-
-    Example: dotted_id=3978d9ca-2d7a-4b47-8fed-57710f6cf50b.attributes.1 will remove the first element
-    in the attribute list of a blueprint with the given id.
+    Example: id_reference=SomeDataSource/3978d9ca-2d7a-4b47-8fed-57710f6cf50b.attributes.1 will remove the first element
+    in the attribute list of a blueprint with the given id in data source 'SomeDataSource'.
     """
-    return remove_use_case(user=user, data_source_id=data_source_id, document_id=dotted_id)
+    return remove_use_case(user=user, id_reference=id_reference)
 
 
 @router.post(
-    "/{path_reference:path}/add-to-path", operation_id="document_add_to_path", response_model=dict, responses=responses
+    "-by-path/{path_reference:path}", operation_id="document_add_to_path", response_model=dict, responses=responses
 )
 @create_response(JSONResponse)
 def add_to_path(
@@ -150,13 +147,11 @@ def add_by_parent_id(
     )
 
 
-@router.delete(
-    "/{data_source_id}/remove-by-path/{directory:path}", operation_id="document_remove_by_path", responses=responses
-)
+@router.delete("-by-path/{path_reference:path}", operation_id="document_remove_by_path", responses=responses)
 @create_response(PlainTextResponse)
-def remove_by_path(data_source_id: str, directory: str, user: User = Depends(auth_w_jwt_or_pat)):
+def remove_by_path(path_reference: str, user: User = Depends(auth_w_jwt_or_pat)):
     """Remove a document from DMSS.
 
-    - **directory**: path to document to remove.
+    - **path_reference**: <data_source>/<path>.<attribute>
     """
-    return remove_by_path_use_case(user=user, data_source_id=data_source_id, directory=directory)
+    return remove_by_path_use_case(user=user, absolute_path=path_reference)

--- a/src/features/document/use_cases/remove_by_path_use_case.py
+++ b/src/features/document/use_cases/remove_by_path_use_case.py
@@ -1,14 +1,12 @@
-from typing import Optional
-
 from authentication.models import User
+from common.utils.string_helpers import split_dmss_ref
 from services.document_service import DocumentService
 from storage.internal.data_source_repository import get_data_source
 
 
-def remove_by_path_use_case(
-    user: User, directory: str, data_source_id: Optional[str] = None, repository_provider=get_data_source
-):
+def remove_by_path_use_case(user: User, absolute_path: str, repository_provider=get_data_source):
     document_service = DocumentService(repository_provider=repository_provider, user=user)
+    data_source_id, directory, attribute = split_dmss_ref(absolute_path)
     document_service.remove_by_path(data_source_id, directory)
     document_service.invalidate_cache()
     return "OK"

--- a/src/features/document/use_cases/remove_use_case.py
+++ b/src/features/document/use_cases/remove_use_case.py
@@ -1,10 +1,12 @@
 from authentication.models import User
+from common.utils.string_helpers import split_dmss_ref
 from services.document_service import DocumentService
 from storage.internal.data_source_repository import get_data_source
 
 
-def remove_use_case(user: User, data_source_id: str, document_id: str, repository_provider=get_data_source):
+def remove_use_case(user: User, id_reference: str, repository_provider=get_data_source):
     document_service = DocumentService(repository_provider=repository_provider, user=user)
-    document_service.remove_document(data_source_id, document_id)
+    data_source_id, document_id, attribute = split_dmss_ref(id_reference)
+    document_service.remove_document(data_source_id, document_id, attribute)
     document_service.invalidate_cache()
     return "OK"

--- a/src/services/document_service.py
+++ b/src/services/document_service.py
@@ -211,16 +211,16 @@ class DocumentService:
         document_id = get_document_uid_by_path(path, document_repository)
         return self.get_node_by_uid(data_source_id, document_id)
 
-    def remove_document(self, data_source_id: str, document_id: str):
+    def remove_document(self, data_source_id: str, document_id: str, attribute: str = None):
         """
         Delete a document, and any model contained children.
         If document_id is a dotted attribute path, it will remove the reference in the parent.
         Does not use the Node class, as blueprints won't necessarily be available when deleting.
         """
         repository = self.repository_provider(data_source_id, self.user)
-        if "." in document_id:
-            root_document: dict = repository.get(document_id.split(".")[0])
-            path_after_root = document_id.split(".")[1:]
+        if attribute:
+            root_document: dict = repository.get(document_id)
+            path_after_root = attribute.split(".")
             nested_doc = root_document
             for index, attr in enumerate(path_after_root):
                 if index + 1 == len(path_after_root):
@@ -382,7 +382,11 @@ class DocumentService:
 
         return {"uid": new_node.node_id}
 
-    def remove_by_path(self, data_source_id: str, directory: str):
+    def remove_by_path(self, data_source_id: str, directory: str, attribute: str = None):
+        if attribute:
+            raise ApplicationException(
+                "Removing a document by path in combination with attribute is not yet supported"
+            )
         directory = directory.rstrip("/").lstrip("/")
         data_source = self.repository_provider(data_source_id, self.user)
 

--- a/src/tests/bdd/document/add_file.feature
+++ b/src/tests/bdd/document/add_file.feature
@@ -448,7 +448,7 @@ Feature: Explorer - Add file
     """
 
   Scenario: Add file with duplicate name
-    Given i access the resource url "/api/documents/test-DS/root_package/add-to-path"
+    Given i access the resource url "/api/documents-by-path/test-DS/root_package"
     When i make a "POST" request with "1" files
     """
       {
@@ -485,8 +485,8 @@ Feature: Explorer - Add file
     """
     Then the response status should be "OK"
 
-  Scenario: Add Parent entity without a name attribute with add-to-path endpoint
-    Given i access the resource url "/api/documents/test-DS/root_package/add-to-path?update_uncontained=True"
+  Scenario: Add Parent entity without a name attribute with -by-path endpoint
+    Given i access the resource url "/api/documents-by-path/test-DS/root_package?update_uncontained=True"
     When i make a "POST" request with "1" files
     """
     {
@@ -509,7 +509,7 @@ Feature: Explorer - Add file
     """
 
   Scenario: Adding file with id set to empty string should generate new uid
-    Given I access the resource url "/api/documents/test-DS/root_package/add-to-path"
+    Given I access the resource url "/api/documents-by-path/test-DS/root_package"
     When i make a "POST" request with "1" files
     """
     {
@@ -525,7 +525,7 @@ Feature: Explorer - Add file
     And the response should have valid uid
 
   Scenario: Adding file with id
-    Given I access the resource url "/api/documents/test-DS/root_package/add-to-path"
+    Given I access the resource url "/api/documents-by-path/test-DS/root_package"
     When i make a "POST" request with "1" files
     """
     {
@@ -540,8 +540,8 @@ Feature: Explorer - Add file
     Then the response status should be "OK"
     And the response should have valid uid
 
-  Scenario: Add Comment entity without a name attribute with add-to-path endpoint
-    Given i access the resource url "/api/documents/test-DS/root_package/add-to-path?update_uncontained=True"
+  Scenario: Add Comment entity without a name attribute with -by-path endpoint
+    Given i access the resource url "/api/documents-by-path/test-DS/root_package?update_uncontained=True"
     When i make a "POST" request with "1" files
     """
     {
@@ -555,8 +555,8 @@ Feature: Explorer - Add file
     """
     Then the response status should be "OK"
 
-  Scenario: Add blueprint without a name attribute with add-to-path endpoint should fail
-    Given i access the resource url "/api/documents/test-DS/root_package/add-to-path?update_uncontained=True"
+  Scenario: Add blueprint without a name attribute with -by-path endpoint should fail
+    Given i access the resource url "/api/documents-by-path/test-DS/root_package?update_uncontained=True"
     When i make a "POST" request with "1" files
     """
     {
@@ -579,8 +579,8 @@ Feature: Explorer - Add file
     }
     """
 
-  Scenario: Add package without a name attribute with add-to-path endpoint should fail
-    Given i access the resource url "/api/documents/test-DS/root_package/add-to-path?update_uncontained=True"
+  Scenario: Add package without a name attribute with -by-path endpoint should fail
+    Given i access the resource url "/api/documents-by-path/test-DS/root_package?update_uncontained=True"
     When i make a "POST" request with "1" files
     """
     {
@@ -679,7 +679,7 @@ Feature: Explorer - Add file
     """
 
   Scenario: Add file with multiple PDFs
-    Given i access the resource url "/api/documents/test-DS/root_package/add-to-path?update_uncontained=True"
+    Given i access the resource url "/api/documents-by-path/test-DS/root_package?update_uncontained=True"
     When i make a "POST" request with "4" files
     """
     {

--- a/src/tests/bdd/document/add_to_path.feature
+++ b/src/tests/bdd/document/add_to_path.feature
@@ -209,7 +209,7 @@ Feature: Add document with document_service
 
 
   Scenario: Add test
-    Given i access the resource url "/api/documents/data-source-name/root_package/EntityPackage/add-to-path"
+    Given i access the resource url "/api/documents-by-path/data-source-name/root_package/EntityPackage"
     When i make a "POST" request with "1" files
     """
     {
@@ -245,7 +245,7 @@ Feature: Add document with document_service
     """
 
   Scenario: Add root package
-    Given i access the resource url "/api/documents/data-source-name/add-to-path"
+    Given i access the resource url "/api/documents-by-path/data-source-name"
     When i make a form-data "POST" request
     """
     {

--- a/src/tests/bdd/document/remove_by_path.feature
+++ b/src/tests/bdd/document/remove_by_path.feature
@@ -14,7 +14,7 @@ Feature: Explorer - Remove by path
       | 3   | 2          | document_1    |             | dmss://system/SIMOS/Blueprint |
 
   Scenario: Remove root package
-    Given i access the resource url "/api/documents/data-source-name/remove-by-path/blueprints"
+    Given i access the resource url "/api/documents-by-path/data-source-name/blueprints"
     When i make a "DELETE" request
     Then the response status should be "OK"
     Given I access the resource url "/api/documents/data-source-name/1"
@@ -58,7 +58,7 @@ Feature: Explorer - Remove by path
   """
 
   Scenario: Remove subpackage with child
-    Given i access the resource url "/api/documents/data-source-name/remove-by-path/blueprints/sub_package_1"
+    Given i access the resource url "/api/documents-by-path/data-source-name/blueprints/sub_package_1"
     When i make a "DELETE" request
     Then the response status should be "OK"
     Given I access the resource url "/api/documents/data-source-name/1"
@@ -81,7 +81,7 @@ Feature: Explorer - Remove by path
     """
 
   Scenario: Remove file with no children
-    Given i access the resource url "/api/documents/data-source-name/remove-by-path/blueprints"
+    Given i access the resource url "/api/documents-by-path/data-source-name/blueprints"
     When i make a "DELETE" request
     Then the response status should be "OK"
     Given I access the resource url "/api/documents/data-source-name/3"
@@ -99,7 +99,7 @@ Feature: Explorer - Remove by path
     """
 
   Scenario: Remove file with children
-    Given i access the resource url "/api/documents/data-source-name/remove-by-path/blueprints/sub_package_1"
+    Given i access the resource url "/api/documents-by-path/data-source-name/blueprints/sub_package_1"
     When i make a "DELETE" request
     Then the response status should be "OK"
     Given I access the resource url "/api/documents/data-source-name/2"

--- a/src/tests/bdd/steps/schemas.py
+++ b/src/tests/bdd/steps/schemas.py
@@ -47,9 +47,10 @@ def step_impl(context):
     DataSourceRepository(context.user).create(document["name"], DataSourceRequest(**document))
 
     # Import SIMOS package
+    logger_level_before = logger.level
     logger.setLevel("ERROR")
     import_package(f"{config.APPLICATION_HOME}/system/SIMOS", context.user, is_root=True, data_source_name="system")
-    logger.setLevel("INFO")
+    logger.setLevel(logger_level_before)
 
     user = User(user_id=config.DMSS_ADMIN)
     create_lookup_table_use_case("system/SIMOS/recipe_links", "DMSS", user)

--- a/src/tests/unit/test_remove.py
+++ b/src/tests/unit/test_remove.py
@@ -91,7 +91,7 @@ class DocumentServiceTestCase(unittest.TestCase):
         repository.get = lambda doc_id: doc_storage[doc_id]
         repository.delete = lambda doc_id: doc_storage.pop(doc_id)
         document_service = get_mock_document_service(lambda id, user: repository)
-        document_service.remove_document(data_source_id="testing", document_id="1.nested")
+        document_service.remove_document(data_source_id="testing", document_id="1", attribute="nested")
         assert doc_storage["1"].get("nested") is None
 
     def test_remove_second_level_nested(self):
@@ -214,7 +214,7 @@ class DocumentServiceTestCase(unittest.TestCase):
                 return repository
 
         document_service = get_mock_document_service(repository_provider)
-        document_service.remove_document(data_source_id="testing", document_id="1.reference")
+        document_service.remove_document(data_source_id="testing", document_id="1", attribute="reference")
         assert doc_storage["1"] == {
             "_id": "1",
             "name": "Parent",
@@ -250,7 +250,7 @@ class DocumentServiceTestCase(unittest.TestCase):
         repository.get = mock_get
         repository.delete = lambda doc_id: doc_storage.pop(doc_id)
         document_service = get_mock_document_service(repository_provider)
-        document_service.remove_document("testing", "1.im_optional")
+        document_service.remove_document("testing", "1", "im_optional")
         assert {
             "_id": "1",
             "name": "Parent",


### PR DESCRIPTION
## What does this pull request change?
- Standardize how parameters to "/document" and "/document-by-path/" endpoints should look like

## Why is this pull request needed?
- Easier to maintain and use endpoints if they all behave in a more similar fashion

## Issues related to this change:
related to #381 