### PR TITLE
test: fix holes in traverse_compare

### DIFF
--- a/src/tests/unit/data_structure/traverse_test.py
+++ b/src/tests/unit/data_structure/traverse_test.py
@@ -17,19 +17,49 @@ class TraverseTestCase(unittest.TestCase):
         actual = [{"key3": "value3"}, {"key2": "value2"}, {"key1": "value1"}]
         expected = [{"key3": "value3"}, {"key2": "value2"}, {"key1": "value-1"}]
         result = traverse_compare(actual, expected)
-        self.assertEqual(result, [{"expected_value": "value-1", "path": "[2].key1", "actual_value": "value1"}])
+        self.assertEqual(
+            result,
+            [
+                {
+                    "expected_value": "value-1",
+                    "path": "[2].key1",
+                    "actual_value": "value1",
+                    "message": "Difference in primitive value",
+                }
+            ],
+        )
 
     def test_compare_lists_missing_entry(self):
         actual = [{"key3": "value3"}, {"key2": "value2"}]
         expected = [{"key3": "value3"}, {"key2": "value2"}, {"key1": "value1"}]
         result = traverse_compare(actual, expected)
-        self.assertEqual(result, [{"expected_value": expected, "path": "", "actual_value": actual}])
+        self.assertEqual(
+            result,
+            [
+                {
+                    "expected_value": expected,
+                    "path": "",
+                    "actual_value": actual,
+                    "message": "Actual length: 2. Expected length: 3",
+                }
+            ],
+        )
 
     def test_compare_lists_extra_entry(self):
         actual = [{"key3": "value3"}, {"key2": "value2"}, {"key1": "value1"}]
         expected = [{"key3": "value3"}, {"key2": "value2"}]
         result = traverse_compare(actual, expected)
-        self.assertEqual(result, [{"expected_value": expected, "path": "", "actual_value": actual}])
+        self.assertEqual(
+            result,
+            [
+                {
+                    "expected_value": expected,
+                    "path": "",
+                    "actual_value": actual,
+                    "message": "Actual length: 3. Expected length: 2",
+                }
+            ],
+        )
 
     def test_compare_dicts_identical(self):
         actual = {"top": {"middle": {"nested": "value"}}}
@@ -41,7 +71,14 @@ class TraverseTestCase(unittest.TestCase):
         expected = {"top": {"middle": {"nested": "wrong value"}}}
         self.assertEqual(
             traverse_compare(actual, expected),
-            [{"expected_value": "wrong value", "path": "top.middle.nested", "actual_value": "value"}],
+            [
+                {
+                    "expected_value": "wrong value",
+                    "path": "top.middle.nested",
+                    "actual_value": "value",
+                    "message": "Difference in primitive value",
+                }
+            ],
         )
 
     def test_compare_missing_key(self):
@@ -54,6 +91,7 @@ class TraverseTestCase(unittest.TestCase):
                     "expected_value": {"nested": "value", "nested2": "value2"},
                     "path": "top.middle",
                     "actual_value": {"nested": "value"},
+                    "message": "Missing keys: nested2. Extra keys: ",
                 }
             ],
         )
@@ -68,6 +106,7 @@ class TraverseTestCase(unittest.TestCase):
                     "expected_value": {"nested": "value"},
                     "path": "top.middle",
                     "actual_value": {"nested": "value", "nested2": "value2"},
+                    "message": "Missing keys: . Extra keys: nested2",
                 }
             ],
         )

--- a/src/tests/unit/data_structure/traverse_test.py
+++ b/src/tests/unit/data_structure/traverse_test.py
@@ -7,39 +7,67 @@ class TraverseTestCase(unittest.TestCase):
     def setUp(self):
         pass
 
-    def test_actual_bigger_than_expected(self):
-        actual = [{"key1": "value1"}, {"key2": "value2"}, {"key3": "value3"}]
-        expected = [{"key1": "value1"}, {"key2": "value2"}]
-        result = traverse_compare(actual, expected, ignoreIndexErrors=True, ignoreKeyErrors=True)
-        self.assertEqual(result, [])
-
-    def test_actual_bigger_than_expected_primitives(self):
-        actual = ["a", "b", "c"]
-        expected = ["a", "b"]
-        result = traverse_compare(actual, expected, ignoreIndexErrors=True)
-        self.assertEqual(result, [])
-
-    def test_compare_identical_list_of_dicts(self):
+    def test_compare_lists_identical(self):
         actual = [{"key3": "value3"}, {"key2": "value2"}, {"key1": "value1"}]
         expected = [{"key3": "value3"}, {"key2": "value2"}, {"key1": "value1"}]
         result = traverse_compare(actual, expected)
         self.assertEqual(result, [])
 
-    def test_compare_not_identical_list_of_dicts(self):
+    def test_compare_lists_different_entry(self):
         actual = [{"key3": "value3"}, {"key2": "value2"}, {"key1": "value1"}]
         expected = [{"key3": "value3"}, {"key2": "value2"}, {"key1": "value-1"}]
         result = traverse_compare(actual, expected)
         self.assertEqual(result, [{"expected_value": "value-1", "path": "[2].key1", "actual_value": "value1"}])
 
-    def test_compare_identical_dictionaries(self):
+    def test_compare_lists_missing_entry(self):
+        actual = [{"key3": "value3"}, {"key2": "value2"}]
+        expected = [{"key3": "value3"}, {"key2": "value2"}, {"key1": "value1"}]
+        result = traverse_compare(actual, expected)
+        self.assertEqual(result, [{"expected_value": expected, "path": "", "actual_value": actual}])
+
+    def test_compare_lists_extra_entry(self):
+        actual = [{"key3": "value3"}, {"key2": "value2"}, {"key1": "value1"}]
+        expected = [{"key3": "value3"}, {"key2": "value2"}]
+        result = traverse_compare(actual, expected)
+        self.assertEqual(result, [{"expected_value": expected, "path": "", "actual_value": actual}])
+
+    def test_compare_dicts_identical(self):
         actual = {"top": {"middle": {"nested": "value"}}}
         expected = {"top": {"middle": {"nested": "value"}}}
         self.assertEqual(traverse_compare(actual, expected), [])
 
-    def test_compare_not_identical_dictionaries(self):
+    def test_compare_dicts_different_value(self):
         actual = {"top": {"middle": {"nested": "value"}}}
         expected = {"top": {"middle": {"nested": "wrong value"}}}
         self.assertEqual(
             traverse_compare(actual, expected),
             [{"expected_value": "wrong value", "path": "top.middle.nested", "actual_value": "value"}],
+        )
+
+    def test_compare_missing_key(self):
+        actual = {"top": {"middle": {"nested": "value"}}}
+        expected = {"top": {"middle": {"nested": "value", "nested2": "value2"}}}
+        self.assertEqual(
+            traverse_compare(actual, expected),
+            [
+                {
+                    "expected_value": {"nested": "value", "nested2": "value2"},
+                    "path": "top.middle",
+                    "actual_value": {"nested": "value"},
+                }
+            ],
+        )
+
+    def test_compare_extra_key(self):
+        actual = {"top": {"middle": {"nested": "value", "nested2": "value2"}}}
+        expected = {"top": {"middle": {"nested": "value"}}}
+        self.assertEqual(
+            traverse_compare(actual, expected),
+            [
+                {
+                    "expected_value": {"nested": "value"},
+                    "path": "top.middle",
+                    "actual_value": {"nested": "value", "nested2": "value2"},
+                }
+            ],
         )

--- a/src/tests/unit/mock_utils.py
+++ b/src/tests/unit/mock_utils.py
@@ -403,7 +403,7 @@ car_rental = {
         {
             "name": "cars",
             "dimensions": "*",
-            "attributeType": "test_data/complex/CarTest",
+            "attributeType": "test_data/complex/RentalCar",
             "type": "system/SIMOS/BlueprintAttribute",
         },
         {
@@ -415,6 +415,36 @@ car_rental = {
     ],
 }
 
+car_rental_car = {
+    "type": "system/SIMOS/Blueprint",
+    "name": "RentalCar",
+    "attributes": [
+        {
+            "name": "name",
+            "attributeType": "string",
+            "type": "system/SIMOS/BlueprintAttribute",
+            "default": "RentalCar",
+        },
+        {
+            "name": "type",
+            "attributeType": "string",
+            "type": "system/SIMOS/BlueprintAttribute",
+            "default": "test_data/complex/RentalCar",
+        },
+        {
+            "name": "plateNumber",
+            "attributeType": "string",
+            "type": "system/SIMOS/BlueprintAttribute",
+        },
+        {
+            "type": "system/SIMOS/BlueprintAttribute",
+            "name": "engine",
+            "attributeType": "test_data/complex/EngineTest",
+            "optional": True,
+        },
+    ],
+}
+
 car_rental_customer = {
     "name": "Customer",
     "type": "system/SIMOS/Blueprint",
@@ -422,7 +452,7 @@ car_rental_customer = {
         {"name": "name", "attributeType": "string", "type": "system/SIMOS/BlueprintAttribute"},
         {
             "name": "car",
-            "attributeType": "test_data/complex/CarTest",
+            "attributeType": "test_data/complex/RentalCar",
             "type": "system/SIMOS/BlueprintAttribute",
             "contained": False,
         },
@@ -501,6 +531,8 @@ class BlueprintProvider:
             return Blueprint(wheel, type)
         if type == "test_data/complex/CarRental":
             return Blueprint(car_rental, type)
+        if type == "test_data/complex/RentalCar":
+            return Blueprint(car_rental_car, type)
         if type == "test_data/complex/Customer":
             return Blueprint(car_rental_customer, type)
         if type == "Parent":

--- a/src/tests/unit/test_get.py
+++ b/src/tests/unit/test_get.py
@@ -16,11 +16,9 @@ class DocumentServiceTestCase(unittest.TestCase):
             "_id": "1",
             "type": "test_data/complex/CarRental",
             "name": "myCarRental",
-            "description": "",
-            "extends": [SIMOS.NAMED_ENTITY.value],
             "cars": [
-                {"type": "test_data/complex/CarTest", "name": "Volvo 240", "plateNumber": "123"},
-                {"type": "test_data/complex/CarTest", "name": "Ferrari", "plateNumber": "456"},
+                {"type": "test_data/complex/RentalCar", "name": "Volvo 240", "plateNumber": "123"},
+                {"type": "test_data/complex/RentalCar", "name": "Ferrari", "plateNumber": "456"},
             ],
             "customers": [
                 {
@@ -63,11 +61,9 @@ class DocumentServiceTestCase(unittest.TestCase):
             "_id": "2",
             "type": "test_data/complex/CarRental",
             "name": "myCarRental",
-            "description": "",
-            "extends": [SIMOS.NAMED_ENTITY.value],
             "cars": [
                 {
-                    "type": "test_data/complex/CarTest",
+                    "type": "test_data/complex/RentalCar",
                     "name": "Volvo 240",
                     "plateNumber": "123",
                     "engine": {
@@ -77,7 +73,7 @@ class DocumentServiceTestCase(unittest.TestCase):
                     },
                 },
                 {
-                    "type": "test_data/complex/CarTest",
+                    "type": "test_data/complex/RentalCar",
                     "name": "Ferrari",
                     "plateNumber": "456",
                     "engine": {
@@ -259,59 +255,22 @@ class DocumentServiceTestCase(unittest.TestCase):
 
         assert isinstance(directly, dict)
 
-        actual = {
-            "_id": "2",
-            "type": "test_data/complex/CarRental",
-            "name": "myCarRental",
-            "cars": [{"type": "test_data/complex/CarTest", "name": "Volvo 240"}],
-            "customers": [
-                {
-                    "type": "test_data/complex/Customer",
-                    "name": "Full absolute path prefixed with protocol",
-                    "car": {"type": "test_data/complex/CarTest", "name": "Volvo 240"},
-                },
-                {
-                    "type": "test_data/complex/Customer",
-                    "name": "Relative from the destination data source by id",
-                    "car": {"type": "test_data/complex/CarTest", "name": "Volvo 240"},
-                },
-                {
-                    "type": "test_data/complex/Customer",
-                    "name": "Relative from the destination data source by path",
-                    "car": {"type": "test_data/complex/CarTest", "name": "Volvo 240"},
-                },
-                {
-                    "type": "test_data/complex/Customer",
-                    "name": "Relative from the destination data source by query",
-                    "car": {"type": "test_data/complex/CarTest", "name": "Volvo 240"},
-                },
-                {
-                    "type": "test_data/complex/Customer",
-                    "name": "Relative from the destination data source by query on array",
-                    "car": {"type": "test_data/complex/CarTest", "name": "Volvo 240"},
-                },
-                {
-                    "type": "test_data/complex/Customer",
-                    "name": "Test",
-                    "car": {"type": "test_data/complex/CarTest", "name": "Volvo 240"},
-                },
-                {
-                    "type": "test_data/complex/Customer",
-                    "name": "Test2",
-                    "car": {"type": "test_data/complex/CarTest", "name": "Volvo 240"},
-                },
-                {
-                    "type": "test_data/complex/Customer",
-                    "name": "Relative from the document",
-                    "car": {"type": "test_data/complex/CarTest", "name": "Volvo 240"},
-                },
-                {
-                    "type": "test_data/complex/Customer",
-                    "name": "Relative from the document with query on plate number",
-                    "car": {"type": "test_data/complex/CarTest", "name": "Ferrari"},
-                },
-            ],
-        }
+        actual_engine = {**my_engine}
+        actual_engine.pop("_id")
+        actual_volvo = {**my_car_rental["cars"][0], "engine": actual_engine}
+        actual_ferrari = {**my_car_rental["cars"][1], "engine": actual_engine}
+        actual_customers = [
+            {**my_car_rental["customers"][0], "car": actual_volvo},
+            {**my_car_rental["customers"][1], "car": actual_volvo},
+            {**my_car_rental["customers"][2], "car": actual_volvo},
+            {**my_car_rental["customers"][3], "car": actual_volvo},
+            {**my_car_rental["customers"][4], "car": actual_volvo},
+            {**my_car_rental["customers"][5], "car": actual_volvo},
+            {**my_car_rental["customers"][6], "car": actual_volvo},
+            {**my_car_rental["customers"][7], "car": actual_volvo},
+            {**my_car_rental["customers"][8], "car": actual_ferrari},
+        ]
+        actual = {**my_car_rental, "cars": [actual_volvo, actual_ferrari], "customers": actual_customers}
 
         assert pretty_eq(actual, directly) is None
         assert pretty_eq(actual, complex_package["content"][0]) is None

--- a/src/tests/unit/test_tree_node_helpers.py
+++ b/src/tests/unit/test_tree_node_helpers.py
@@ -708,7 +708,7 @@ class TreenodeTestCase(unittest.TestCase):
 
         root.update(update_0)
 
-        assert pretty_eq(update_0, tree_node_to_dict(root)) is None
+        assert pretty_eq({**update_0, "_id": "1"}, tree_node_to_dict(root)) is None
 
         update_1 = {
             "name": "New-name",
@@ -731,7 +731,7 @@ class TreenodeTestCase(unittest.TestCase):
 
         root.update(update_1)
 
-        assert pretty_eq(update_1, tree_node_to_dict(root)) is None
+        assert pretty_eq({**update_1, "_id": "1"}, tree_node_to_dict(root)) is None
 
         update_2 = {
             "name": "New-name",
@@ -754,7 +754,7 @@ class TreenodeTestCase(unittest.TestCase):
 
         root.update(update_2)
 
-        assert pretty_eq(update_2, tree_node_to_dict(root)) is None
+        assert pretty_eq({**update_2, "_id": "1"}, tree_node_to_dict(root)) is None
 
         expected = {
             "_id": "1",
@@ -852,13 +852,19 @@ class TreenodeTestCase(unittest.TestCase):
                     "name": "Nested",
                     "description": "",
                     "type": "blueprint_3",
-                    "reference": {"_id": "5", "name": "Reference", "description": "", "type": "basic_blueprint"},
+                    "reference": {
+                        "_id": "5",
+                        "name": "Reference",
+                        "description": "",
+                        "type": "basic_blueprint",
+                        "nested": {},
+                    },
                 },
             },
-            "reference": {"_id": "2", "name": "Reference", "description": "", "type": "basic_blueprint"},
+            "reference": {"_id": "2", "name": "Reference", "description": "", "type": "basic_blueprint", "nested": {}},
             "references": [
-                {"_id": "3", "name": "Reference-1", "description": "", "type": "basic_blueprint"},
-                {"_id": "4", "name": "Reference-2", "description": "", "type": "basic_blueprint"},
+                {"_id": "3", "name": "Reference-1", "description": "", "type": "basic_blueprint", "nested": {}},
+                {"_id": "4", "name": "Reference-2", "description": "", "type": "basic_blueprint", "nested": {}},
             ],
         }
 
@@ -936,13 +942,19 @@ class TreenodeTestCase(unittest.TestCase):
                     "name": "Nested",
                     "description": "",
                     "type": "blueprint_3",
-                    "reference": {"_id": "5", "name": "Reference", "description": "", "type": "basic_blueprint"},
+                    "reference": {
+                        "_id": "5",
+                        "name": "Reference",
+                        "description": "",
+                        "type": "basic_blueprint",
+                        "nested": {},
+                    },
                 },
             },
-            "reference": {"_id": "2", "name": "Reference", "description": "", "type": "basic_blueprint"},
+            "reference": {"_id": "2", "name": "Reference", "description": "", "type": "basic_blueprint", "nested": {}},
             "references": [
-                {"_id": "3", "name": "Reference-1", "description": "", "type": "basic_blueprint"},
-                {"_id": "4", "name": "Reference-2", "description": "", "type": "basic_blueprint"},
+                {"_id": "3", "name": "Reference-1", "description": "", "type": "basic_blueprint", "nested": {}},
+                {"_id": "4", "name": "Reference-2", "description": "", "type": "basic_blueprint", "nested": {}},
             ],
         }
 

--- a/src/tests/unit/test_validate_entity.py
+++ b/src/tests/unit/test_validate_entity.py
@@ -221,11 +221,9 @@ class ValidateEntityTestCase(unittest.TestCase):
             "name": "myCarRental",
             "cars": [
                 {
-                    "type": "test_data/complex/CarTest",
+                    "type": "test_data/complex/RentalCar",
                     "name": "Volvo 240",
                     "plateNumber": "123",
-                    "wheels": [],
-                    "wheel": {"name": "Wheel", "power": 0.0, "type": "test_data/complex/WheelTest"},
                     "engine": {
                         "name": "myEngine",
                         "description": "Some description",
@@ -237,12 +235,6 @@ class ValidateEntityTestCase(unittest.TestCase):
                         "power": 120,
                         "type": "test_data/complex/EngineTest",
                     },
-                    "seats": 2,
-                    "is_sedan": True,
-                    "floatValues": [2.1, 0, 4.2],
-                    "intValues": [1, 5, 4, 2],
-                    "boolValues": [True, False, True],
-                    "stringValues": ["one", "two", "three"],
                 },
             ],
             "customers": [],


### PR DESCRIPTION
## What does this pull request change?

Rewrite traverse_compare to something more readable and add checks for missing keys and indices
Add more tests
Fix tests now failing due to the change

## Why is this pull request needed?

traverse_compare didn't catch extra indices or keys

## Issues related to this change:
