### PR TITLE
fix: ListNode missing 'set_uid' function

### DIFF
--- a/src/domain_classes/tree_node.py
+++ b/src/domain_classes/tree_node.py
@@ -389,6 +389,9 @@ class ListNode(NodeBase):
     def blueprint(self):
         return self.blueprint_provider(self.attribute.attribute_type)  # TODO: blueprint_provider is required now...
 
+    def set_uid(self, new_id: str | None = None):
+        self.uid = None
+
     def update(self, data: list):
         # Replaces the whole list with the new one
         self.children = []


### PR DESCRIPTION
## What does this pull request change?
Adds the "set_uid" function to ListNode

## Why is this pull request needed?
DMSS failed to save a ListNode, since it did not implement the set_uid method

## Issues related to this change:
none
