### PR TITLE
refactor: detailed exception messages in 'resolve_reference()'

### DIFF
--- a/src/common/tree_node_serializer.py
+++ b/src/common/tree_node_serializer.py
@@ -1,7 +1,11 @@
 from copy import deepcopy
 from typing import Any, Callable
 
-from common.exceptions import BadRequestException
+from common.exceptions import (
+    ApplicationException,
+    BadRequestException,
+    NotFoundException,
+)
 from common.utils.logging import logger
 from config import config
 from domain_classes.blueprint import Blueprint
@@ -141,6 +145,11 @@ def tree_node_from_dict(
         attribute=node_attribute,
         recipe_provider=recipe_provider,
     )
+
+    try:
+        node.blueprint
+    except NotFoundException as e:
+        raise ApplicationException(f"Failed to find blueprint with reference '{node.type}'", debug=str(e))
 
     for child_attribute in node.blueprint.get_none_primitive_types():
         if child_attribute.name == "_meta_":

--- a/src/common/utils/get_resolved_document_by_id.py
+++ b/src/common/utils/get_resolved_document_by_id.py
@@ -58,6 +58,8 @@ def get_complete_sys_document(
     resolve_links: bool = False,
 ) -> dict:
     address = reference["address"]
+    if not address:
+        raise ApplicationException("Invalid link. Missing 'address'", data=reference)
 
     if address.startswith("^"):
         # Replace ^ with an id reference that contains the current document id

--- a/src/common/utils/package_import.py
+++ b/src/common/utils/package_import.py
@@ -1,6 +1,6 @@
 import json
 import os
-from typing import Dict, List, Union
+from typing import Dict, List
 from uuid import uuid4
 
 from authentication.models import User
@@ -37,7 +37,7 @@ def _add_documents(path, documents, data_source) -> List[Dict]:
     return docs
 
 
-def import_package(path, user: User, data_source_name: str, is_root: bool = False) -> Union[Dict]:
+def import_package(path, user: User, data_source_name: str, is_root: bool = False) -> dict:
     data_source: DataSource = get_data_source(data_source_id=data_source_name, user=user)
     package = {"name": os.path.basename(path), "type": SIMOS.PACKAGE.value, "isRoot": is_root}
     try:

--- a/src/tests/bdd/authentication/access_control.feature
+++ b/src/tests/bdd/authentication/access_control.feature
@@ -68,11 +68,11 @@ Feature: Access Control
     And the response should be
     """
     {
-    "status": 403,
-    "type": "MissingPrivilegeException",
-    "message": "The requested operation requires 'READ' privileges",
-    "debug": "Action denied because of insufficient permissions",
-    "data": null
+      "data": null,
+      "debug": "The requested operation requires 'READ' privileges. Action denied because of insufficient permissions",
+      "message": "Failed to get document referenced with '/test-DS/$1'",
+      "status": 403,
+      "type": "MissingPrivilegeException"
     }
     """
 

--- a/src/tests/bdd/document/add_file.feature
+++ b/src/tests/bdd/document/add_file.feature
@@ -409,11 +409,11 @@ Feature: Explorer - Add file
     And the response should be
     """
     {
+    "data": null,
+    "debug": "Document with id '-1' was not found in the 'test-DS' data-source. The requested resource could not be found",
+    "message": "Failed to get document referenced with 'test-DS/$-1'",
     "status": 404,
-    "type": "NotFoundException",
-    "message": "Document with id '-1' was not found in the 'test-DS' data-source",
-    "debug": "The requested resource could not be found",
-    "data": null
+    "type": "NotFoundException"
     }
     """
 

--- a/src/tests/bdd/document/remove.feature
+++ b/src/tests/bdd/document/remove.feature
@@ -29,11 +29,11 @@ Feature: Explorer - Remove
     And the response should be
   """
   {
+  "data": null,
+  "debug": "Document with id '1' was not found in the 'data-source-name' data-source. The requested resource could not be found",
+  "message": "Failed to get document referenced with '/data-source-name/$1'",
   "status": 404,
-  "type": "NotFoundException",
-  "message": "Document with id '1' was not found in the 'data-source-name' data-source",
-  "debug": "The requested resource could not be found",
-  "data": null
+  "type": "NotFoundException"
   }
   """
     Given I access the resource url "/api/documents/data-source-name/$2"
@@ -42,11 +42,11 @@ Feature: Explorer - Remove
     And the response should be
   """
   {
+  "data": null,
+  "debug": "Document with id '2' was not found in the 'data-source-name' data-source. The requested resource could not be found",
+  "message": "Failed to get document referenced with '/data-source-name/$2'",
   "status": 404,
-  "type": "NotFoundException",
-  "message": "Document with id '2' was not found in the 'data-source-name' data-source",
-  "debug": "The requested resource could not be found",
-  "data": null
+  "type": "NotFoundException"
   }
   """
     Given I access the resource url "/api/documents/data-source-name/$3"
@@ -55,11 +55,11 @@ Feature: Explorer - Remove
     And the response should be
   """
   {
+  "data": null,
+  "debug": "Document with id '3' was not found in the 'data-source-name' data-source. The requested resource could not be found",
+  "message": "Failed to get document referenced with '/data-source-name/$3'",
   "status": 404,
-  "type": "NotFoundException",
-  "message": "Document with id '3' was not found in the 'data-source-name' data-source",
-  "debug": "The requested resource could not be found",
-  "data": null
+  "type": "NotFoundException"
   }
   """
 
@@ -77,11 +77,11 @@ Feature: Explorer - Remove
     And the response should be
     """
     {
+    "data": null,
+    "debug": "Document with id '2' was not found in the 'data-source-name' data-source. The requested resource could not be found",
+    "message": "Failed to get document referenced with '/data-source-name/$2'",
     "status": 404,
-    "type": "NotFoundException",
-    "message": "Document with id '2' was not found in the 'data-source-name' data-source",
-    "debug": "The requested resource could not be found",
-    "data": null
+    "type": "NotFoundException"
     }
     """
 
@@ -95,11 +95,11 @@ Feature: Explorer - Remove
     And the response should be
     """
     {
+    "data": null,
+    "debug": "Document with id '3' was not found in the 'data-source-name' data-source. The requested resource could not be found",
+    "message": "Failed to get document referenced with '/data-source-name/$3'",
     "status": 404,
-    "type": "NotFoundException",
-    "message": "Document with id '3' was not found in the 'data-source-name' data-source",
-    "debug": "The requested resource could not be found",
-    "data": null
+    "type": "NotFoundException"
     }
     """
 
@@ -113,11 +113,11 @@ Feature: Explorer - Remove
     And the response should be
   """
   {
+  "data": null,
+  "debug": "Document with id '2' was not found in the 'data-source-name' data-source. The requested resource could not be found",
+  "message": "Failed to get document referenced with '/data-source-name/$2'",
   "status": 404,
-  "type": "NotFoundException",
-  "message": "Document with id '2' was not found in the 'data-source-name' data-source",
-  "debug": "The requested resource could not be found",
-  "data": null
+  "type": "NotFoundException"
   }
   """
     Given I access the resource url "/api/documents/data-source-name/$3"
@@ -126,11 +126,11 @@ Feature: Explorer - Remove
     And the response should be
   """
   {
+  "data": null,
+  "debug": "Document with id '3' was not found in the 'data-source-name' data-source. The requested resource could not be found",
+  "message": "Failed to get document referenced with '/data-source-name/$3'",
   "status": 404,
-  "type": "NotFoundException",
-  "message": "Document with id '3' was not found in the 'data-source-name' data-source",
-  "debug": "The requested resource could not be found",
-  "data": null
+  "type": "NotFoundException"
   }
   """
 

--- a/src/tests/bdd/document/remove_by_path.feature
+++ b/src/tests/bdd/document/remove_by_path.feature
@@ -23,11 +23,11 @@ Feature: Explorer - Remove by path
     And the response should be
   """
   {
+  "data": null,
+  "debug": "Document with id '1' was not found in the 'data-source-name' data-source. The requested resource could not be found",
+  "message": "Failed to get document referenced with '/data-source-name/$1'",
   "status": 404,
-  "type": "NotFoundException",
-  "message": "Document with id '1' was not found in the 'data-source-name' data-source",
-  "debug": "The requested resource could not be found",
-  "data": null
+  "type": "NotFoundException"
   }
   """
     Given I access the resource url "/api/documents/data-source-name/$2"
@@ -36,11 +36,11 @@ Feature: Explorer - Remove by path
     And the response should be
   """
   {
+  "data": null,
+  "debug": "Document with id '2' was not found in the 'data-source-name' data-source. The requested resource could not be found",
+  "message": "Failed to get document referenced with '/data-source-name/$2'",
   "status": 404,
-  "type": "NotFoundException",
-  "message": "Document with id '2' was not found in the 'data-source-name' data-source",
-  "debug": "The requested resource could not be found",
-  "data": null
+  "type": "NotFoundException"
   }
   """
     Given I access the resource url "/api/documents/data-source-name/$3"
@@ -49,11 +49,11 @@ Feature: Explorer - Remove by path
     And the response should be
   """
   {
+  "data": null,
+  "debug": "Document with id '3' was not found in the 'data-source-name' data-source. The requested resource could not be found",
+  "message": "Failed to get document referenced with '/data-source-name/$3'",
   "status": 404,
-  "type": "NotFoundException",
-  "message": "Document with id '3' was not found in the 'data-source-name' data-source",
-  "debug": "The requested resource could not be found",
-  "data": null
+  "type": "NotFoundException"
   }
   """
 
@@ -72,11 +72,11 @@ Feature: Explorer - Remove by path
     And the response should be
     """
     {
+    "data": null,
+    "debug": "Document with id '2' was not found in the 'data-source-name' data-source. The requested resource could not be found",
+    "message": "Failed to get document referenced with '/data-source-name/$2'",
     "status": 404,
-    "type": "NotFoundException",
-    "message": "Document with id '2' was not found in the 'data-source-name' data-source",
-    "debug": "The requested resource could not be found",
-    "data": null
+    "type": "NotFoundException"
     }
     """
 
@@ -90,11 +90,11 @@ Feature: Explorer - Remove by path
     And the response should be
     """
     {
+    "data": null,
+    "debug": "Document with id '3' was not found in the 'data-source-name' data-source. The requested resource could not be found",
+    "message": "Failed to get document referenced with '/data-source-name/$3'",
     "status": 404,
-    "type": "NotFoundException",
-    "message": "Document with id '3' was not found in the 'data-source-name' data-source",
-    "debug": "The requested resource could not be found",
-    "data": null
+    "type": "NotFoundException"
     }
     """
 
@@ -108,11 +108,11 @@ Feature: Explorer - Remove by path
     And the response should be
   """
   {
-  "status": 404,
-  "type": "NotFoundException",
-  "message": "Document with id '2' was not found in the 'data-source-name' data-source",
-  "debug": "The requested resource could not be found",
-  "data": null
+    "data": null,
+    "debug": "Document with id '2' was not found in the 'data-source-name' data-source. The requested resource could not be found",
+    "message": "Failed to get document referenced with '/data-source-name/$2'",
+    "status": 404,
+    "type": "NotFoundException"
   }
   """
     Given I access the resource url "/api/documents/data-source-name/$3"
@@ -121,11 +121,11 @@ Feature: Explorer - Remove by path
     And the response should be
   """
   {
+  "data": null,
+  "debug": "Document with id '3' was not found in the 'data-source-name' data-source. The requested resource could not be found",
+  "message": "Failed to get document referenced with '/data-source-name/$3'",
   "status": 404,
-  "type": "NotFoundException",
-  "message": "Document with id '3' was not found in the 'data-source-name' data-source",
-  "debug": "The requested resource could not be found",
-  "data": null
+  "type": "NotFoundException"
   }
   """
 


### PR DESCRIPTION
## What does this pull request change?
- Add more detailed and context aware messages to returned exception messages.

Example on a wrongly named Blueprint

``` 
{
'status': 500,
'type': 'ApplicationException',
'message': "Failed to get document referenced with '/DemoDataSource/recipes'",
'debug': 'Failed to find blueprint with reference \'dmss://system/Plugins/dm-core-plugins/attribute-selector/AttributeSelectorPluginConfig\'. No entity
matches \'Query="name=AttributeSelectorPluginConfig"\' in document \'dmss://system/$3a3c754c-3d40-45f9-871a-1614bb703325.content\'',
'data': None
}
```


## Why is this pull request needed?
- DMSS should tell any user as detailed as possible what is wrong with the models/data

## Issues related to this change:
none
