### PR TITLE
fix: update_documents now supports new reference scheme

### DIFF
--- a/src/common/utils/get_resolved_document_by_id.py
+++ b/src/common/utils/get_resolved_document_by_id.py
@@ -56,7 +56,7 @@ def get_complete_sys_document(
     depth: int = 1,
     depth_count: int = 0,
     resolve_links: bool = False,
-) -> dict:
+) -> dict | list:
     address = reference["address"]
     if not address:
         raise ApplicationException("Invalid link. Missing 'address'", data=reference)
@@ -91,7 +91,7 @@ def get_complete_sys_document(
 
 def resolve_document(
     entity, data_source, get_data_source, current_id, depth: int = 1, depth_count: int = 0, resolve_links: bool = False
-) -> dict:
+) -> dict | list:
     if depth <= depth_count:
         if depth_count >= 999:
             raise RecursionError("Reached max-nested-depth (999). Most likely some recursive entities")

--- a/src/common/utils/resolve_reference.py
+++ b/src/common/utils/resolve_reference.py
@@ -10,6 +10,31 @@ from enums import Protocols
 from storage.data_source_class import DataSource
 
 
+def split_reference(reference: str) -> list[str]:
+    """Splits a reference into it's string components
+    e.g. "$123.content[1]" -> ["$123", ".content", "[1]"]"""
+    parts = []
+    remaining_ref = reference
+    while remaining_ref:
+        if remaining_ref[0] in "./":
+            prefix_delim = remaining_ref[0]
+            content = re.split(r"[./\[(]", remaining_ref, 2)[1]
+            parts.append(f"{prefix_delim}{content}")
+            remaining_ref = remaining_ref.removeprefix(parts[-1])
+            continue
+        if remaining_ref[0] in "[(":
+            prefix_delim = remaining_ref[0]
+            content = re.split(r"[\[\]\(\)]", remaining_ref, 2)[1]
+            parts.append(f"{prefix_delim}{content}{']' if prefix_delim == '[' else ')'}")
+            remaining_ref = remaining_ref.removeprefix(parts[-1])
+            continue
+
+        content = re.split(r"[./]", remaining_ref, 1)[0]
+        remaining_ref = remaining_ref.removeprefix(content)
+        parts.append(content)
+    return parts
+
+
 def _next_reference_part(reference: str) -> Tuple[str, Union[str, None], str]:
     """Utility to get next reference part."""
     content = reference  # Default to reference
@@ -26,50 +51,15 @@ def _next_reference_part(reference: str) -> Tuple[str, Union[str, None], str]:
     return content, deliminator, remaining_reference
 
 
-def reference_to_reference_items(reference: str, items=None, prev_deliminator=None):
-    """Split up the reference into reference items."""
-
-    if len(reference) == 0:
-        return items
-
-    if not items:
-        items = []
-
-    content, deliminator, remaining_reference = _next_reference_part(reference)
-    if content == "":
-        # If the original reference starts with a deliminator (e.g. /)
-        # or two deliminators are next to each other (e.g. ([),
-        # then there is no content.
-        # The deliminator is extracted from the remaining reference.
-        # Continue resolve the remaining reference.
-        return reference_to_reference_items(remaining_reference, items, deliminator)
-
-    if "$" in content:  # By id
-        items.append(IdItem(content[1:]))
-    elif prev_deliminator == "/" and len(items) == 0:  # By root package
-        items.append(QueryItem(query=f"name={content},isRoot=True"))
-    elif prev_deliminator == "/":  # By package
-        items.append(AttributeItem("content"))
-        items.append(QueryItem(query=f"name={content}"))
-    elif prev_deliminator == "(" and deliminator == ")":  # By query
-        items.append(QueryItem(query=content))
-    elif prev_deliminator == "[" and deliminator == "]":  # By list index
-        items.append(AttributeItem(f"[{content}]"))
-    elif prev_deliminator == ".":  # By attribute
-        items.append(AttributeItem(content))
-    else:
-        raise Exception(f"Not supported reference format: {reference}")
-
-    return reference_to_reference_items(remaining_reference, items, deliminator)
-
-
 @dataclass
 class IdItem:
     """Points to an id."""
 
     id: str
 
-    def resolve(self, document: dict | list, data_source: DataSource, get_data_source: Callable) -> Tuple[dict, str]:
+    def resolve(
+        self, document: dict | list | None, data_source: DataSource, get_data_source: Callable
+    ) -> Tuple[dict, str]:
         # Get the document from the data source
         return data_source.get(self.id), self.id
 
@@ -98,7 +88,7 @@ class QueryItem:
         return query
 
     def resolve(
-        self, document: dict | list, data_source: DataSource, get_data_source: Callable
+        self, document: dict | list | None, data_source: DataSource, get_data_source: Callable
     ) -> Tuple[Union[dict | None], Union[str | None]]:
         # We need to search inside the data source for the document
         if not document:
@@ -137,7 +127,9 @@ class AttributeItem:
     def __repr__(self):
         return f'Attribute="{self.path}"'
 
-    def resolve(self, document: dict | list, data_source: DataSource, get_data_source: Callable) -> Tuple[dict, str]:
+    def resolve(
+        self, document: dict | list | None, data_source: DataSource, get_data_source: Callable
+    ) -> tuple[dict | list | None, str]:
         try:
             result = find(document, [self.path])
         except (IndexError, TypeError, KeyError):
@@ -146,6 +138,61 @@ class AttributeItem:
         if is_reference(result):
             return resolve_reference(f"/{data_source.name}/{result['address']}", get_data_source).entity, self.path
         return result, self.path
+
+
+def reference_to_reference_items(
+    reference: str, items=None, prev_deliminator=None
+) -> list[AttributeItem | QueryItem | IdItem]:
+    """Split up the reference into reference items. DataSourceItem return as first element"""
+
+    if len(reference) == 0:
+        return items
+
+    if not items:
+        items = []
+
+    content, deliminator, remaining_reference = _next_reference_part(reference)
+    if content == "":
+        # If the original reference starts with a deliminator (e.g. /)
+        # or two deliminators are next to each other (e.g. ([),
+        # then there is no content.
+        # The deliminator is extracted from the remaining reference.
+        # Continue resolve the remaining reference.
+        return reference_to_reference_items(remaining_reference, items, deliminator)
+
+    if "$" in content:  # By id
+        items.append(IdItem(content[1:]))
+    elif prev_deliminator == "/" and len(items) == 0:  # By root package
+        items.append(QueryItem(query=f"name={content},isRoot=True"))
+    elif prev_deliminator == "/":  # By package
+        items.append(AttributeItem("content"))
+        items.append(QueryItem(query=f"name={content}"))
+    elif prev_deliminator == "(" and deliminator == ")":  # By query
+        items.append(QueryItem(query=content))
+    elif prev_deliminator == "[" and deliminator == "]":  # By list index
+        items.append(AttributeItem(f"[{content}]"))
+    elif prev_deliminator == ".":  # By attribute
+        items.append(AttributeItem(content))
+    else:
+        raise Exception(f"Not supported reference format: {reference}")
+
+    return reference_to_reference_items(remaining_reference, items, deliminator)
+
+
+def split_data_source_and_reference(reference: str) -> tuple[str, str]:
+    if "://" in reference:  # Expects format: dmss://DATA_SOURCE/(PATH|ID).Attribute"""
+        # The reference points to another data source
+        protocol, address = reference.split("://", 1)
+        if protocol != Protocols.DMSS.value:
+            # Only support one reference type
+            raise NotImplementedError(f"The protocol '{protocol}' is not supported")
+        data_source_id, reference = address.split("/", 1)
+    else:  # Expects format: /DATA_SOURCE/(PATH|ID).Attribute"""
+        reference = reference.strip("/. ")  # Remove leading and trailing stuff
+        data_source_id, reference = reference.split("/", 1)
+
+    # The data source is given, so rest of reference should start with "/"
+    return data_source_id, f"/{reference}"
 
 
 def resolve_reference_items(
@@ -167,6 +214,8 @@ def resolve_reference_items(
         path = [path_element]
     else:
         if resolved_document and "_id" in resolved_document:
+            if isinstance(resolved_document, list):
+                raise NotImplementedError("Support for resolving lists has not been fully implemented")
             # Found a new document, use that as new starting point for the attribute path
             path = [resolved_document["_id"]]
         else:
@@ -180,7 +229,7 @@ class ResolvedReference:
     data_source_id: str
     document_id: str
     attribute_path: str
-    entity: dict
+    entity: dict | list
 
 
 def resolve_reference(reference: str, get_data_source: Callable) -> ResolvedReference:
@@ -188,24 +237,13 @@ def resolve_reference(reference: str, get_data_source: Callable) -> ResolvedRefe
     if not reference:
         raise ApplicationException("Failed to resolve reference. Got empty reference.")
 
-    if "://" in reference:  # Expects format: dmss://DATA_SOURCE/(PATH|ID).Attribute"""
-        # The reference points to another data source
-        protocol, address = reference.split("://", 1)
-        if protocol != Protocols.DMSS.value:
-            # Only support one reference type
-            raise NotImplementedError(f"The protocol '{protocol}' is not supported")
-        data_source_id, reference = address.split("/", 1)
-        data_source = get_data_source(data_source_id)
-        reference = f"/{reference}"  # The data source is given, so should start with an /
-    else:  # Expects format: /DATA_SOURCE/(PATH|ID).Attribute"""
-        reference = reference.strip("/. ")  # Remove leading and trailing stuff
-        data_source_id, reference = reference.split("/", 1)
-        data_source = get_data_source(data_source_id)
-        reference = f"/{reference}"
+    data_source_id, _reference = split_data_source_and_reference(reference)
+    reference_items = reference_to_reference_items(_reference)
 
-    reference_items = reference_to_reference_items(reference)
+    # The first reference item should always be a DataSourceItem
+    data_source = get_data_source(data_source_id)
     document, path = resolve_reference_items(data_source, reference_items, get_data_source)
-    if not document:
+    if document is None:
         raise NotFoundException(
             f"No document found that matches '{reference}', in the data source '{data_source.name}' could be found.",
             debug=str(reference_items),

--- a/src/domain_classes/tree_node.py
+++ b/src/domain_classes/tree_node.py
@@ -209,6 +209,18 @@ class NodeBase:
         next_node = next_node.get_by_path(keys)
         return next_node
 
+    def get_by_ref_part(self, keys: List[str]):
+        # TODO: Only supports AttributeItems now
+        if len(keys) == 0:
+            return self
+
+        next_node = next((x for x in self.children if x.key == keys[0].strip(".")), None)
+        if not next_node:
+            return
+        keys.pop(0)
+        next_node = next_node.get_by_path(keys)
+        return next_node
+
     def remove_by_path(self, keys: List) -> None:
         if len(keys) == 1:
             for index, child in enumerate(self.children):

--- a/src/features/document/document_feature.py
+++ b/src/features/document/document_feature.py
@@ -56,7 +56,7 @@ def update(
     """
     return update_document_use_case(
         user=user,
-        id_reference=id_reference,
+        reference=id_reference,
         data=data,
         files=files,
         update_uncontained=update_uncontained,

--- a/src/features/document/use_cases/update_document_use_case.py
+++ b/src/features/document/use_cases/update_document_use_case.py
@@ -3,7 +3,6 @@ from typing import List, Optional, Union
 from fastapi import File, UploadFile
 
 from authentication.models import User
-from common.utils.string_helpers import split_dmss_ref
 from enums import SIMOS
 from services.document_service import DocumentService
 from storage.internal.data_source_repository import get_data_source
@@ -11,19 +10,16 @@ from storage.internal.data_source_repository import get_data_source
 
 def update_document_use_case(
     user: User,
-    id_reference: str,
+    reference: str,
     data: Union[dict, list],
     files: Optional[List[UploadFile]] = File(None),
     update_uncontained: Optional[bool] = True,
     repository_provider=get_data_source,
 ):
-    data_source_id, document_id, attribute = split_dmss_ref(id_reference)
     document_service = DocumentService(repository_provider=repository_provider, user=user)
     document = document_service.update_document(
-        data_source_id=data_source_id,
-        document_id=document_id,
-        attribute=attribute,
-        data=data,
+        reference,
+        data,
         files={f.filename: f.file for f in files} if files else None,
         update_uncontained=update_uncontained,
     )

--- a/src/tests/unit/common/utils/test_split_reference.py
+++ b/src/tests/unit/common/utils/test_split_reference.py
@@ -1,0 +1,9 @@
+import unittest
+
+from common.utils.resolve_reference import split_reference
+
+
+class SplitReferenceTestCase(unittest.TestCase):
+    def test_remove_last_reference_part(self):
+        reference = "$123-65435634-123.content[1](name=test)(name=test,isRoot=True,yyz=rush)"
+        self.assertEqual("$123-65435634-123.content[1](name=test)", "".join(split_reference(reference)[:-1]))

--- a/src/tests/unit/test_complex_arrays.py
+++ b/src/tests/unit/test_complex_arrays.py
@@ -1,4 +1,5 @@
 import unittest
+from copy import deepcopy
 from unittest import mock, skip
 
 from authentication.models import User
@@ -102,7 +103,7 @@ class ArraysDocumentServiceTestCase(unittest.TestCase):
         }
 
         def mock_get(document_id: str):
-            return doc_storage[document_id]
+            return deepcopy(doc_storage[document_id])
 
         def mock_update(entity: dict, *args, **kwargs):
             doc_storage[entity["_id"]] = entity
@@ -248,7 +249,7 @@ class ArraysDocumentServiceTestCase(unittest.TestCase):
         # fmt: on
 
         def mock_get(document_id: str):
-            return doc_storage[document_id]
+            return deepcopy(doc_storage[document_id])
 
         def mock_update(entity: dict, *args, **kwargs):
             doc_storage[entity["_id"]] = entity
@@ -264,8 +265,7 @@ class ArraysDocumentServiceTestCase(unittest.TestCase):
         document_service = get_mock_document_service(repository_provider, blueprint_provider=blueprint_provider)
         # fmt: off
         document_service.update_document(
-            data_source_id="testing",
-            document_id="$1",
+            reference="dmss://testing/$1",
             data={
                 "_id": "1",
                 "name": "complexArraysEntity",

--- a/src/tests/unit/test_get.py
+++ b/src/tests/unit/test_get.py
@@ -25,7 +25,7 @@ class DocumentServiceTestCase(unittest.TestCase):
                     "type": "test_data/complex/Customer",
                     "name": "Wrong protocol",
                     "car": {
-                        "address": "wrong:///$1.cars.0",
+                        "address": "wrong://$1.cars[0]",
                         "type": SIMOS.REFERENCE.value,
                         "referenceType": REFERENCE_TYPES.LINK.value,
                     },

--- a/src/tests/unit/test_reference.py
+++ b/src/tests/unit/test_reference.py
@@ -201,7 +201,7 @@ class ReferenceTestCase(unittest.TestCase):
         }
 
         def mock_get(document_id: str):
-            return doc_storage[document_id]
+            return deepcopy(doc_storage[document_id])
 
         def mock_update(entity: dict, *args, **kwargs):
             doc_storage[entity["_id"]] = entity

--- a/src/tests/unit/test_remove.py
+++ b/src/tests/unit/test_remove.py
@@ -1,4 +1,5 @@
 import unittest
+from copy import deepcopy
 from unittest import mock
 
 from authentication.models import User
@@ -51,7 +52,7 @@ class DocumentServiceTestCase(unittest.TestCase):
         }
 
         def mock_get(document_id: str):
-            return doc_storage[document_id]
+            return deepcopy(doc_storage[document_id])
 
         def mock_update(entity: dict, *args, **kwargs):
             doc_storage[entity["_id"]] = entity
@@ -238,14 +239,18 @@ class DocumentServiceTestCase(unittest.TestCase):
         }
 
         def mock_get(document_id: str):
-            return doc_storage[document_id]
+            return deepcopy(doc_storage[document_id])
 
         def repository_provider(data_source_id, user: User):
             if data_source_id == "testing":
                 return repository
 
+        def mock_update(entity: dict, *args, **kwargs):
+            doc_storage[entity["_id"]] = entity
+
         repository.get = mock_get
         repository.delete = lambda doc_id: doc_storage.pop(doc_id)
+        repository.update = mock_update
         document_service = get_mock_document_service(repository_provider)
         document_service.remove_document("testing", "1", "im_optional")
         assert {
@@ -270,7 +275,7 @@ class DocumentServiceTestCase(unittest.TestCase):
         }
 
         def mock_get(document_id: str):
-            return doc_storage[document_id]
+            return deepcopy(doc_storage[document_id])
 
         def repository_provider(data_source_id, user: User):
             if data_source_id == "testing":

--- a/src/tests/unit/test_tree_node_update.py
+++ b/src/tests/unit/test_tree_node_update.py
@@ -1,4 +1,5 @@
 import unittest
+from copy import deepcopy
 from unittest import mock
 
 from authentication.models import User
@@ -147,7 +148,7 @@ class DocumentServiceTestCase(unittest.TestCase):
         }
 
         def mock_get(document_id: str):
-            return doc_storage[document_id]
+            return deepcopy(doc_storage[document_id])
 
         def mock_update(entity: dict, *args, **kwargs):
             doc_storage[entity["_id"]] = entity
@@ -197,7 +198,7 @@ class DocumentServiceTestCase(unittest.TestCase):
         }
 
         def mock_get(document_id: str):
-            return doc_storage[document_id]
+            return deepcopy(doc_storage[document_id])
 
         def mock_update(entity: dict, *args, **kwargs):
             doc_storage[entity["_id"]] = entity
@@ -231,7 +232,7 @@ class DocumentServiceTestCase(unittest.TestCase):
         }
 
         def mock_get(document_id: str):
-            return doc_storage[document_id]
+            return deepcopy(doc_storage[document_id])
 
         def mock_update(entity: dict, *args, **kwargs):
             doc_storage[entity["_id"]] = entity
@@ -244,9 +245,7 @@ class DocumentServiceTestCase(unittest.TestCase):
         )
         with self.assertRaises(ValidationException) as error:
             document_service.update_document(
-                data_source_id="testing",
-                document_id="$1",
-                attribute="SomeChild",
+                reference="dmss://testing/$1.SomeChild",
                 data={"name": "whatever", "type": "special_child_no_inherit", "AnExtraValue": "Hallo there!"},
             )
         assert (
@@ -291,7 +290,7 @@ class DocumentServiceTestCase(unittest.TestCase):
         }
 
         def mock_get(document_id: str):
-            return doc_storage[document_id]
+            return deepcopy(doc_storage[document_id])
 
         def mock_update(entity: dict, *args, **kwargs):
             doc_storage[entity["_id"]] = entity
@@ -329,7 +328,7 @@ class DocumentServiceTestCase(unittest.TestCase):
         }
 
         def mock_get(document_id: str):
-            return doc_storage[document_id]
+            return deepcopy(doc_storage[document_id])
 
         def mock_update(entity: dict, *args, **kwargs):
             doc_storage[entity["_id"]] = entity
@@ -351,7 +350,7 @@ class DocumentServiceTestCase(unittest.TestCase):
         doc_storage = {"1": {"_id": "1", "name": "parent", "description": "", "type": "parent", "SomeChild": {}}}
 
         def mock_get(document_id: str):
-            return doc_storage[document_id]
+            return deepcopy(doc_storage[document_id])
 
         def mock_update(entity: dict, *args, **kwargs):
             doc_storage[entity["_id"]] = entity
@@ -362,9 +361,7 @@ class DocumentServiceTestCase(unittest.TestCase):
             lambda id, user: repository, blueprint_provider=MultiTypeBlueprintProvider()
         )
         document_service.update_document(
-            data_source_id="testing",
-            document_id="$1",
-            attribute="SomeChild",
+            reference="dmss://testing/$1.SomeChild",
             data={"name": "whatever", "type": "special_child", "AnExtraValue": "Hallo there!", "AValue": 13},
         )
         assert doc_storage["1"]["SomeChild"] == {
@@ -380,7 +377,7 @@ class DocumentServiceTestCase(unittest.TestCase):
         doc_storage = {"1": {"_id": "1", "name": "parent", "description": "", "type": "parent", "SomeChild": {}}}
 
         def mock_get(document_id: str):
-            return doc_storage[document_id]
+            return deepcopy(doc_storage[document_id])
 
         def mock_update(entity: dict, *args, **kwargs):
             doc_storage[entity["_id"]] = entity
@@ -391,9 +388,7 @@ class DocumentServiceTestCase(unittest.TestCase):
             lambda id, user: repository, blueprint_provider=MultiTypeBlueprintProvider()
         )
         document_service.update_document(
-            data_source_id="testing",
-            document_id="$1",
-            attribute="SomeChild",
+            reference="dmss://testing/$1.SomeChild",
             data={
                 "name": "whatever",
                 "type": "extra_special_child",
@@ -418,7 +413,7 @@ class DocumentServiceTestCase(unittest.TestCase):
         }
 
         def mock_get(document_id: str):
-            return doc_storage[document_id]
+            return deepcopy(doc_storage[document_id])
 
         def mock_update(entity: dict, *args, **kwargs):
             doc_storage[entity["_id"]] = entity
@@ -429,9 +424,7 @@ class DocumentServiceTestCase(unittest.TestCase):
             lambda id, user: repository, blueprint_provider=MultiTypeBlueprintProvider()
         )
         document_service.update_document(
-            data_source_id="testing",
-            document_id="$1",
-            attribute="SomeChild",
+            reference="dmss://testing/$1.SomeChild",
             data=[
                 {"name": "whatever", "type": "special_child", "AnExtraValue": "Hallo there!", "AValue": 13},
                 {
@@ -462,7 +455,7 @@ class DocumentServiceTestCase(unittest.TestCase):
         }
 
         def mock_get(document_id: str):
-            return doc_storage[document_id]
+            return deepcopy(doc_storage[document_id])
 
         def mock_update(entity: dict, *args, **kwargs):
             doc_storage[entity["_id"]] = entity
@@ -475,9 +468,7 @@ class DocumentServiceTestCase(unittest.TestCase):
 
         with self.assertRaises(ValidationException) as error:
             document_service.update_document(
-                data_source_id="testing",
-                document_id="$1",
-                attribute="SomeChild",
+                reference="dmss://testing/$1.SomeChild",
                 data=[
                     {"name": "whatever", "type": "special_child", "AnExtraValue": "Hallo there!", "AValue": 13},
                     {
@@ -501,7 +492,7 @@ class DocumentServiceTestCase(unittest.TestCase):
         }
 
         def mock_get(document_id: str):
-            return doc_storage[document_id]
+            return deepcopy(doc_storage[document_id])
 
         def mock_update(entity: dict, *args, **kwargs):
             doc_storage[entity["_id"]] = entity
@@ -513,8 +504,7 @@ class DocumentServiceTestCase(unittest.TestCase):
         )
 
         document_service.update_document(
-            data_source_id="testing",
-            document_id="$1",
+            reference="dmss://testing/$1",
             data={
                 "_id": "1",
                 "name": "parent",


### PR DESCRIPTION
## What does this pull request change?
- DocumentService.update() now understands "ReferenceItems" when getting the "parentNode" (needed since the main target might not exist
- New utility function to split a reference into the different components
- Moved "split_data_source_and _reference" to separate function, since it's needed outside of "resolve_reference()"
- Fixed a bug in unittests where "save()" where never actually tested, since we passed documents by reference. We now operate on a copy, so that "save()" is properly tested.

## Why is this pull request needed?
- Update failed to operate on items in a list (the bug in the tests caused this to go undiscovered)
- The rest follows from that

## Issues related to this change:
none
