### PR TITLE
feature: added dimensions on ui recipes

### DIFF
--- a/src/domain_classes/ui_recipe.py
+++ b/src/domain_classes/ui_recipe.py
@@ -38,6 +38,7 @@ class Recipe(BaseModel):
     roles: List[str] | None = None
     config: dict | None = None
     label: str = ""
+    dimensions: str = ""
 
     def get_attribute_by_name(self, key):
         return next((attr for attr in self.attributes if attr.name == key), None)

--- a/src/home/system/SIMOS/UiRecipe.json
+++ b/src/home/system/SIMOS/UiRecipe.json
@@ -31,6 +31,13 @@
       "attributeType": "object",
       "contained": true,
       "optional": true
+    },
+        {
+      "name": "dimensions",
+      "attributeType": "string",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "optional": true,
+      "default": ""
     }
   ]
 }


### PR DESCRIPTION
## What does this pull request change?
- Add a "dimensions" attribute to uiRecipes

## Why is this pull request needed?
- Need a way to know which recipes support different dimensions

## Issues related to this change:
needed for "generic list plugin"