### PR TITLE
refactor: rename is_same and rewrite queryitem

### DIFF
--- a/src/common/utils/data_structure/has_key_value_pairs.py
+++ b/src/common/utils/data_structure/has_key_value_pairs.py
@@ -1,5 +1,5 @@
-def is_same(target: dict, content: dict):
-    """Util method that for checking that target document contains the content."""
+def has_key_value_pairs(target: dict, content: dict):
+    """Util method for checking that target entity contains the key-value pairs defined in content"""
     is_identical = True
     for key in content:
         if key not in target:

--- a/src/tests/unit/data_structure/test_is_same.py
+++ b/src/tests/unit/data_structure/test_is_same.py
@@ -1,15 +1,15 @@
 import unittest
 
-from common.utils.data_structure.is_same import is_same
+from common.utils.data_structure.has_key_value_pairs import has_key_value_pairs
 
 
 class IsSameTestCase(unittest.TestCase):
     def test_is_same(self):
         target = {"a": "1", "b": "2"}
         content = {"a": "1"}
-        assert is_same(target, content)
+        assert has_key_value_pairs(target, content)
 
     def test_is_not_same(self):
         target = {"a": "1", "b": "2"}
         content = {"a": "2"}
-        assert is_same(target, content) is False
+        assert has_key_value_pairs(target, content) is False

--- a/src/tests/unit/test_get_document/test_reference_resolve.py
+++ b/src/tests/unit/test_get_document/test_reference_resolve.py
@@ -5,7 +5,7 @@ import pytest
 
 from common.tree_node_serializer import tree_node_to_dict
 from common.utils.data_structure.compare import get_and_print_diff
-from common.utils.data_structure.is_same import is_same
+from common.utils.data_structure.has_key_value_pairs import has_key_value_pairs
 from enums import REFERENCE_TYPES, SIMOS, Protocols
 from tests.unit.mock_utils import get_mock_document_service
 
@@ -232,7 +232,7 @@ class GetDocumentResolveTestCase(unittest.TestCase):
 
         def find(target: dict, data_source: list) -> dict:
             """Utility method to be able to search for a document inside a test data source."""
-            hit = next((f for f in data_source if is_same(f, target)), None)
+            hit = next((f for f in data_source if has_key_value_pairs(f, target)), None)
             if hit:
                 return [hit.copy()]
 


### PR DESCRIPTION
## What does this pull request change?

Renames is_same and refactors QueryItem

## Why is this pull request needed?

The function is_same has a misleading name. And QueryItem is hard to read

## Issues related to this change:
