### PR TITLE
fix: make find() handle indexing of long lists

### DIFF
--- a/src/tests/unit/data_structure/find_test.py
+++ b/src/tests/unit/data_structure/find_test.py
@@ -12,11 +12,20 @@ class FindTestCase(unittest.TestCase):
             "top": {
                 "middle": {"nested": "value"},
                 "list": [{"top": {"middle": {"nested": "value 1"}}}, {"top": {"middle": {"nested": "value 2"}}}],
+                "intlist": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
+                "4": "anInt",
             }
         }
         self.assertEqual(find(nested_dict, ["top", "middle", "nested"]), "value")
         self.assertEqual(find(nested_dict, ["top", "list", "[0]", "top", "middle", "nested"]), "value 1")
         self.assertEqual(find(nested_dict, ["top", "list", "[1]", "top", "middle", "nested"]), "value 2")
+        self.assertEqual(find(nested_dict, ["top", "intlist", [10]]), 11)
+
+        # Validate that a mismatch between object type and key raises a ValueError
+        self.assertRaises(ValueError, find, nested_dict, ["top", "[4]"])
+        self.assertRaises(ValueError, find, nested_dict, ["top", "4", "[2]"])
+        self.assertRaises(ValueError, find, nested_dict, ["top", "list", "top"])
+
         self.assertRaises(IndexError, find, nested_dict, ["top", "list", "[2]"])
         self.assertRaises(KeyError, find, nested_dict, ["top", "middle", "uknown"])
 


### PR DESCRIPTION
## What does this pull request change?

Rewrites utils/data_structure/find.py to handle lists with indexes above 9. Also gives better error messages when the object type is primitive or if its type doesn't match the type of the key. Finally, I added types and documentation

## Why is this pull request needed?

Previously, if input key to _get_value was a string "[10]", the index would be calculated as the last number (ie 0) and the call would get incorrect results. Also, the documentation was lacking.

## Issues related to this change:
