### PR TITLE
fix: update node list need to remove special symbol before compare to key

### DIFF
--- a/src/common/tree_node_serializer.py
+++ b/src/common/tree_node_serializer.py
@@ -148,7 +148,8 @@ def tree_node_from_dict(
     )
 
     try:
-        node.blueprint
+        if node.attribute.attribute_type != "object":
+            node.blueprint
     except NotFoundException as e:
         raise ApplicationException(f"Failed to find blueprint with reference '{node.type}'", debug=str(e))
 

--- a/src/domain_classes/tree_node.py
+++ b/src/domain_classes/tree_node.py
@@ -224,7 +224,7 @@ class NodeBase:
         if len(keys) == 0:
             return self
 
-        next_node = next((x for x in self.children if x.key == keys[0].strip(".")), None)
+        next_node = next((x for x in self.children if x.key == keys[0].strip(".").strip("[]")), None)
         if not next_node:
             return
         keys.pop(0)


### PR DESCRIPTION
## What does this pull request change?

* When finding a child inside an array the get_by_ref_part takes in [0] but the key inside each node only keeps 0, so when compare need to remove the brackets.  
* Also added so that we don't try to get blueprint for attributes with attribute type object

## Why is this pull request needed?

## Issues related to this change:
