### PR TITLE
refactor: more useful exception and errors messages

### DIFF
--- a/src/common/utils/get_document_by_path.py
+++ b/src/common/utils/get_document_by_path.py
@@ -54,15 +54,12 @@ def _get_document_uid_by_path(package: dict, path_elements: List[str], data_sour
 def get_document_uid_by_path(dotted_path: str, repository: Repository) -> Union[str, None]:
     path_elements = dotted_path.split("/")
     root_package_name = path_elements.pop(0)
-    try:
-        root_package = get_root_package(root_package_name, repository)
-        # Check if it's a root-package
-        if not path_elements:
-            return root_package["_id"]
-        uid = _get_document_uid_by_path(root_package, path_elements, repository)
-        return uid
-    except NotFoundException:
-        return None
+    root_package = get_root_package(root_package_name, repository)
+    # Check if it's a root-package
+    if not path_elements:
+        return root_package["_id"]
+    uid = _get_document_uid_by_path(root_package, path_elements, repository)
+    return uid
 
 
 def get_document_by_absolute_path(absolute_path: str, user: User) -> dict:
@@ -79,9 +76,14 @@ def get_document_by_absolute_path(absolute_path: str, user: User) -> dict:
             if not path:
                 raise BadRequestException(f"The path '{absolute_path}' is an invalid document reference.")
             document_repository = get_data_source(data_source_id, user)
-            type_id = get_document_uid_by_path(path, document_repository)
-            if not type_id:
-                raise NotFoundException(message=f"Entity referenced with '{address}' could not be found")
+            try:
+                type_id = get_document_uid_by_path(path, document_repository)
+            except NotFoundException as error:
+                raise NotFoundException(
+                    message=f"Entity referenced with '{absolute_path}' could not be found",
+                    debug=error.message,
+                    data=error.dict(),
+                )
             return document_repository.get(uid=type_id)
         case "http":  # The entity should be fetched by an HTTP call
             raise NotImplementedError

--- a/src/services/document_service.py
+++ b/src/services/document_service.py
@@ -446,11 +446,16 @@ class DocumentService:
             if not document.type == SIMOS.PACKAGE.value or not document_dict.get("isRoot", False):
                 raise BadRequestException("Only root packages may be added to the root of a data source")
             # TODO: Validate package entity
-            if get_document_uid_by_path(document_dict["name"], self.repository_provider(data_source_id, self.user)):
-                raise ValidationException(
-                    message=f"A root package named '{document_dict['name']}' already exists",
-                    data={"dataSource": data_source_id, "document": document_dict},
-                )
+            try:
+                if get_document_uid_by_path(
+                    document_dict["name"], self.repository_provider(data_source_id, self.user)
+                ):
+                    raise ValidationException(
+                        message=f"A root package named '{document_dict['name']}' already exists",
+                        data={"dataSource": data_source_id, "document": document_dict},
+                    )
+            except NotFoundException:
+                pass
             document_repository = self.repository_provider(data_source_id, self.user)
             document_repository.update(document_dict)
             return {"uid": document_dict["_id"]}


### PR DESCRIPTION
## What does this pull request change?
- To be able to return more useful error messages, we should not return "None" from "get_document_uid_by_path"

## Why is this pull request needed?
- More precise and accurate error messages

## Issues related to this change:
none