### PR TITLE
refactor: rewrite pretty_eq

### DIFF
--- a/src/common/utils/data_structure/compare.py
+++ b/src/common/utils/data_structure/compare.py
@@ -12,19 +12,13 @@ def print_pygments(json_object):
     print(highlight(json_str, JsonLexer(), TerminalFormatter()))
 
 
-def pretty_eq(expected, actual):
-    try:
-        a = traverse_compare(expected, actual)
-        b = []
-        if a != b:
-            print("Actual:")
-            print_pygments(actual)
-            print("Expected:")
-            print_pygments(expected)
-            print("Differences:")
-            print_pygments(a)
-        if a != b:
-            raise Exception
-    except Exception as e:
+def get_and_print_diff(actual: dict | list, expected: dict | list):
+    diff = traverse_compare(actual, expected)
+    if diff:
+        print("Actual:")
         print_pygments(actual)
-        raise e
+        print("Expected:")
+        print_pygments(expected)
+        print("Differences:")
+        print_pygments(diff)
+    return diff

--- a/src/tests/bdd/steps/handle_response.py
+++ b/src/tests/bdd/steps/handle_response.py
@@ -6,7 +6,7 @@ from behave import then
 from deepdiff import DeepDiff
 from dictdiffer import diff
 
-from common.utils.data_structure.compare import pretty_eq, print_pygments
+from common.utils.data_structure.compare import get_and_print_diff, print_pygments
 from common.utils.data_structure.find import find
 
 STATUS_CODES = {
@@ -115,7 +115,7 @@ def step_impl_should_be(context):
     else:
         actual = context.response.json()
         data = json.loads(context.text) or json.loads(context.data)
-        pretty_eq(data, actual)
+        assert get_and_print_diff(actual, data) == []
 
 
 @then("the length of the response should not be zero")

--- a/src/tests/unit/test_complex_arrays.py
+++ b/src/tests/unit/test_complex_arrays.py
@@ -2,7 +2,7 @@ import unittest
 from unittest import mock, skip
 
 from authentication.models import User
-from common.utils.data_structure.compare import pretty_eq
+from common.utils.data_structure.compare import get_and_print_diff
 from domain_classes.blueprint import Blueprint
 from enums import SIMOS
 from storage.repositories.file import LocalFileRepository
@@ -182,8 +182,8 @@ class ArraysDocumentServiceTestCase(unittest.TestCase):
         }
         # fmt: on
 
-        assert pretty_eq(expected_1, doc_storage["1"]) is None
-        assert pretty_eq(expected_2, doc_storage[list(doc_storage)[1]]) is None
+        assert get_and_print_diff(doc_storage["1"], expected_1) == []
+        assert get_and_print_diff(doc_storage[list(doc_storage)[1]], expected_2) == []
 
     def test_update_complex_array(self):
         # fmt: off

--- a/src/tests/unit/test_concat_meta_data.py
+++ b/src/tests/unit/test_concat_meta_data.py
@@ -1,6 +1,6 @@
 import unittest
 
-from common.utils.data_structure.compare import pretty_eq
+from common.utils.data_structure.compare import get_and_print_diff
 from features.export.use_cases.export_meta_use_case import concat_meta_data
 
 
@@ -55,8 +55,8 @@ class ConcatMetaTestCase(unittest.TestCase):
             ],
         }
 
-        result = pretty_eq(expected, concat_meta)
-        self.assertEqual(result, None)
+        result = get_and_print_diff(concat_meta, expected)
+        self.assertEqual(result, [])
 
     def test_concat_entity_with_override(self):
         existing_meta = {
@@ -115,5 +115,5 @@ class ConcatMetaTestCase(unittest.TestCase):
             ],
         }
 
-        result = pretty_eq(expected, concat_meta)
-        self.assertEqual(result, None)
+        result = get_and_print_diff(concat_meta, expected)
+        self.assertEqual(result, [])

--- a/src/tests/unit/test_get.py
+++ b/src/tests/unit/test_get.py
@@ -4,7 +4,7 @@ from unittest import mock
 import pytest
 
 from common.tree_node_serializer import tree_node_to_dict
-from common.utils.data_structure.compare import pretty_eq
+from common.utils.data_structure.compare import get_and_print_diff
 from common.utils.data_structure.is_same import is_same
 from enums import REFERENCE_TYPES, SIMOS, Protocols
 from tests.unit.mock_utils import get_mock_document_service
@@ -272,8 +272,8 @@ class DocumentServiceTestCase(unittest.TestCase):
         ]
         actual = {**my_car_rental, "cars": [actual_volvo, actual_ferrari], "customers": actual_customers}
 
-        assert pretty_eq(actual, directly) is None
-        assert pretty_eq(actual, complex_package["content"][0]) is None
+        assert get_and_print_diff(actual, directly) == []
+        assert get_and_print_diff(actual, complex_package["content"][0]) == []
 
     def test_get_complete_document(self):
         document_1 = {
@@ -322,7 +322,7 @@ class DocumentServiceTestCase(unittest.TestCase):
             "references": [document_3, document_4],
         }
 
-        assert pretty_eq(actual, root) is None
+        assert get_and_print_diff(actual, root) == []
 
     def test_get_complete_nested_reference(self):
         document_1 = {
@@ -386,4 +386,4 @@ class DocumentServiceTestCase(unittest.TestCase):
             },
         }
 
-        assert pretty_eq(actual, root) is None
+        assert get_and_print_diff(actual, root) == []

--- a/src/tests/unit/test_get_extended.py
+++ b/src/tests/unit/test_get_extended.py
@@ -1,7 +1,7 @@
 import unittest
 from unittest import mock
 
-from common.utils.data_structure.compare import pretty_eq
+from common.utils.data_structure.compare import get_and_print_diff
 from domain_classes.blueprint import Blueprint
 from domain_classes.tree_node import Node
 from tests.unit.mock_utils import get_mock_document_service
@@ -56,4 +56,4 @@ class GetExtendedBlueprintTestCase(unittest.TestCase):
         node.update(doc_1_after)
         document_service.save(node, "testing")
 
-        assert pretty_eq(doc_1_after, doc_storage["1"]) is None
+        assert get_and_print_diff(doc_storage["1"], doc_1_after) == []

--- a/src/tests/unit/test_remove.py
+++ b/src/tests/unit/test_remove.py
@@ -2,7 +2,7 @@ import unittest
 from unittest import mock
 
 from authentication.models import User
-from common.utils.data_structure.compare import pretty_eq
+from common.utils.data_structure.compare import get_and_print_diff
 from enums import REFERENCE_TYPES, SIMOS
 from tests.unit.mock_utils import get_mock_document_service
 
@@ -73,7 +73,7 @@ class DocumentServiceTestCase(unittest.TestCase):
         document_service = get_mock_document_service(repository_provider=repository_provider)
         document_service.remove_document(data_source_id="testing", document_id="1")
         expected = {"2": {"uid": "2", "_id": "2", "name": "a_reference", "description": "", "type": "basic_blueprint"}}
-        assert pretty_eq(expected, doc_storage) is None
+        assert get_and_print_diff(doc_storage, expected) == []
 
     def test_remove_nested(self):
         repository = mock.Mock()

--- a/src/tests/unit/test_tree_node_helpers.py
+++ b/src/tests/unit/test_tree_node_helpers.py
@@ -5,7 +5,7 @@ from common.tree_node_serializer import (
     tree_node_to_dict,
     tree_node_to_ref_dict,
 )
-from common.utils.data_structure.compare import pretty_eq
+from common.utils.data_structure.compare import get_and_print_diff
 from domain_classes.blueprint import Blueprint
 from domain_classes.blueprint_attribute import BlueprintAttribute
 from domain_classes.tree_node import ListNode, Node
@@ -708,7 +708,7 @@ class TreenodeTestCase(unittest.TestCase):
 
         root.update(update_0)
 
-        assert pretty_eq({**update_0, "_id": "1"}, tree_node_to_dict(root)) is None
+        assert get_and_print_diff(tree_node_to_dict(root), {**update_0, "_id": "1"}) == []
 
         update_1 = {
             "name": "New-name",
@@ -731,7 +731,7 @@ class TreenodeTestCase(unittest.TestCase):
 
         root.update(update_1)
 
-        assert pretty_eq({**update_1, "_id": "1"}, tree_node_to_dict(root)) is None
+        assert get_and_print_diff(tree_node_to_dict(root), {**update_1, "_id": "1"}) == []
 
         update_2 = {
             "name": "New-name",
@@ -754,7 +754,7 @@ class TreenodeTestCase(unittest.TestCase):
 
         root.update(update_2)
 
-        assert pretty_eq({**update_2, "_id": "1"}, tree_node_to_dict(root)) is None
+        assert get_and_print_diff(tree_node_to_dict(root), {**update_2, "_id": "1"}) == []
 
         expected = {
             "_id": "1",
@@ -868,7 +868,7 @@ class TreenodeTestCase(unittest.TestCase):
             ],
         }
 
-        assert pretty_eq(actual, tree_node_to_dict(root)) is None
+        assert get_and_print_diff(actual, tree_node_to_dict(root)) == []
 
     def test_recursive_from_dict(self):
         document_1 = {"_id": "1", "name": "Parent", "description": "", "type": "recursive_blueprint", "im_me!": {}}
@@ -962,7 +962,7 @@ class TreenodeTestCase(unittest.TestCase):
             document_1, get_blueprint, uid=document_1.get("_id"), recipe_provider=mock_storage_recipe_provider
         )
 
-        assert pretty_eq(actual, tree_node_to_dict(root)) is None
+        assert get_and_print_diff(actual, tree_node_to_dict(root)) == []
 
     def test_to_dict(self):
         root_data = {"_id": 1, "name": "root", "description": "", "type": "all_contained_cases_blueprint"}

--- a/src/tests/unit/test_tree_node_update.py
+++ b/src/tests/unit/test_tree_node_update.py
@@ -3,7 +3,7 @@ from unittest import mock
 
 from authentication.models import User
 from common.exceptions import BadRequestException, ValidationException
-from common.utils.data_structure.compare import pretty_eq
+from common.utils.data_structure.compare import get_and_print_diff
 from domain_classes.blueprint import Blueprint
 from domain_classes.tree_node import Node
 from enums import SIMOS
@@ -215,7 +215,7 @@ class DocumentServiceTestCase(unittest.TestCase):
             data={"type": "basic_blueprint", "name": "new_entity", "description": "This is my new entity"},
         )
 
-        assert pretty_eq(doc_1_after, doc_storage["1"]) is None
+        assert get_and_print_diff(doc_storage["1"], doc_1_after) == []
 
     def test_add_invalid_child_type(self):
         repository = mock.Mock()
@@ -309,7 +309,7 @@ class DocumentServiceTestCase(unittest.TestCase):
             {"name": "new_entity", "description": "This is my new entity", "type": "basic_blueprint"},
         )
 
-        assert pretty_eq(doc_1_after, doc_storage["1"]) is None
+        assert get_and_print_diff(doc_storage["1"], doc_1_after) == []
 
     def test_add_duplicate(self):
         repository = mock.Mock()


### PR DESCRIPTION
## What does this pull request change?

Rewrite pretty_eq and adapt all functions using it accordingly

## Why is this pull request needed?

The name "pretty_eq" is misleading, as pretty can mean both beautiful and fairly. Also, the function passes its input to traverse_compare in the wrong order. Finally, the try/catch is no longer needed, since traverse_compare no longer should raise Exceptions

## Issues related to this change:
