### PR TITLE
Fix/wrong blueprint used to validate list items

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
-# Created by https://www.gitignore.io/api/macos
-# Edit at https://www.gitignore.io/?templates=macos
+.ruff_cache
+.pytest_cache
 .env
 gen/
 /data/

--- a/src/common/responses.py
+++ b/src/common/responses.py
@@ -86,6 +86,8 @@ def create_response(
                 logger.error(e)
                 return JSONResponse(e.dict(), status_code=status.HTTP_404_NOT_FOUND)
             except BadRequestException as e:
+                if logger.level <= logging.DEBUG:
+                    traceback.print_exc()
                 logger.error(e)
                 logger.error(e.dict())
                 return JSONResponse(e.dict(), status_code=status.HTTP_400_BAD_REQUEST)

--- a/src/common/responses.py
+++ b/src/common/responses.py
@@ -71,9 +71,13 @@ def create_response(
                 logger.error(error_response)
                 return JSONResponse(error_response.dict(), status_code=error_response.status)
             except ValidationError as e:
+                if logger.level <= logging.DEBUG:
+                    traceback.print_exc()
                 validation_exception = ValidationException(message=str(e))
                 return JSONResponse(validation_exception.dict(), status_code=status.HTTP_400_BAD_REQUEST)
             except ValidationException as e:
+                if logger.level <= logging.DEBUG:
+                    traceback.print_exc()
                 logger.error(e)
                 return JSONResponse(e.dict(), status_code=status.HTTP_400_BAD_REQUEST)
             except NotFoundException as e:

--- a/src/common/utils/validators.py
+++ b/src/common/utils/validators.py
@@ -35,9 +35,11 @@ def is_blueprint_instance_of(
 
 def _validate_primitive_attribute(attribute: BlueprintAttribute, value: bool | int | float | str, key: str):
     python_type = BuiltinDataTypes(attribute.attribute_type).to_py_type()
+    if attribute.attribute_type == "number" and type(value) == int:  # float is considered a superset containing int
+        return
     if type(value) != python_type:
         raise ValidationException(
-            f"Attribute '{attribute.name}' should be type '{python_type.__name__}'. Got '{type(value).__name__}'",
+            f"Attribute '{attribute.name}' should be type '{python_type.__name__}'. Got '{type(value).__name__}'. Value: {value}",
             debug=_get_debug_message(key),
         )
 
@@ -96,7 +98,7 @@ def _validate_entity(
     key: str,
 ) -> None:
     if implementation_mode == "extend":
-        if entity["type"] not in (SIMOS.REFERENCE.value):
+        if entity["type"] != SIMOS.REFERENCE.value:
             if not is_blueprint_instance_of(blueprint.path, entity["type"], get_blueprint):
                 raise ValidationException(
                     f"Entity should be of type '{blueprint.path}' (or extending from it). Got '{entity['type']}'",
@@ -110,7 +112,7 @@ def _validate_entity(
             key for key in entity.keys() if key not in (blueprint.get_attribute_names() + ["_id"])
         ]:
             raise ValidationException(
-                f"Attributes '{keys_not_in_blueprint}' are not specified in the '{blueprint.path}'",
+                f"Attributes '{keys_not_in_blueprint}' are not specified in the blueprint '{blueprint.path}'",
                 debug=_get_debug_message(key),
             )
         if not blueprint.path == entity["type"]:

--- a/src/domain_classes/tree_node.py
+++ b/src/domain_classes/tree_node.py
@@ -387,7 +387,7 @@ class ListNode(NodeBase):
 
     @property
     def blueprint(self):
-        return self.parent.blueprint
+        return self.blueprint_provider(self.attribute.attribute_type)  # TODO: blueprint_provider is required now...
 
     def update(self, data: list):
         # Replaces the whole list with the new one

--- a/src/services/document_service.py
+++ b/src/services/document_service.py
@@ -330,15 +330,14 @@ class DocumentService:
                 )
             )
 
-        # If the leaf attribute is a list. Set that as parent and get validation blueprint from the ListNode
+        # If the leaf attribute is a list, set the ListNode as parent
         if leaf_parent.is_array():
             parent = leaf_parent
-            validation_blueprint = parent.blueprint
-        else:
-            # validation_blueprint = self.get_blueprint(parent.blueprint.get_attribute_type_by_key(leaf_attribute))
-            validation_blueprint = parent.get_by_path([leaf_attribute]).blueprint
 
-        if parent.type != SIMOS.PACKAGE.value:
+        if parent.type != BuiltinDataTypes.OBJECT.value:
+            validation_blueprint = (
+                parent.blueprint if parent.is_array() else parent.get_by_path([leaf_attribute]).blueprint
+            )
             validate_entity(data, self.get_blueprint, validation_blueprint, "extend")
 
         entity: dict = data

--- a/src/services/document_service.py
+++ b/src/services/document_service.py
@@ -329,12 +329,18 @@ class DocumentService:
                     + f"Received '{leaf_attribute}'"
                 )
             )
-        if parent.type != SIMOS.PACKAGE.value:
-            validate_entity(data, self.get_blueprint, leaf_parent.blueprint, "extend")
 
-        # If the leaf attribute is a list. Set that as parent
+        # If the leaf attribute is a list. Set that as parent and get validation blueprint from the ListNode
         if leaf_parent.is_array():
             parent = leaf_parent
+            validation_blueprint = parent.blueprint
+        else:
+            # validation_blueprint = self.get_blueprint(parent.blueprint.get_attribute_type_by_key(leaf_attribute))
+            validation_blueprint = parent.get_by_path([leaf_attribute]).blueprint
+
+        if parent.type != SIMOS.PACKAGE.value:
+            validate_entity(data, self.get_blueprint, validation_blueprint, "extend")
+
         entity: dict = data
 
         if type == SIMOS.BLUEPRINT.value and not entity.get("extends"):  # Extend default attributes and uiRecipes

--- a/src/tests/unit/mock_utils.py
+++ b/src/tests/unit/mock_utils.py
@@ -399,6 +399,7 @@ car_rental = {
     "type": "system/SIMOS/Blueprint",
     "attributes": [
         {"name": "name", "attributeType": "string", "type": "system/SIMOS/BlueprintAttribute"},
+        {"name": "type", "attributeType": "string", "type": "system/SIMOS/BlueprintAttribute"},
         {
             "name": "cars",
             "dimensions": "*",


### PR DESCRIPTION
## What does this pull request change?
- Fixes a "bug"/unintended behavior where integers were not valid values for "number" types
- Fixes a bug where a ListNode.blueprint returned the parent's blueprint

## Why is this pull request needed?
- Even "numbers" (floats in python) should be allowed to be whole numbers
- Validating with the wrong blueprint obviously gives ValidationException

## Issues related to this change:
none