### PR TITLE
fix: update data source if it exists

### DIFF
--- a/src/storage/internal/data_source_repository.py
+++ b/src/storage/internal/data_source_repository.py
@@ -75,7 +75,7 @@ class DataSourceRepository:
         document["_id"] = id
         try:
             self.validate_data_source(document)
-            result = data_source_collection.replace_one({"_id": id}, document, upsert=True)
+            result = data_source_collection.update_one({"_id": id}, {"$set": document}, upsert=True)
         except BadRequestException:
             raise BadRequestException(
                 message=f"Failed to create data source '{id}'. The posted entity is invalid...", data=document


### PR DESCRIPTION
## What does this pull request change?
update data source repository to update data source document in the database if it already exists, instead of replacing the entire database document
## Why is this pull request needed?
bug with import ds command in dm-cli
## Issues related to this change:
closes #402 
