### PR TITLE
Feat: add and use reference blueprints

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -23,6 +23,9 @@ services:
       AUTH_PROVIDER_FOR_ROLE_CHECK:
     ports:
       - "5000:5000"
+    depends_on:
+      - db
+      - db-ui
 
   db:
     image: mongo:3.4

--- a/src/common/utils/delete_documents.py
+++ b/src/common/utils/delete_documents.py
@@ -15,8 +15,8 @@ def delete_list_recursive(value: Union[list, dict], data_source: DataSource):
 
 
 def delete_dict_recursive(in_dict: dict, data_source: DataSource):
-    if in_dict.get("_id") and in_dict.get("contained") is True:  # It's a model contained reference
-        delete_document(data_source, in_dict["_id"])
+    if in_dict.get("ref") and in_dict.get("type") == SIMOS.STORAGE_ADDRESS.value:  # It's a model contained reference
+        delete_document(data_source, in_dict["ref"])
     elif in_dict.get("type") == SIMOS.BLOB.value:
         data_source.delete_blob(in_dict["_blob_id"])
     else:

--- a/src/common/utils/get_document_by_path.py
+++ b/src/common/utils/get_document_by_path.py
@@ -34,18 +34,18 @@ def _get_document_uid_by_path(package: dict, path_elements: List[str], data_sour
     """
     if len(path_elements) == 1:
         target = path_elements[0]
-        file = next((f for f in package["content"] if f.get("name") == target), None)
+        file = next((f for f in package["content"] if f.get("targetName") == target), None)
         if not file:
             raise NotFoundException(f"The document {target} could not be found in the package {package['name']}")
-        return file["_id"]
+        return file["ref"]
 
-    next_package_ref = next((p for p in package["content"] if p["name"] == path_elements[0]), None)
+    next_package_ref = next((p for p in package["content"] if p["targetName"] == path_elements[0]), None)
     if not next_package_ref:
         raise NotFoundException(f"The package {path_elements[0]} could not be found in the package {package['name']}")
-    next_package: dict = data_source.get(next_package_ref["_id"])
+    next_package: dict = data_source.get(next_package_ref["ref"])
     if not next_package:
         raise NotFoundException(
-            f"Could not find a package '{next_package_ref['_id']}' in datasource {data_source.name}"
+            f"Could not find a package '{next_package_ref['ref']}' in datasource {data_source.name}"
         )
     del path_elements[0]
     return _get_document_uid_by_path(next_package, path_elements, data_source)

--- a/src/common/utils/get_resolved_document_by_id.py
+++ b/src/common/utils/get_resolved_document_by_id.py
@@ -9,8 +9,10 @@ def resolve_reference_list(x: list, document_repository: DataSource, depth: int 
     if isinstance(x[0], list):  # Call recursively for nested lists
         resolved = [resolve_reference_list(item, document_repository) for item in x]
     for value in x:
-        if isinstance(value, dict) and value.get("_id"):  # It's a reference!
-            resolved.append(get_complete_sys_document(value["_id"], document_repository, depth, depth_count))
+        if isinstance(value, dict) and value.get("ref"):  # It's a reference!
+            resolved.append(get_complete_sys_document(value["ref"], document_repository, depth, depth_count))
+        # elif isinstance(value, dict) and value.get("_id"):  # It's a reference!
+        #    resolved.append(get_complete_sys_document(value["_id"], document_repository, depth, depth_count))
         elif isinstance(value, dict):
             resolved.append(resolve_contained_dict(value, document_repository, depth, depth_count))
         else:
@@ -58,8 +60,11 @@ def resolve_complete_document(entity, data_source, depth, depth_count) -> dict:
             if isinstance(value, list):  # If it's a list, resolve any references
                 entity[key] = resolve_reference_list(value, data_source, depth, depth_count)
             else:
-                if ref_id := value.get("_id"):  # It's a reference
-                    entity[key] = get_complete_sys_document(ref_id, data_source, depth_count)
+                if ref := value.get("ref"):  # It's a reference
+                    entity[key] = get_complete_sys_document(ref, data_source, depth_count)
+                # TODO: Remove ref_id
+                # elif ref_id := value.get("_id"):  # It's a reference
+                #    entity[key] = get_complete_sys_document(ref_id, data_source, depth_count)
                 else:
                     entity[key] = resolve_contained_dict(value, data_source, depth, depth_count)
 

--- a/src/common/utils/package_import.py
+++ b/src/common/utils/package_import.py
@@ -26,7 +26,14 @@ def _add_documents(path, documents, data_source) -> List[Dict]:
             )
         document["_id"] = document.get("_id", str(uuid4()))
         data_source.update(document)
-        docs.append({"_id": document["_id"], "name": document.get("name"), "type": document["type"]})
+        docs.append(
+            {
+                "ref": document["_id"],
+                "targetName": document.get("name"),
+                "targetType": document["type"],
+                "type": SIMOS.LINK.value,
+            }
+        )
 
     return docs
 
@@ -61,4 +68,10 @@ def import_package(path, user: User, data_source_name: str, is_root: bool = Fals
 
     data_source.update(package)
     logger.info(f"Imported package {package['name']}")
-    return {"_id": package["_id"], "type": package["type"], "name": package.get("name")}
+    # return {"_id": package["_id"], "type": package["type"], "name": package.get("name")}
+    return {
+        "ref": package["_id"],
+        "targetType": package["type"],
+        "targetName": package.get("name"),
+        "type": SIMOS.LINK.value,
+    }

--- a/src/domain_classes/tree_node.py
+++ b/src/domain_classes/tree_node.py
@@ -139,7 +139,8 @@ class NodeBase:
             node = node.parent
 
     def __repr__(self):
-        return f"Name: '{self.entity.get('name')}', Key: '{self.key}', Type: '{self.type}', Node_ID: '{self.node_id}'"
+        print(self.entity)
+        return f"Name: '{self.name}', Key: '{self.key}', Type: '{self.type}', Node_ID: '{self.node_id}'"
 
     def show_tree(self, level=0):
         print("%s%s" % ("." * level, self))
@@ -273,6 +274,9 @@ class Node(NodeBase):
 
     @property
     def name(self):
+        # if not self.contained:
+        #    return self.entity.get("targetName")
+        # else:
         return self.entity.get("name", self.attribute.name)
 
     # Replace the entire data of the node with the input dict. If it matches the blueprint...

--- a/src/enums.py
+++ b/src/enums.py
@@ -56,6 +56,8 @@ class SIMOS(Enum):
     BLOB = "dmss://system/SIMOS/Blob"
     RECIPE_LINK = "dmss://system/SIMOS/RecipeLink"
     DATASOURCE = "datasource"
+    LINK = "dmss://system/SIMOS/Link"
+    STORAGE_ADDRESS = "dmss://system/SIMOS/StorageAddress"
 
 
 class AuthProviderForRoleCheck(str, Enum):

--- a/src/features/blueprint/use_cases/resolve_blueprint_use_case.py
+++ b/src/features/blueprint/use_cases/resolve_blueprint_use_case.py
@@ -10,7 +10,7 @@ from storage.internal.data_source_repository import get_data_source
 def find_package_with_document(data_source: str, document_id: str, user) -> dict:
     repository = get_data_source(data_source, user)
     packages: List[dict] = repository.find(
-        {"type": SIMOS.PACKAGE.value, "content": {"$elemMatch": {"_id": document_id}}}
+        {"type": SIMOS.PACKAGE.value, "content": {"$elemMatch": {"ref": document_id}}}
     )
     if not packages:
         raise NotFoundException(document_id, "Failed to find package")
@@ -23,7 +23,7 @@ def resolve_blueprint_use_case(user: User, absolute_id: str):
     protocol_prefix = "dmss://"
     package = find_package_with_document(data_source_id, document_id, user)
     root_package_found = package["isRoot"]
-    blueprint_name = next((c["name"] for c in package["content"] if c["_id"] == document_id))
+    blueprint_name = next((c["targetName"] for c in package["content"] if c["ref"] == document_id))
     path_elements.append(blueprint_name)
     path_elements.append(package["name"])
     next_document_id = package["_id"]

--- a/src/home/system/SIMOS/Link.json
+++ b/src/home/system/SIMOS/Link.json
@@ -1,0 +1,24 @@
+{
+  "type": "dmss://system/SIMOS/Blueprint",
+  "description": "Reference to another self-contained entity.",
+  "name": "Link",
+  "attributes": [
+    {
+      "attributeType": "string",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "name": "targetType",
+      "optional": true
+    },
+    {
+      "attributeType": "string",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "name": "targetName",
+      "optional": true
+    },
+    {
+      "attributeType": "string",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "name": "ref"
+    }
+  ]
+}

--- a/src/home/system/SIMOS/StorageAddress.json
+++ b/src/home/system/SIMOS/StorageAddress.json
@@ -1,0 +1,24 @@
+{
+  "type": "dmss://system/SIMOS/Blueprint",
+  "description": "Reference to a contained entity that is stored separately.",
+  "name": "StorageAddress",
+  "attributes": [
+    {
+      "attributeType": "string",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "name": "targetType",
+      "optional": true
+    },
+    {
+      "attributeType": "string",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "name": "targetName",
+      "optional": true
+    },
+    {
+      "attributeType": "string",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "name": "ref"
+    }
+  ]
+}

--- a/src/restful/request_types/shared.py
+++ b/src/restful/request_types/shared.py
@@ -36,10 +36,16 @@ class EntityUUID(BaseModel):
     uid: UUID4 = Field(..., alias="_id")
 
 
-class Reference(EntityType, EntityName, EntityUUID):
+class Reference(BaseModel):
+    # TODO: uid can also be dotted path
+    uid: str = Field(..., alias="ref")
+    type: common_type_constrained_string  # type: ignore
+    targetType: Optional[common_type_constrained_string]  # type: ignore
+    targetName: Optional[common_name_constrained_string]  # type: ignore
+
     @root_validator(pre=True)
     def from_underscore_id_to_uid(cls, values):
-        return {**values, "uid": values.get("_id")}
+        return {**values, "uid": values.get("ref")}
 
 
 class UncontainedEntity(EntityType, OptionalEntityName, EntityUUID, extra=Extra.allow):  # type: ignore

--- a/src/tests/bdd/authentication/set_access_control_list.feature
+++ b/src/tests/bdd/authentication/set_access_control_list.feature
@@ -28,9 +28,10 @@ Feature: Set Access Control List
         "isRoot": true,
         "content": [
             {
-                "_id": "3",
-                "name": "SubPack",
-                "type": "dmss://system/SIMOS/Package"
+                "type": "dmss://system/SIMOS/Link",
+                "ref": "3",
+                "targetName": "SubPack",
+                "targetType": "dmss://system/SIMOS/Package"
             }
         ]
     }
@@ -42,9 +43,10 @@ Feature: Set Access Control List
         "type": "dmss://system/SIMOS/Package",
         "content": [
             {
-                "_id": "4",
-                "name": "SubSubPack",
-                "type": "dmss://system/SIMOS/Package"
+                "type": "dmss://system/SIMOS/Link",
+                "ref": "4",
+                "targetName": "SubSubPack",
+                "targetType": "dmss://system/SIMOS/Package"
             }
         ],
         "isRoot": false

--- a/src/tests/bdd/document/add_contained.feature
+++ b/src/tests/bdd/document/add_contained.feature
@@ -22,9 +22,10 @@ Feature: Explorer - Add contained node
         "isRoot": true,
         "content": [
             {
-                "_id": "2",
-                "name": "RecursiveBlueprint",
-                "type": "dmss://system/SIMOS/Blueprint"
+                "ref": "2",
+                "type": "dmss://system/SIMOS/Link",
+                "targetName": "RecursiveBlueprint",
+                "targetType": "dmss://system/SIMOS/Blueprint"
             }
         ]
     }

--- a/src/tests/bdd/document/add_file.feature
+++ b/src/tests/bdd/document/add_file.feature
@@ -21,39 +21,46 @@ Feature: Explorer - Add file
         "isRoot": true,
         "content": [
             {
-                "_id": "2",
-                "name": "MultiplePdfContainer",
-                "type": "dmss://system/SIMOS/Blueprint"
+                "ref": "2",
+                "type": "dmss://system/SIMOS/Link",
+                "targetName": "MultiplePdfContainer",
+                "targetType": "dmss://system/SIMOS/Blueprint"
             },
             {
-                "_id": "3",
-                "name": "BaseChild",
-                "type": "dmss://system/SIMOS/Blueprint"
+                "ref": "3",
+                "type": "dmss://system/SIMOS/Link",
+                "targetName": "BaseChild",
+                "targetType": "dmss://system/SIMOS/Blueprint"
             },
             {
-                "_id": "4",
-                "name": "Parent",
-                "type": "dmss://system/SIMOS/Blueprint"
+                "ref": "4",
+                "type": "dmss://system/SIMOS/Link",
+                "targetName": "Parent",
+                "targetType": "dmss://system/SIMOS/Blueprint"
             },
             {
-                "_id": "5",
-                "name": "SpecialChild",
-                "type": "dmss://system/SIMOS/Blueprint"
+                "ref": "5",
+                "type": "dmss://system/SIMOS/Link",
+                "targetName": "SpecialChild",
+                "targetType": "dmss://system/SIMOS/Blueprint"
             },
             {
-                "_id": "6",
-                "name": "parentEntity",
-                "type": "dmss://test-DS/root_package/Parent"
+                "ref": "6",
+                "type": "dmss://system/SIMOS/Link",
+                "targetName": "parentEntity",
+                "targetType": "dmss://test-DS/root_package/Parent"
             },
             {
-                "_id": "7",
-                "name": "Hobby",
-                "type": "dmss://system/SIMOS/Blueprint"
+                "ref": "7",
+                "type": "dmss://system/SIMOS/Link",
+                "targetName": "Hobby",
+                "targetType": "dmss://system/SIMOS/Blueprint"
             },
             {
-                "_id": "8",
-                "name": "Comment",
-                "type": "dmss://system/SIMOS/Blueprint"
+                "ref": "8",
+                "type": "dmss://system/SIMOS/Link",
+                "targetName": "Comment",
+                "targetType": "dmss://system/SIMOS/Blueprint"
             }
         ]
     }

--- a/src/tests/bdd/document/add_to_path.feature
+++ b/src/tests/bdd/document/add_to_path.feature
@@ -20,34 +20,40 @@ Feature: Add document with document_service
           "isRoot": true,
           "content": [
               {
-                  "_id": "2",
-                  "name": "Operation",
-                  "type": "dmss://system/SIMOS/Blueprint"
+                  "ref": "2",
+                  "type": "dmss://system/SIMOS/Link",
+                  "targetName": "Operation",
+                  "targetType": "dmss://system/SIMOS/Blueprint"
               },
               {
-                  "_id": "3",
-                  "name": "Phase",
-                  "type": "dmss://system/SIMOS/Blueprint"
+                  "ref": "3",
+                  "type": "dmss://system/SIMOS/Link",
+                  "targetName": "Phase",
+                  "targetType": "dmss://system/SIMOS/Blueprint"
               },
               {
-                  "_id": "6",
-                  "name": "ResponseContainer",
-                  "type": "dmss://system/SIMOS/Blueprint"
+                  "ref": "6",
+                  "type": "dmss://system/SIMOS/Link",
+                  "targetName": "ResponseContainer",
+                  "targetType": "dmss://system/SIMOS/Blueprint"
               },
               {
-                  "_id": "5",
-                  "name": "ResultFile",
-                  "type": "dmss://system/SIMOS/Blueprint"
+                  "ref": "5",
+                  "type": "dmss://system/SIMOS/Link",
+                  "targetName": "ResultFile",
+                  "targetType": "dmss://system/SIMOS/Blueprint"
               },
               {
-                  "_id": "101",
-                  "type": "dmss://system/SIMOS/Package",
-                  "name": "Results"
+                  "ref": "101",
+                  "type": "dmss://system/SIMOS/Link",
+                  "targetName": "Results",
+                  "targetType": "dmss://system/SIMOS/Package"
               },
               {
-                  "_id": "102",
-                  "type": "dmss://system/SIMOS/Package",
-                  "name": "EntityPackage"
+                  "ref": "102",
+                  "type": "dmss://system/SIMOS/Link",
+                  "targetName": "EntityPackage",
+                  "targetType": "dmss://system/SIMOS/Package"
               }
           ]
       }
@@ -62,9 +68,10 @@ Feature: Add document with document_service
           "isRoot": false,
           "content": [
             {
-                  "_id": "99",
-                  "type": "dmss://data-source-name/root_package/Operation",
-                  "name": "result1"
+                  "ref": "99",
+                  "type": "dmss://system/SIMOS/Link",
+                  "targetType": "dmss://data-source-name/root_package/Operation",
+                  "targetName": "result1"
             }
           ]
       }
@@ -80,9 +87,10 @@ Feature: Add document with document_service
           "isRoot": false,
           "content": [
               {
-                  "_id": "11",
-                  "type": "dmss://data-source-name/root_package/Operation",
-                  "name": "operation1"
+                  "ref": "11",
+                  "type": "dmss://system/SIMOS/Link",
+                  "targetType": "dmss://data-source-name/root_package/Operation",
+                  "targetName": "operation1"
               }
           ]
       }
@@ -138,7 +146,7 @@ Feature: Add document with document_service
             {
               "name": "responseContainer",
               "type": "dmss://system/SIMOS/BlueprintAttribute",
-              "attributeType": "data-source-name/root_package/ResponseContainer",
+              "attributeType": "dmss://data-source-name/root_package/ResponseContainer",
               "contained": true,
               "optional": false
             }

--- a/src/tests/bdd/document/get.feature
+++ b/src/tests/bdd/document/get.feature
@@ -133,19 +133,22 @@ Feature: Get document
         "type": "dmss://system/SIMOS/Package",
         "content": [
             {
-                "_id": "3",
-                "name": "TestContainer",
-                "type": "dmss://test-source-name/TestData/TestContainer"
+                "ref": "3",
+                "type": "dmss://system/SIMOS/Link",
+                "targetName": "TestContainer",
+                "targetType": "dmss://test-source-name/TestData/TestContainer"
             },
             {
-                "_id": "2",
-                "name": "ItemType",
-                "type": "dmss://test-source-name/TestData/ItemType"
+                "ref": "2",
+                "type": "dmss://system/SIMOS/Link",
+                "targetName": "ItemType",
+                "targetType": "dmss://test-source-name/TestData/ItemType"
             },
             {
-                "_id": "4",
-                "name": "ItemTypeTwo",
-                "type": "dmss://test-source-name/TestData/ItemTypeTwo"
+                "ref": "4",
+                "type": "dmss://system/SIMOS/Link",
+                "targetName": "ItemTypeTwo",
+                "targetType": "dmss://test-source-name/TestData/ItemTypeTwo"
             }
 
         ],

--- a/src/tests/bdd/document/reference.feature
+++ b/src/tests/bdd/document/reference.feature
@@ -32,9 +32,10 @@ Feature: Add and remove references
     When i make a "PUT" request
     """
     {
-      "name": "some-blueprint",
-      "type": "dmss://system/SIMOS/Blueprint",
-      "_id": "3f9ff99f-9cb5-4afc-947b-a3224eee341f"
+      "type": "dmss://system/SIMOS/Link",
+      "targetName": "some-blueprint",
+      "targetType": "dmss://system/SIMOS/Blueprint",
+      "ref": "3f9ff99f-9cb5-4afc-947b-a3224eee341f"
     }
     """
     Then the response status should be "OK"
@@ -77,24 +78,28 @@ Feature: Add and remove references
       "type": "dmss://system/SIMOS/Package",
       "content": [
         {
-          "name": "Turbine",
-          "type": "dmss://system/SIMOS/Blueprint",
-          "_id": "2"
+          "type": "dmss://system/SIMOS/Link",
+          "targetName": "Turbine",
+          "targetType": "dmss://system/SIMOS/Blueprint",
+          "ref": "2"
         },
         {
-          "name": "Mooring",
-          "type": "dmss://system/SIMOS/Blueprint",
-          "_id": "3"
+          "type": "dmss://system/SIMOS/Link",
+          "targetName": "Mooring",
+          "targetType": "dmss://system/SIMOS/Blueprint",
+          "ref": "3"
         },
         {
-          "name": "myTurbine",
-          "type": "dmss://system/SIMOS/Blueprint",
-          "_id": "4"
+          "type": "dmss://system/SIMOS/Link",
+          "targetName": "myTurbine",
+          "targetType": "dmss://system/SIMOS/Blueprint",
+          "ref": "4"
         },
         {
-          "name": "myMooring",
-          "type": "dmss://system/SIMOS/Blueprint",
-          "_id": "3f9ff99f-9cb5-4afc-947b-a3224eee341f"
+          "type": "dmss://system/SIMOS/Link",
+          "targetName": "myMooring",
+          "targetType": "dmss://system/SIMOS/Blueprint",
+          "ref": "3f9ff99f-9cb5-4afc-947b-a3224eee341f"
         }
       ],
       "isRoot": true
@@ -160,9 +165,10 @@ Feature: Add and remove references
     When i make a "PUT" request
     """
     {
-      "name": "myMooring",
-      "type": "dmss://test-DS/TestData/Mooring",
-      "_id": "3f9ff99f-9cb5-4afc-947b-a3224eee341f"
+      "type": "dmss://system/SIMOS/Link",
+      "targetName": "myMooring",
+      "targetType": "dmss://test-DS/TestData/Mooring",
+      "ref": "3f9ff99f-9cb5-4afc-947b-a3224eee341f"
     }
     """
     Then the response status should be "OK"

--- a/src/tests/bdd/document/update.feature
+++ b/src/tests/bdd/document/update.feature
@@ -135,19 +135,22 @@ Feature: Document 2
         "type": "dmss://system/SIMOS/Package",
         "content": [
             {
-                "_id": "3",
-                "name": "TestContainer",
-                "type": "dmss://test-source-name/TestData/TestContainer"
+                "ref": "3",
+                "type": "dmss://system/SIMOS/Link",
+                "targetName": "TestContainer",
+                "targetType": "dmss://test-source-name/TestData/TestContainer"
             },
             {
-                "_id": "2",
-                "name": "ItemType",
-                "type": "dmss://test-source-name/TestData/ItemType"
+                "ref": "2",
+                "type": "dmss://system/SIMOS/Link",
+                "targetName": "ItemType",
+                "targetType": "dmss://test-source-name/TestData/ItemType"
             },
             {
-                "_id": "4",
-                "name": "ItemTypeTwo",
-                "type": "dmss://test-source-name/TestData/ItemTypeTwo"
+                "ref": "4",
+                "type": "dmss://system/SIMOS/Link",
+                "targetName": "ItemTypeTwo",
+                "targetType": "dmss://test-source-name/TestData/ItemTypeTwo"
             }
 
         ],

--- a/src/tests/bdd/document/update_with_blob.feature
+++ b/src/tests/bdd/document/update_with_blob.feature
@@ -22,14 +22,16 @@ Feature: Update document that has blob data
         "isRoot": true,
         "content": [
             {
-                "_id": "2",
-                "name": "MultiplePdfContainer",
-                "type": "dmss://system/SIMOS/Blueprint"
+               "type": "dmss://system/SIMOS/Link",
+                "ref": "2",
+                "targetName": "MultiplePdfContainer",
+                "targetType": "dmss://system/SIMOS/Blueprint"
             },
             {
-                "_id": "3",
-                "name": "new_pdf_container",
-                "type": "dmss://test-DS/root_package/MultiplePdfContainer"
+               "type": "dmss://system/SIMOS/Link",
+                "ref": "3",
+                "targetName": "new_pdf_container",
+                "targetType": "dmss://test-DS/root_package/MultiplePdfContainer"
             }
         ]
     }

--- a/src/tests/bdd/search.feature
+++ b/src/tests/bdd/search.feature
@@ -23,24 +23,28 @@ Feature: Explorer - Search entity
         "isRoot": true,
         "content": [
             {
-                "_id": "2",
-                "name": "ValuesBlueprint",
-                "type": "dmss://system/SIMOS/Blueprint"
+                "ref": "2",
+                "target": "dmss://system/SIMOS/Link",
+                "targetName": "ValuesBlueprint",
+                "targetType": "dmss://system/SIMOS/Blueprint"
             },
             {
-                "_id": "3",
-                "name": "NestedVectorsBlueprint",
-                "type": "dmss://system/SIMOS/Blueprint"
+                "ref": "3",
+                "target": "dmss://system/SIMOS/Link",
+                "targetName": "NestedVectorsBlueprint",
+                "targetType": "dmss://system/SIMOS/Blueprint"
             },
             {
-                "_id": "4",
-                "name": "NestedBlueprint",
-                "type": "dmss://system/SIMOS/Blueprint"
+                "ref": "4",
+                "target": "dmss://system/SIMOS/Link",
+                "targetName": "NestedBlueprint",
+                "targetType": "dmss://system/SIMOS/Blueprint"
             },
             {
-                "_id": "5",
-                "name": "NestedListBlueprint",
-                "type": "dmss://system/SIMOS/Blueprint"
+                "ref": "5",
+                "target": "dmss://system/SIMOS/Link",
+                "targetName": "NestedListBlueprint",
+                "targetType": "dmss://system/SIMOS/Blueprint"
             }
         ]
     }

--- a/src/tests/unit/test_get.py
+++ b/src/tests/unit/test_get.py
@@ -3,6 +3,7 @@ from unittest import mock
 
 from common.tree_node_serializer import tree_node_to_dict
 from common.utils.data_structure.compare import pretty_eq
+from enums import SIMOS
 from tests.unit.mock_utils import get_mock_document_service
 
 
@@ -14,10 +15,10 @@ class DocumentServiceTestCase(unittest.TestCase):
             "description": "",
             "type": "all_contained_cases_blueprint",
             "nested": {"name": "Nested", "description": "", "type": "basic_blueprint"},
-            "reference": {"_id": "2", "name": "Reference", "type": "basic_blueprint"},
+            "reference": {"ref": "2", "name": "Reference", "type": "basic_blueprint"},
             "references": [
-                {"_id": "3", "name": "Reference1", "type": "basic_blueprint"},
-                {"_id": "4", "name": "Reference2", "type": "basic_blueprint"},
+                {"ref": "3", "name": "Reference1", "type": SIMOS.LINK},
+                {"ref": "4", "name": "Reference2", "type": SIMOS.LINK},
             ],
         }
 
@@ -67,10 +68,10 @@ class DocumentServiceTestCase(unittest.TestCase):
                 "description": "",
                 "type": "all_contained_cases_blueprint",
                 "nested": {"name": "Nested", "description": "", "type": "basic_blueprint"},
-                "reference": {"_id": "2", "name": "Reference", "type": "basic_blueprint"},
+                "reference": {"ref": "2", "name": "Reference", "type": SIMOS.LINK},
                 "references": [
-                    {"_id": "3", "name": "Reference1", "type": "basic_blueprint"},
-                    {"_id": "4", "name": "Reference2", "type": "basic_blueprint"},
+                    {"ref": "3", "name": "Reference1", "type": SIMOS.LINK},
+                    {"ref": "4", "name": "Reference2", "type": SIMOS.LINK},
                 ],
             },
         }

--- a/src/tests/unit/test_reference.py
+++ b/src/tests/unit/test_reference.py
@@ -4,6 +4,7 @@ from unittest import mock
 from pydantic import ValidationError
 
 from common.exceptions import BadRequestException, NotFoundException
+from enums import SIMOS
 from restful.request_types.shared import Reference
 from tests.unit.mock_utils import get_mock_document_service
 
@@ -35,20 +36,25 @@ class ReferenceTestCase(unittest.TestCase):
         repository.get = lambda x: doc_storage[str(x)]
         repository.update = mock_update
         document_service = get_mock_document_service(lambda x, y: repository)
-
+        reference = Reference.parse_obj(
+            {
+                "ref": "2d7c3249-985d-43d2-83cf-a887e440825a",
+                "targetName": "something",
+                "targetType": "basic_blueprint",
+                "type": SIMOS.LINK.value,
+            }
+        )
         document_service.insert_reference(
             "testing",
             document_id="1",
-            reference=Reference.parse_obj(
-                {"_id": "2d7c3249-985d-43d2-83cf-a887e440825a", "name": "something", "type": "basic_blueprint"}
-            ),
+            reference=reference,
             attribute_path="uncontained_in_every_way",
         )
         assert doc_storage["1"]["uncontained_in_every_way"] == {
-            "_id": "2d7c3249-985d-43d2-83cf-a887e440825a",
-            "name": "something",
-            "contained": False,
-            "type": "basic_blueprint",
+            "ref": "2d7c3249-985d-43d2-83cf-a887e440825a",
+            "targetName": "something",
+            "targetType": "basic_blueprint",
+            "type": SIMOS.LINK.value,
         }
 
     def test_insert_reference_target_does_not_exist(self):
@@ -83,7 +89,12 @@ class ReferenceTestCase(unittest.TestCase):
                 "testing",
                 document_id="1",
                 reference=Reference.parse_obj(
-                    {"_id": "2d7c3249-985d-43d2-83cf-a887e440825a", "name": "something", "type": "something"}
+                    {
+                        "ref": "2d7c3249-985d-43d2-83cf-a887e440825a",
+                        "targetName": "something",
+                        "targetType": "something",
+                        "type": SIMOS.LINK.value,
+                    }
                 ),
                 attribute_path="uncontained_in_every_way",
             )
@@ -120,7 +131,12 @@ class ReferenceTestCase(unittest.TestCase):
                 "testing",
                 document_id="1",
                 reference=Reference.parse_obj(
-                    {"_id": "2d7c3249-985d-43d2-83cf-a887e440825a", "name": "something", "type": "wrong_type"}
+                    {
+                        "ref": "2d7c3249-985d-43d2-83cf-a887e440825a",
+                        "targetName": "something",
+                        "targetType": "wrong_type",
+                        "type": SIMOS.LINK.value,
+                    }
                 ),
                 attribute_path="uncontained_in_every_way",
             )
@@ -160,20 +176,21 @@ class ReferenceTestCase(unittest.TestCase):
             document_id="1",
             reference=Reference.parse_obj(
                 {
-                    "_id": "2d7c3249-985d-43d2-83cf-a887e440825a",
-                    "name": "something",
-                    "type": "basic_blueprint",
+                    "ref": "2d7c3249-985d-43d2-83cf-a887e440825a",
+                    "targetName": "something",
+                    "targetType": "basic_blueprint",
                     "description": "hallO",
                     "something": "something",
+                    "type": SIMOS.LINK.value,
                 }
             ),
             attribute_path="uncontained_in_every_way",
         )
         assert doc_storage["1"]["uncontained_in_every_way"] == {
-            "_id": "2d7c3249-985d-43d2-83cf-a887e440825a",
-            "name": "something",
-            "type": "basic_blueprint",
-            "contained": False,
+            "ref": "2d7c3249-985d-43d2-83cf-a887e440825a",
+            "targetName": "something",
+            "targetType": "basic_blueprint",
+            "type": SIMOS.LINK.value,
         }
 
     def test_insert_reference_missing_required_attribute(self):
@@ -302,14 +319,16 @@ class ReferenceTestCase(unittest.TestCase):
                 "type": "uncontained_list_blueprint",
                 "uncontained_in_every_way": [
                     {
-                        "_id": "2d7c3249-985d-43d2-83cf-a887e440825a",
-                        "name": "something",
-                        "type": "basic_blueprint",
+                        "ref": "2d7c3249-985d-43d2-83cf-a887e440825a",
+                        "targetName": "something",
+                        "targetType": "basic_blueprint",
+                        "type": SIMOS.LINK.value,
                     },
                     {
-                        "_id": "42dbe4a5-0eb0-4ee2-826c-695172c3c35a",
-                        "name": "something",
-                        "type": "basic_blueprint",
+                        "ref": "42dbe4a5-0eb0-4ee2-826c-695172c3c35a",
+                        "targetName": "something",
+                        "targetType": "basic_blueprint",
+                        "type": SIMOS.LINK.value,
                     },
                 ],
             },
@@ -339,10 +358,10 @@ class ReferenceTestCase(unittest.TestCase):
         )
         assert len(doc_storage["1"]["uncontained_in_every_way"]) == 1
         assert doc_storage["1"]["uncontained_in_every_way"][0] == {
-            "_id": "42dbe4a5-0eb0-4ee2-826c-695172c3c35a",
-            "name": "something",
-            "type": "basic_blueprint",
-            "contained": False,
+            "ref": "42dbe4a5-0eb0-4ee2-826c-695172c3c35a",
+            "targetName": "something",
+            "targetType": "basic_blueprint",
+            "type": SIMOS.LINK.value,
         }
 
     def test_add_reference_in_list(self):
@@ -356,9 +375,10 @@ class ReferenceTestCase(unittest.TestCase):
                 "type": "uncontained_list_blueprint",
                 "uncontained_in_every_way": [
                     {
-                        "_id": "2d7c3249-985d-43d2-83cf-a887e440825a",
-                        "name": "something",
-                        "type": "basic_blueprint",
+                        "ref": "2d7c3249-985d-43d2-83cf-a887e440825a",
+                        "targetName": "something",
+                        "targetType": "basic_blueprint",
+                        "type": SIMOS.LINK.value,
                     }
                 ],
             },
@@ -384,14 +404,19 @@ class ReferenceTestCase(unittest.TestCase):
             "testing",
             document_id="1",
             reference=Reference(
-                **{"_id": "42dbe4a5-0eb0-4ee2-826c-695172c3c35a", "name": "something", "type": "basic_blueprint"}
+                **{
+                    "ref": "42dbe4a5-0eb0-4ee2-826c-695172c3c35a",
+                    "targetName": "something",
+                    "targetType": "basic_blueprint",
+                    "type": SIMOS.LINK.value,
+                }
             ),
             attribute_path="uncontained_in_every_way",
         )
         assert len(doc_storage["1"]["uncontained_in_every_way"]) == 2
         assert doc_storage["1"]["uncontained_in_every_way"][1] == {
-            "_id": "42dbe4a5-0eb0-4ee2-826c-695172c3c35a",
-            "name": "something",
-            "type": "basic_blueprint",
-            "contained": False,
+            "ref": "42dbe4a5-0eb0-4ee2-826c-695172c3c35a",
+            "targetName": "something",
+            "targetType": "basic_blueprint",
+            "type": SIMOS.LINK.value,
         }

--- a/src/tests/unit/test_remove.py
+++ b/src/tests/unit/test_remove.py
@@ -108,10 +108,10 @@ class DocumentServiceTestCase(unittest.TestCase):
                     "description": "",
                     "type": "all_contained_cases_blueprint",
                     "nested": {
-                        "_id": "2",
-                        "name": "Parent",
-                        "contained": True,
-                        "type": "all_contained_cases_blueprint",
+                        "ref": "2",
+                        "targetName": "Parent",
+                        "targetType": "all_contained_cases_blueprint",
+                        "type": SIMOS.STORAGE_ADDRESS.value,
                     },
                 },
             },
@@ -149,10 +149,10 @@ class DocumentServiceTestCase(unittest.TestCase):
                             "type": "all_contained_cases_blueprint",
                             "nested": [
                                 {
-                                    "_id": "2",
-                                    "name": "Parent",
-                                    "contained": True,
-                                    "type": "all_contained_cases_blueprint",
+                                    "ref": "2",
+                                    "targetName": "Parent",
+                                    "targetType": "all_contained_cases_blueprint",
+                                    "type": SIMOS.STORAGE_ADDRESS.value,
                                 }
                             ],
                         },
@@ -161,10 +161,10 @@ class DocumentServiceTestCase(unittest.TestCase):
                             "type": "all_contained_cases_blueprint",
                             "nested": [
                                 {
-                                    "_id": "3",
-                                    "name": "Parent",
-                                    "contained": True,
-                                    "type": "all_contained_cases_blueprint",
+                                    "ref": "3",
+                                    "targetName": "Parent",
+                                    "targetType": "all_contained_cases_blueprint",
+                                    "type": SIMOS.STORAGE_ADDRESS.value,
                                 }
                             ],
                         },

--- a/src/tests/unit/test_rename.py
+++ b/src/tests/unit/test_rename.py
@@ -94,7 +94,7 @@ class DocumentServiceTestCase(unittest.TestCase):
                 "type": "all_contained_cases_blueprint",
                 "nested": {"name": "Nested", "description": "", "type": "basic_blueprint"},
                 "references": [],
-                "reference": {"_id": "2", "name": "Reference", "type": "basic_blueprint"},
+                "reference": {"ref": "2", "name": "Reference", "type": SIMOS.LINK},
             },
             "2": {"_id": "2", "name": "Reference", "description": "", "type": "basic_blueprint"},
         }
@@ -131,8 +131,20 @@ class DocumentServiceTestCase(unittest.TestCase):
                 "description": "",
                 "type": "all_contained_cases_blueprint",
                 "nested": {"name": "Nested", "description": "", "type": "basic_blueprint"},
-                "reference": {"_id": "2", "name": "Reference", "type": "basic_blueprint"},
-                "references": [{"_id": "2", "name": "Reference", "type": "basic_blueprint"}],
+                "reference": {
+                    "ref": "2",
+                    "targetName": "Reference",
+                    "targetType": "basic_blueprint",
+                    "type": SIMOS.STORAGE_ADDRESS.value,
+                },
+                "references": [
+                    {
+                        "ref": "2",
+                        "targetName": "Reference",
+                        "targetType": "basic_blueprint",
+                        "type": SIMOS.STORAGE_ADDRESS.value,
+                    }
+                ],
             },
             "2": {"_id": "2", "name": "Reference", "description": "", "type": "basic_blueprint"},
         }
@@ -153,7 +165,17 @@ class DocumentServiceTestCase(unittest.TestCase):
         document_service = get_mock_document_service(repository_provider)
         document_service.rename_document(data_source_id="testing", document_id="2", parent_uid="1", name="New_name")
 
-        actual = {"_id": "1", "references": [{"_id": "2", "name": "New_name", "type": "basic_blueprint"}]}
+        actual = {
+            "_id": "1",
+            "references": [
+                {
+                    "ref": "2",
+                    "targetName": "New_name",
+                    "targetType": "basic_blueprint",
+                    "type": SIMOS.STORAGE_ADDRESS.value,
+                }
+            ],
+        }
         actual2 = {"_id": "2", "name": "New_name", "type": "basic_blueprint"}
 
         assert pretty_eq(actual, doc_storage["1"]) is None

--- a/src/tests/unit/test_save.py
+++ b/src/tests/unit/test_save.py
@@ -6,6 +6,7 @@ from authentication.models import User
 from common.tree_node_serializer import tree_node_from_dict
 from domain_classes.blueprint_attribute import BlueprintAttribute
 from domain_classes.tree_node import Node
+from enums import SIMOS
 from tests.unit.mock_utils import (
     flatten_dict,
     get_mock_document_service,
@@ -100,7 +101,12 @@ class DocumentServiceTestCase(unittest.TestCase):
         document_service.save(node, "testing")
 
         assert doc_storage["1"]["references"] == [
-            {"name": "a_reference", "type": "basic_blueprint", "_id": "2", "contained": True}
+            {
+                "targetName": "a_reference",
+                "targetType": "basic_blueprint",
+                "ref": "2",
+                "type": SIMOS.STORAGE_ADDRESS.value,
+            }
         ]
 
     def test_save_delete(self):
@@ -115,9 +121,24 @@ class DocumentServiceTestCase(unittest.TestCase):
                 "nested": {"name": "Nested", "description": "", "type": "basic_blueprint"},
                 "reference": {"_id": "2", "name": "a_reference", "type": "basic_blueprint"},
                 "references": [
-                    {"_id": "2", "name": "a_reference", "type": "basic_blueprint"},
-                    {"_id": "3", "name": "a_reference", "type": "basic_blueprint"},
-                    {"_id": "4", "name": "a_reference", "type": "basic_blueprint"},
+                    {
+                        "ref": "2",
+                        "targetName": "a_reference",
+                        "targetType": "basic_blueprint",
+                        "type": SIMOS.STORAGE_ADDRESS.value,
+                    },
+                    {
+                        "ref": "3",
+                        "targetName": "a_reference",
+                        "targetType": "basic_blueprint",
+                        "type": SIMOS.STORAGE_ADDRESS.value,
+                    },
+                    {
+                        "ref": "4",
+                        "targetName": "a_reference",
+                        "targetType": "basic_blueprint",
+                        "type": SIMOS.STORAGE_ADDRESS.value,
+                    },
                 ],
             },
             "2": {"_id": "2", "name": "a_reference", "description": "Index 1", "type": "basic_blueprint"},
@@ -133,8 +154,18 @@ class DocumentServiceTestCase(unittest.TestCase):
             "nested": {},
             "reference": {},
             "references": [
-                {"_id": "2", "name": "a_reference", "type": "basic_blueprint", "contained": True},
-                {"_id": "4", "name": "a_reference", "type": "basic_blueprint", "contained": True},
+                {
+                    "ref": "2",
+                    "targetName": "a_reference",
+                    "targetType": "basic_blueprint",
+                    "type": SIMOS.STORAGE_ADDRESS.value,
+                },
+                {
+                    "ref": "4",
+                    "targetName": "a_reference",
+                    "targetType": "basic_blueprint",
+                    "type": SIMOS.STORAGE_ADDRESS.value,
+                },
             ],
         }
 
@@ -214,7 +245,7 @@ class DocumentServiceTestCase(unittest.TestCase):
         target_node = node.get_by_path(["i_have_a_uncontained_attribute", "uncontained_in_every_way"])
         target_node.update(doc_storage["3"])
         document_service.save(node, "testing")
-        assert doc_storage["1"]["i_have_a_uncontained_attribute"]["uncontained_in_every_way"]["_id"] == "3"
+        assert doc_storage["1"]["i_have_a_uncontained_attribute"]["uncontained_in_every_way"]["ref"] == "3"
 
     def test_save_no_overwrite_uncontained_document(self):
         repository = mock.Mock()


### PR DESCRIPTION
## What does this pull request change?

Add two blueprints for references
* Link - link to another document (model un-contained)
* StorageAddress - pointer to some address  where content is stored (model contained, but storage non-contained)

Refactor the code to use the two new blueprints.

## Why is this pull request needed?

* Consistency by using blueprints 

## Issues related to this change:

> **Note**
> I think we also should take a par-programming session together on this PR, and at the same time look at improvements (add more issues). 
