### PR TITLE
refactor: rename test_resolve_reference

### DIFF
--- a/src/tests/unit/common/utils/test_reference_to_reference_items.py
+++ b/src/tests/unit/common/utils/test_reference_to_reference_items.py
@@ -9,7 +9,7 @@ from common.utils.resolve_reference import (
 )
 
 
-class ResolveReferenceTestCase(unittest.TestCase):
+class ReferenceToReferenceItemsTestCase(unittest.TestCase):
     def setUp(self):
         pass
 


### PR DESCRIPTION
## What does this pull request change?

Rename file and class

## Why is this pull request needed?

The file doesn't test resolve_reference, so the name is misleading

## Issues related to this change:
