### PR TITLE
feat: attribute-selector as default initial recipe

### DIFF
--- a/src/common/utils/get_storage_recipe.py
+++ b/src/common/utils/get_storage_recipe.py
@@ -28,6 +28,50 @@ default_list_recipe = Recipe(
     }
 )
 
+default_initial_ui_recipe = Recipe(
+    **{
+        "name": "RecipeSelect",
+        "type": SIMOS.UI_RECIPE.value,
+        "plugin": "@development-framework/dm-core-plugins/attribute-selector",
+        "config": {
+            "type": "dmss://system/Plugins/dm-core-plugins/attribute-selector/AttributeSelectorConfig",
+            "asSidebar": False,
+            "items": [
+                {
+                    "type": "dmss://system/Plugins/dm-core-plugins/attribute-selector/AttributeSelectorItem",
+                    "label": "Yaml",
+                    "view": {
+                        "type": "dmss://system/SIMOS/InlineRecipeViewConfig",
+                        "recipe": {
+                            "type": "dmss://system/SIMOS/UiRecipe",
+                            "name": "YAML",
+                            "description": "YAML representation",
+                            "plugin": "@development-framework/dm-core-plugins/yaml",
+                        },
+                        "scope": "self",
+                        "eds_icon": "code",
+                    },
+                },
+                {
+                    "type": "dmss://system/Plugins/dm-core-plugins/attribute-selector/AttributeSelectorItem",
+                    "label": "Edit",
+                    "view": {
+                        "type": "dmss://system/SIMOS/InlineRecipeViewConfig",
+                        "recipe": {
+                            "type": "dmss://system/SIMOS/UiRecipe",
+                            "name": "Edit",
+                            "description": "Default edit",
+                            "plugin": "@development-framework/dm-core-plugins/form",
+                        },
+                        "scope": "self",
+                        "eds_icon": "edit",
+                    },
+                },
+            ],
+        },
+    }
+)
+
 
 def storage_recipe_provider(type: str, context: str | None = None) -> list[StorageRecipe]:
     if not context:

--- a/src/features/blueprint/use_cases/get_blueprint_use_case.py
+++ b/src/features/blueprint/use_cases/get_blueprint_use_case.py
@@ -3,6 +3,7 @@ from pydantic import BaseModel
 from authentication.models import User
 from common.utils.get_storage_recipe import (
     default_form_edit,
+    default_initial_ui_recipe,
     default_list_recipe,
     default_yaml_view,
 )
@@ -51,7 +52,9 @@ def get_blueprint_use_case(type: common_type_constrained_string, context: str | 
 
     return {
         "blueprint": blueprint.to_dict(),
-        "initialUiRecipe": lookup.initial_ui_recipes[type].dict() if lookup.initial_ui_recipes.get(type) else None,
+        "initialUiRecipe": lookup.initial_ui_recipes[type].dict()
+        if lookup.initial_ui_recipes.get(type)
+        else default_initial_ui_recipe.dict(by_alias=True),
         "uiRecipes": [ur.dict(by_alias=True) for ur in ui_recipes],
         "storageRecipes": [sr.dict(by_alias=True) for sr in storage_recipes],
     }


### PR DESCRIPTION
## What does this pull request change?
- Adds 'attribute-selector' as a default initialUiRecipe

## Why is this pull request needed?
DM framework should work with sane defaults

## Issues related to this change:
closes #360 