### PR TITLE
fix: handle more complex reference queries

### DIFF
--- a/src/common/utils/resolve_reference.py
+++ b/src/common/utils/resolve_reference.py
@@ -146,10 +146,10 @@ def reference_to_reference_items(reference: str) -> list[AttributeItem | QueryIt
     """Split up the reference into reference items"""
     queries = re.findall(r"\(([^\)]+)\)", reference)
     if queries:
-        # Split the reference into the pieces surrounding the queries
-        remaining_ref_parts = list(
-            map(lambda x: re.sub(r"\[?\($|^\)\]?", "", x), re.split("|".join(queries), reference))
-        )
+        # Split the reference into the pieces surrounding the queries and remove trailing [( and )]
+        remaining_ref_parts = re.split(re.escape("|".join(queries)), reference)
+        remaining_ref_parts = list(map(lambda x: re.sub(r"\[?\($|^\)\]?", "", x), remaining_ref_parts))
+
         items = _reference_to_reference_items(remaining_ref_parts[0], [], None)
         for index, query in enumerate(queries):
             items.append(QueryItem(query=query))
@@ -171,7 +171,6 @@ def _reference_to_reference_items(reference: str, items, prev_deliminator) -> li
         # Continue resolve the remaining reference.
         return _reference_to_reference_items(remaining_reference, items, deliminator)
 
-    # TODO: Handle queries with paths, ex type=test_data/complex/Customer
     if "$" in content:  # By id
         items.append(IdItem(content[1:]))
     elif prev_deliminator == "/" and len(items) == 0:  # By root package

--- a/src/common/utils/resolve_reference.py
+++ b/src/common/utils/resolve_reference.py
@@ -147,7 +147,7 @@ def reference_to_reference_items(reference: str) -> list[AttributeItem | QueryIt
     queries = re.findall(r"\(([^\)]+)\)", reference)
     if queries:
         # Split the reference into the pieces surrounding the queries and remove trailing [( and )]
-        remaining_ref_parts = re.split(re.escape("|".join(queries)), reference)
+        remaining_ref_parts = re.split("|".join([re.escape(q) for q in queries]), reference)
         remaining_ref_parts = list(map(lambda x: re.sub(r"\[?\($|^\)\]?", "", x), remaining_ref_parts))
 
         items = _reference_to_reference_items(remaining_ref_parts[0], [], None)

--- a/src/tests/unit/common/utils/test_resolve_reference.py
+++ b/src/tests/unit/common/utils/test_resolve_reference.py
@@ -99,6 +99,28 @@ class ResolveReferenceTestCase(unittest.TestCase):
             ],
         )
 
+    def test_reference_with_query_and_slash_to_reference_items(self):
+        reference = "/(name=package,isRoot=True)/subPackage"
+        items = reference_to_reference_items(reference)
+        self.assertEqual(
+            items,
+            [
+                QueryItem(query="name=package,isRoot=True"),
+                AttributeItem(path="content"),
+                QueryItem(query="name=subPackage"),
+            ],
+        )
+
+    def test_reference_with_query_2_to_reference_items(self):
+        reference = "/(type=test_data/complex/Customer)"
+        items = reference_to_reference_items(reference)
+        self.assertEqual(
+            items,
+            [
+                QueryItem(query="type=test_data/complex/Customer"),
+            ],
+        )
+
     def test_reference_with_query_and_attribute_query_to_reference_items(self):
         reference = "/[(_id=1)].attribute(key1=value1,key2=value2)"
         items = reference_to_reference_items(reference)


### PR DESCRIPTION
## What does this pull request change?

Rewrite the reference_to_reference_items function somewhat. Also add tests for catching this issue in the future

## Why is this pull request needed?

References with queries like `type=test_data/complex/Customer` would fail

## Issues related to this change:
