### PR TITLE
refactor: reference object

### DIFF
--- a/src/common/address.py
+++ b/src/common/address.py
@@ -17,9 +17,9 @@ class Address:
 
     @classmethod
     def from_absolute(cls, address: str):
-        """Returns an instance of the Reference class based on the reference input
+        """Returns an instance of the Address class based on the address input
 
-        @param reference: Must be on one of the following formats (.Attribute is optional)
+        @param address: Must be on one of the following formats (.Attribute is optional)
             - dmss://DATA_SOURCE/(PATH|$ID).Attribute
             - DATA_SOURCE/(PATH|$ID).Attribute
             - /DATA_SOURCE/(PATH|$ID).Attribute

--- a/src/common/address.py
+++ b/src/common/address.py
@@ -19,10 +19,10 @@ class Address:
     def from_absolute(cls, address: str):
         """Returns an instance of the Reference class based on the reference input
 
-        @param reference: Must be on one of the following formats
-            - dmss://DATA_SOURCE/(PATH|ID).Attribute
-            - DATA_SOURCE/(PATH|ID).Attribute
-            - /DATA_SOURCE/(PATH|ID).Attribute
+        @param reference: Must be on one of the following formats (.Attribute is optional)
+            - dmss://DATA_SOURCE/(PATH|$ID).Attribute
+            - DATA_SOURCE/(PATH|$ID).Attribute
+            - /DATA_SOURCE/(PATH|$ID).Attribute
         """
         protocol = Protocols.DMSS.value
         path = None

--- a/src/common/address.py
+++ b/src/common/address.py
@@ -2,7 +2,7 @@ from common.exceptions import ApplicationException
 from enums import Protocols
 
 
-class Reference:
+class Address:
     def __repr__(self):
         path = f"/{self.path}" if self.path else ""
         return f"{self.protocol}://{self.data_source}{path}"
@@ -16,7 +16,7 @@ class Reference:
         self.path = path
 
     @classmethod
-    def fromabsolute(cls, reference: str):
+    def fromabsolute(cls, address: str):
         """Returns an instance of the Reference class based on the reference input
 
         @param reference: Must be on one of the following formats
@@ -26,23 +26,23 @@ class Reference:
         """
         protocol = Protocols.DMSS.value
         path = None
-        reference = reference.strip("/. ")
-        if "://" in reference:
-            protocol, reference = reference.split("://", 1)
-        if "/" in reference:
-            reference, path = reference.split("/", 1)
-        return cls(path, reference, protocol)
+        address = address.strip("/. ")
+        if "://" in address:
+            protocol, address = address.split("://", 1)
+        if "/" in address:
+            address, path = address.split("/", 1)
+        return cls(path, address, protocol)
 
     @classmethod
-    def fromrelative(cls, reference: str, document_id: str | None, data_source: str):
-        if "://" in reference:
+    def fromrelative(cls, address: str, document_id: str | None, data_source: str):
+        if "://" in address:
             # Already contains protocol and data source
-            return cls.fromabsolute(reference)
-        elif reference.startswith("^"):
+            return cls.fromabsolute(address)
+        elif address.startswith("^"):
             if not document_id:
                 raise ApplicationException(
                     "Document id is missing and therefore it is not possible to replace ^ with an id reference."
                 )
-            return cls(reference.replace("^", f"${document_id}"), data_source)
+            return cls(address.replace("^", f"${document_id}"), data_source)
         else:
-            return cls(reference, data_source)
+            return cls(address, data_source)

--- a/src/common/address.py
+++ b/src/common/address.py
@@ -16,7 +16,7 @@ class Address:
         self.path = path
 
     @classmethod
-    def fromabsolute(cls, address: str):
+    def from_absolute(cls, address: str):
         """Returns an instance of the Reference class based on the reference input
 
         @param reference: Must be on one of the following formats
@@ -34,10 +34,10 @@ class Address:
         return cls(path, address, protocol)
 
     @classmethod
-    def fromrelative(cls, address: str, document_id: str | None, data_source: str):
+    def from_relative(cls, address: str, document_id: str | None, data_source: str):
         if "://" in address:
             # Already contains protocol and data source
-            return cls.fromabsolute(address)
+            return cls.from_absolute(address)
         elif address.startswith("^"):
             if not document_id:
                 raise ApplicationException(

--- a/src/common/reference.py
+++ b/src/common/reference.py
@@ -31,7 +31,7 @@ class Reference:
             protocol, reference = reference.split("://", 1)
         if "/" in reference:
             reference, path = reference.split("/", 1)
-        return cls(f"/{path}", reference, protocol)
+        return cls(path, reference, protocol)
 
     @classmethod
     def fromrelative(cls, reference: str, document_id: str | None, data_source: str):

--- a/src/common/reference.py
+++ b/src/common/reference.py
@@ -1,0 +1,48 @@
+from common.exceptions import ApplicationException
+from enums import Protocols
+
+
+class Reference:
+    def __repr__(self):
+        path = f"/{self.path}" if self.path else ""
+        return f"{self.protocol}://{self.data_source}{path}"
+
+    def __init__(self, path: str | None, data_source: str, protocol: str = Protocols.DMSS.value):
+        if protocol and protocol != Protocols.DMSS.value:
+            # Only support one reference type
+            raise NotImplementedError(f"The protocol '{protocol}' is not supported")
+        self.protocol = protocol
+        self.data_source = data_source
+        self.path = path
+
+    @classmethod
+    def fromabsolute(cls, reference: str):
+        """Returns an instance of the Reference class based on the reference input
+
+        @param reference: Must be on one of the following formats
+            - dmss://DATA_SOURCE/(PATH|ID).Attribute
+            - DATA_SOURCE/(PATH|ID).Attribute
+            - /DATA_SOURCE/(PATH|ID).Attribute
+        """
+        protocol = Protocols.DMSS.value
+        path = None
+        reference = reference.strip("/. ")
+        if "://" in reference:
+            protocol, reference = reference.split("://", 1)
+        if "/" in reference:
+            reference, path = reference.split("/", 1)
+        return cls(f"/{path}", reference, protocol)
+
+    @classmethod
+    def fromrelative(cls, reference: str, document_id: str | None, data_source: str):
+        if "://" in reference:
+            # Already contains protocol and data source
+            return cls.fromabsolute(reference)
+        elif reference.startswith("^"):
+            if not document_id:
+                raise ApplicationException(
+                    "Document id is missing and therefore it is not possible to replace ^ with an id reference."
+                )
+            return cls(reference.replace("^", f"${document_id}"), data_source)
+        else:
+            return cls(reference, data_source)

--- a/src/common/utils/get_address.py
+++ b/src/common/utils/get_address.py
@@ -1,7 +1,0 @@
-def get_address(data_source_id: str, reference: dict) -> str:
-    """Utility method to get address of reference"""
-    if "://" in reference["address"]:
-        # Already contains a data source id
-        return reference["address"]
-    else:
-        return f"{data_source_id}/{reference['address']}"

--- a/src/common/utils/get_blueprint.py
+++ b/src/common/utils/get_blueprint.py
@@ -1,7 +1,7 @@
 from functools import lru_cache
 
 from authentication.models import User
-from common.utils.get_address import get_address
+from common.reference import Reference
 from common.utils.logging import logger
 from common.utils.resolve_reference import ResolvedReference, resolve_reference
 from config import config
@@ -17,10 +17,12 @@ class BlueprintProvider:
     def get_blueprint(self, type: str) -> Blueprint:
         logger.debug(f"Cache miss! Fetching blueprint '{type}'")
         resolved_reference: ResolvedReference = resolve_reference(
-            type, lambda data_source_name: get_data_source(data_source_name, self.user)
+            Reference.fromabsolute(type), lambda data_source_name: get_data_source(data_source_name, self.user)
         )
         resolved_reference = resolve_reference(
-            get_address(resolved_reference.data_source_id, resolved_reference.entity),
+            Reference.fromrelative(
+                resolved_reference.entity["address"], resolved_reference.document_id, resolved_reference.data_source_id
+            ),
             lambda data_source_name: get_data_source(data_source_name, self.user),
         )
         return Blueprint(resolved_reference.entity, type)

--- a/src/common/utils/get_blueprint.py
+++ b/src/common/utils/get_blueprint.py
@@ -1,7 +1,7 @@
 from functools import lru_cache
 
 from authentication.models import User
-from common.reference import Reference
+from common.address import Address
 from common.utils.logging import logger
 from common.utils.resolve_reference import ResolvedReference, resolve_reference
 from config import config
@@ -17,10 +17,10 @@ class BlueprintProvider:
     def get_blueprint(self, type: str) -> Blueprint:
         logger.debug(f"Cache miss! Fetching blueprint '{type}'")
         resolved_reference: ResolvedReference = resolve_reference(
-            Reference.fromabsolute(type), lambda data_source_name: get_data_source(data_source_name, self.user)
+            Address.fromabsolute(type), lambda data_source_name: get_data_source(data_source_name, self.user)
         )
         resolved_reference = resolve_reference(
-            Reference.fromrelative(
+            Address.fromrelative(
                 resolved_reference.entity["address"], resolved_reference.document_id, resolved_reference.data_source_id
             ),
             lambda data_source_name: get_data_source(data_source_name, self.user),

--- a/src/common/utils/get_blueprint.py
+++ b/src/common/utils/get_blueprint.py
@@ -17,10 +17,10 @@ class BlueprintProvider:
     def get_blueprint(self, type: str) -> Blueprint:
         logger.debug(f"Cache miss! Fetching blueprint '{type}'")
         resolved_reference: ResolvedReference = resolve_reference(
-            Address.fromabsolute(type), lambda data_source_name: get_data_source(data_source_name, self.user)
+            Address.from_absolute(type), lambda data_source_name: get_data_source(data_source_name, self.user)
         )
         resolved_reference = resolve_reference(
-            Address.fromrelative(
+            Address.from_relative(
                 resolved_reference.entity["address"], resolved_reference.document_id, resolved_reference.data_source_id
             ),
             lambda data_source_name: get_data_source(data_source_name, self.user),

--- a/src/common/utils/get_resolved_document_by_id.py
+++ b/src/common/utils/get_resolved_document_by_id.py
@@ -60,12 +60,12 @@ def get_complete_sys_document(
 ) -> dict | list:
     if not reference["address"]:
         raise ApplicationException("Invalid link. Missing 'address'", data=reference)
-    address = Address.fromrelative(reference["address"], current_id, data_source.name)
+    address = Address.from_relative(reference["address"], current_id, data_source.name)
 
     resolved_reference: ResolvedReference = resolve_reference(address, get_data_source)
     if is_reference(resolved_reference.entity) and resolve_links:
         resolved_reference = resolve_reference(
-            Address.fromrelative(
+            Address.from_relative(
                 resolved_reference.entity["address"], resolved_reference.document_id, resolved_reference.data_source_id
             ),
             get_data_source,

--- a/src/common/utils/get_resolved_document_by_id.py
+++ b/src/common/utils/get_resolved_document_by_id.py
@@ -1,5 +1,5 @@
+from common.address import Address
 from common.exceptions import ApplicationException
-from common.reference import Reference
 from common.utils.is_reference import is_link, is_reference
 from common.utils.resolve_reference import ResolvedReference, resolve_reference
 from storage.data_source_class import DataSource
@@ -60,12 +60,12 @@ def get_complete_sys_document(
 ) -> dict | list:
     if not reference["address"]:
         raise ApplicationException("Invalid link. Missing 'address'", data=reference)
-    address = Reference.fromrelative(reference["address"], current_id, data_source.name)
+    address = Address.fromrelative(reference["address"], current_id, data_source.name)
 
     resolved_reference: ResolvedReference = resolve_reference(address, get_data_source)
     if is_reference(resolved_reference.entity) and resolve_links:
         resolved_reference = resolve_reference(
-            Reference.fromrelative(
+            Address.fromrelative(
                 resolved_reference.entity["address"], resolved_reference.document_id, resolved_reference.data_source_id
             ),
             get_data_source,

--- a/src/common/utils/package_import.py
+++ b/src/common/utils/package_import.py
@@ -4,8 +4,8 @@ from typing import Dict, List
 from uuid import uuid4
 
 from authentication.models import User
+from common.address import Address
 from common.exceptions import BadRequestException, NotFoundException
-from common.reference import Reference
 from common.utils.logging import logger
 from common.utils.resolve_reference import ResolvedReference, resolve_reference
 from common.utils.string_helpers import url_safe_name
@@ -43,7 +43,7 @@ def import_package(path: str, user: User, data_source_name: str, is_root: bool =
     package = {"name": os.path.basename(path), "type": SIMOS.PACKAGE.value, "isRoot": is_root}
     try:
         resolved_reference: ResolvedReference = resolve_reference(
-            Reference(package["name"], data_source.name),
+            Address(package["name"], data_source.name),
             lambda data_source_name: get_data_source(data_source_name, user),
         )
         if resolved_reference.entity:

--- a/src/common/utils/package_import.py
+++ b/src/common/utils/package_import.py
@@ -5,6 +5,7 @@ from uuid import uuid4
 
 from authentication.models import User
 from common.exceptions import BadRequestException, NotFoundException
+from common.reference import Reference
 from common.utils.logging import logger
 from common.utils.resolve_reference import ResolvedReference, resolve_reference
 from common.utils.string_helpers import url_safe_name
@@ -37,12 +38,12 @@ def _add_documents(path, documents, data_source) -> List[Dict]:
     return docs
 
 
-def import_package(path, user: User, data_source_name: str, is_root: bool = False) -> dict:
+def import_package(path: str, user: User, data_source_name: str, is_root: bool = False) -> dict:
     data_source: DataSource = get_data_source(data_source_id=data_source_name, user=user)
     package = {"name": os.path.basename(path), "type": SIMOS.PACKAGE.value, "isRoot": is_root}
     try:
         resolved_reference: ResolvedReference = resolve_reference(
-            f"dmss://{data_source.name}/{package['name']}",
+            Reference(package["name"], data_source.name),
             lambda data_source_name: get_data_source(data_source_name, user),
         )
         if resolved_reference.entity:

--- a/src/common/utils/resolve_reference.py
+++ b/src/common/utils/resolve_reference.py
@@ -3,11 +3,10 @@ from dataclasses import dataclass
 from typing import Any, Callable, Tuple, Union
 
 from common.exceptions import ApplicationException, NotFoundException
+from common.reference import Reference
 from common.utils.data_structure.find import find
 from common.utils.data_structure.has_key_value_pairs import has_key_value_pairs
-from common.utils.get_address import get_address
 from common.utils.is_reference import is_reference
-from enums import Protocols
 from storage.data_source_class import DataSource
 
 
@@ -102,18 +101,28 @@ class QueryItem:
             )
         return result[0], result[0]["_id"]
 
-    def get_child(self, document: dict | list, data_source: DataSource, get_data_source: Callable) -> Tuple[Any, str]:
-        if isinstance(document, dict) and is_reference(document):
-            document = resolve_reference(get_address(data_source.name, document), get_data_source).entity
+    def get_child(
+        self, entity: dict | list, document_id: str, data_source: DataSource, get_data_source: Callable
+    ) -> Tuple[Any, str]:
+        if isinstance(entity, dict) and is_reference(entity):
+            resolvedRef = resolve_reference(
+                Reference.fromrelative(entity["address"], document_id, data_source.name), get_data_source
+            )
+            entity = resolvedRef.entity
+            document_id = resolvedRef.document_id
 
         # Search inside an existing document (need to resolve any references first before trying to compare against filter)
         elements = [
-            resolve_reference(f"/{data_source.name}/{f['address']}", get_data_source).entity if is_reference(f) else f
-            for f in document
+            resolve_reference(
+                Reference.fromrelative(f["address"], document_id, data_source.name), get_data_source
+            ).entity
+            if is_reference(f)
+            else f
+            for f in entity
         ]  # Resolve any references
         for index, element in enumerate(elements):
             if isinstance(element, dict) and has_key_value_pairs(element, self.query_as_dict):
-                return document[index], f"[{index}]"
+                return entity[index], f"[{index}]"
         raise NotFoundException(f"No object matches filter '{self.query_as_str}'", data={"elements": elements})
 
 
@@ -126,18 +135,22 @@ class AttributeItem:
     def __repr__(self):
         return f'Attribute="{self.path}"'
 
-    def get_child(self, document: dict | list, data_source: DataSource, get_data_source: Callable) -> tuple[Any, str]:
-        if isinstance(document, dict) and is_reference(document):
-            document = resolve_reference(get_address(data_source.name, document), get_data_source).entity
+    def get_child(
+        self, entity: dict | list, document_id: str, data_source: DataSource, get_data_source: Callable
+    ) -> tuple[Any, str]:
+        if isinstance(entity, dict) and is_reference(entity):
+            entity = resolve_reference(
+                Reference.fromrelative(entity["address"], document_id, data_source.name), get_data_source
+            ).entity
         try:
-            result = find(document, [self.path])
+            result = find(entity, [self.path])
         except (IndexError, ValueError, KeyError):
-            if isinstance(document, dict):
+            if isinstance(entity, dict):
                 raise NotFoundException(
-                    f"Invalid attribute '{self.path}'. Valid attributes are '{list(document.keys())}'."
+                    f"Invalid attribute '{self.path}'. Valid attributes are '{list(entity.keys())}'."
                 )
             else:
-                raise NotFoundException(f"Invalid index '{self.path}'. Valid indices are < {len(document)}.")
+                raise NotFoundException(f"Invalid index '{self.path}'. Valid indices are < {len(entity)}.")
 
         return result, self.path
 
@@ -175,7 +188,7 @@ def _reference_to_reference_items(reference: str, items, prev_deliminator) -> li
 
     if "$" in content:  # By id
         items.append(IdItem(content[1:]))
-    elif prev_deliminator == "/" and len(items) == 0:  # By root package
+    elif len(items) == 0:  # By root package
         items.append(QueryItem(query=f"name={content},isRoot=True"))
     elif prev_deliminator == "/":  # By package
         items.append(AttributeItem("content"))
@@ -190,22 +203,6 @@ def _reference_to_reference_items(reference: str, items, prev_deliminator) -> li
     return _reference_to_reference_items(remaining_reference, items, deliminator)
 
 
-def split_data_source_and_reference(reference: str) -> tuple[str, str]:
-    if "://" in reference:  # Expects format: dmss://DATA_SOURCE/(PATH|ID).Attribute"""
-        # The reference points to another data source
-        protocol, address = reference.split("://", 1)
-        if protocol != Protocols.DMSS.value:
-            # Only support one reference type
-            raise NotImplementedError(f"The protocol '{protocol}' is not supported")
-        data_source_id, reference = address.split("/", 1)
-    else:  # Expects format: /DATA_SOURCE/(PATH|ID).Attribute"""
-        reference = reference.strip("/. ")  # Remove leading and trailing stuff
-        data_source_id, reference = reference.split("/", 1)
-
-    # The data source is given, so rest of reference should start with "/"
-    return data_source_id, f"/{reference}"
-
-
 def resolve_reference_items(
     data_source: DataSource,
     reference_items: list[AttributeItem | QueryItem | IdItem],
@@ -213,20 +210,22 @@ def resolve_reference_items(
 ) -> tuple[list | dict, list[str]]:
     if len(reference_items) == 0 or isinstance(reference_items[0], AttributeItem):
         raise NotFoundException(f"Invalid reference_items {reference_items}.")
-    document, id = reference_items[0].get_entry_point(data_source)
+    entity, id = reference_items[0].get_entry_point(data_source)
     path = [id]
     for index, ref_item in enumerate(reference_items[1:]):
         if isinstance(ref_item, IdItem):
             raise NotFoundException(f"Invalid reference_items {reference_items}.")
-        document, attribute = ref_item.get_child(document, data_source, get_data_source)
-        if isinstance(document, dict) and "address" in document and index < len(reference_items) - 2:
+        entity, attribute = ref_item.get_child(entity, path[0], data_source, get_data_source)
+        if is_reference(entity) and index < len(reference_items) - 2:
             # Found a new document, use that as new starting point for the attribute path
-            path = [document["address"][1:]]
+            ref_obj = Reference.fromrelative(entity["address"], path[0], data_source.name)
+            resolved_reference = resolve_reference(ref_obj, get_data_source)
+            path = [resolved_reference.document_id, *resolved_reference.attribute_path]
         else:
             path.append(attribute)
-        if not isinstance(document, (list, dict)):
+        if not isinstance(entity, (list, dict)):
             raise NotFoundException(f"Path {path} leads to a primitive value.")
-    return document, path
+    return entity, path
 
 
 @dataclass(frozen=True)
@@ -237,20 +236,19 @@ class ResolvedReference:
     entity: dict | list
 
 
-def resolve_reference(reference: str, get_data_source: Callable) -> ResolvedReference:
+def resolve_reference(reference: Reference, get_data_source: Callable) -> ResolvedReference:
     """Resolve the reference into a document."""
-    if not reference:
+    if not reference.path:
         raise ApplicationException("Failed to resolve reference. Got empty reference.")
 
-    data_source_id, _reference = split_data_source_and_reference(reference)
-    reference_items = reference_to_reference_items(_reference)
+    reference_items = reference_to_reference_items(reference.path)
 
     # The first reference item should always be a DataSourceItem
-    data_source = get_data_source(data_source_id)
+    data_source = get_data_source(reference.data_source)
     document, path = resolve_reference_items(data_source, reference_items, get_data_source)
     return ResolvedReference(
         entity=document,
-        data_source_id=data_source_id,
+        data_source_id=reference.data_source,
         document_id=str(path[0]),
         attribute_path=path[1:],
     )

--- a/src/common/utils/resolve_reference.py
+++ b/src/common/utils/resolve_reference.py
@@ -106,7 +106,7 @@ class QueryItem:
     ) -> Tuple[Any, str]:
         if isinstance(entity, dict) and is_reference(entity):
             resolvedRef = resolve_reference(
-                Address.fromrelative(entity["address"], document_id, data_source.name), get_data_source
+                Address.from_relative(entity["address"], document_id, data_source.name), get_data_source
             )
             entity = resolvedRef.entity
             document_id = resolvedRef.document_id
@@ -114,7 +114,7 @@ class QueryItem:
         # Search inside an existing document (need to resolve any references first before trying to compare against filter)
         elements = [
             resolve_reference(
-                Address.fromrelative(f["address"], document_id, data_source.name), get_data_source
+                Address.from_relative(f["address"], document_id, data_source.name), get_data_source
             ).entity
             if is_reference(f)
             else f
@@ -140,7 +140,7 @@ class AttributeItem:
     ) -> tuple[Any, str]:
         if isinstance(entity, dict) and is_reference(entity):
             entity = resolve_reference(
-                Address.fromrelative(entity["address"], document_id, data_source.name), get_data_source
+                Address.from_relative(entity["address"], document_id, data_source.name), get_data_source
             ).entity
         try:
             result = find(entity, [self.path])
@@ -218,7 +218,7 @@ def resolve_reference_items(
         entity, attribute = ref_item.get_child(entity, path[0], data_source, get_data_source)
         if is_reference(entity) and index < len(reference_items) - 2:
             # Found a new document, use that as new starting point for the attribute path
-            address = Address.fromrelative(entity["address"], path[0], data_source.name)
+            address = Address.from_relative(entity["address"], path[0], data_source.name)
             resolved_reference = resolve_reference(address, get_data_source)
             path = [resolved_reference.document_id, *resolved_reference.attribute_path]
         else:

--- a/src/common/utils/resolve_reference.py
+++ b/src/common/utils/resolve_reference.py
@@ -105,11 +105,11 @@ class QueryItem:
         self, entity: dict | list, document_id: str, data_source: DataSource, get_data_source: Callable
     ) -> Tuple[Any, str]:
         if isinstance(entity, dict) and is_reference(entity):
-            resolvedRef = resolve_reference(
+            resolved_ref = resolve_reference(
                 Address.from_relative(entity["address"], document_id, data_source.name), get_data_source
             )
-            entity = resolvedRef.entity
-            document_id = resolvedRef.document_id
+            entity = resolved_ref.entity
+            document_id = resolved_ref.document_id
 
         # Search inside an existing document (need to resolve any references first before trying to compare against filter)
         elements = [
@@ -239,7 +239,7 @@ class ResolvedReference:
 def resolve_reference(address: Address, get_data_source: Callable) -> ResolvedReference:
     """Resolve the reference into a document."""
     if not address.path:
-        raise ApplicationException("Failed to resolve reference. Got empty reference.")
+        raise ApplicationException("Failed to resolve reference. Got empty address path.")
 
     reference_items = reference_to_reference_items(address.path)
 

--- a/src/common/utils/string_helpers.py
+++ b/src/common/utils/string_helpers.py
@@ -1,5 +1,4 @@
 import re
-from typing import Tuple, Union
 
 from enums import BuiltinDataTypes
 
@@ -12,23 +11,6 @@ from enums import BuiltinDataTypes
 
 # DMSS_REFERENCE = {PATH_REFERENCE, ID_REFERENCE}
 # ABSOLUTE_REFERENCE = PROTOCOL://ADDRESS
-
-
-def split_dmss_ref(dmss_reference: str) -> Tuple[str, Union[str, None], Union[str, None]]:
-    """Will split 'path_references' and 'id_references' into it's 3 parts.
-    Expects format; DATA_SOURCE/(PATH|ID).Attribute"""
-    dmss_reference = dmss_reference.strip("/. ")  # Remove leading and trailing stuff
-    if "/" not in dmss_reference:  # It's reference to the data_source itself
-        return dmss_reference, None, None
-    data_source, dotted_id = dmss_reference.split("/", 1)
-    document_id, attributes = split_dotted_id(dotted_id)
-    return data_source, document_id, attributes
-
-
-def split_dotted_id(dotted_id: str) -> Tuple[str, str | None]:
-    if "." not in dotted_id:  # No attribute path in the id
-        return dotted_id, None
-    return dotted_id.split(".", 1)  # type: ignore
 
 
 # Convert dmt attribute_types to python types. If complex, return type as string.

--- a/src/features/attribute/attribute_feature.py
+++ b/src/features/attribute/attribute_feature.py
@@ -11,14 +11,14 @@ router = APIRouter(tags=["default", "attribute"], prefix="/attribute")
 
 
 @router.get(
-    "/{reference:path}",
+    "/{address:path}",
     operation_id="attribute_get",
     response_model=dict,
     responses=responses,
 )
 @create_response(JSONResponse)
-def get_attribute(reference: str, user: User = Depends(auth_w_jwt_or_pat)):
+def get_attribute(address: str, user: User = Depends(auth_w_jwt_or_pat)):
     """
-    Fetch the attribute from a reference.
+    Fetch the attribute from a address.
     """
-    return get_attribute_use_case(user=user, reference=reference)
+    return get_attribute_use_case(user=user, address=address)

--- a/src/features/attribute/use_cases/get_attribute_use_case.py
+++ b/src/features/attribute/use_cases/get_attribute_use_case.py
@@ -1,4 +1,5 @@
 from authentication.models import User
+from common.reference import Reference
 from domain_classes.tree_node import Node
 from services.document_service import DocumentService
 from storage.internal.data_source_repository import get_data_source
@@ -11,7 +12,5 @@ def get_attribute_use_case(
 ):
     """Get attribute by reference."""
     document_service = DocumentService(repository_provider=repository_provider, user=user)
-    if "://" not in reference:
-        reference = f"/{reference}"
-    node: Node = document_service.get_document(reference)
+    node: Node = document_service.get_document(Reference.fromabsolute(reference))
     return node.attribute.to_dict()

--- a/src/features/attribute/use_cases/get_attribute_use_case.py
+++ b/src/features/attribute/use_cases/get_attribute_use_case.py
@@ -1,16 +1,16 @@
 from authentication.models import User
-from common.reference import Reference
+from common.address import Address
 from domain_classes.tree_node import Node
 from services.document_service import DocumentService
 from storage.internal.data_source_repository import get_data_source
 
 
 def get_attribute_use_case(
-    reference: str,
+    address: str,
     user: User,
     repository_provider=get_data_source,
 ):
     """Get attribute by reference."""
     document_service = DocumentService(repository_provider=repository_provider, user=user)
-    node: Node = document_service.get_document(Reference.fromabsolute(reference))
+    node: Node = document_service.get_document(Address.fromabsolute(address))
     return node.attribute.to_dict()

--- a/src/features/attribute/use_cases/get_attribute_use_case.py
+++ b/src/features/attribute/use_cases/get_attribute_use_case.py
@@ -12,5 +12,5 @@ def get_attribute_use_case(
 ):
     """Get attribute by reference."""
     document_service = DocumentService(repository_provider=repository_provider, user=user)
-    node: Node = document_service.get_document(Address.fromabsolute(address))
+    node: Node = document_service.get_document(Address.from_absolute(address))
     return node.attribute.to_dict()

--- a/src/features/blueprint/blueprint_feature.py
+++ b/src/features/blueprint/blueprint_feature.py
@@ -34,13 +34,11 @@ def get_blueprint(
     return get_blueprint_use_case(type_ref, context, user)
 
 
-@router.get(
-    "/resolve-path/{absolute_id:path}", operation_id="blueprint_resolve", response_model=str, responses=responses
-)
+@router.get("/resolve-path/{address:path}", operation_id="blueprint_resolve", response_model=str, responses=responses)
 @create_response(PlainTextResponse)
-def resolve_blueprint_id(absolute_id: str, user: User = Depends(auth_w_jwt_or_pat)):
-    """Resolve absolute_id of a blueprint to its type path.
+def resolve_blueprint_id(address: str, user: User = Depends(auth_w_jwt_or_pat)):
+    """Resolve address of a blueprint to its type path.
 
-    - **absolute_id**: <data_source</<blueprint_uuid>
+    - **address**: <data_source</<blueprint_uuid>
     """
-    return resolve_blueprint_use_case(user=user, absolute_id=absolute_id)
+    return resolve_blueprint_use_case(user=user, address=address)

--- a/src/features/blueprint/blueprint_feature.py
+++ b/src/features/blueprint/blueprint_feature.py
@@ -39,6 +39,6 @@ def get_blueprint(
 def resolve_blueprint_id(address: str, user: User = Depends(auth_w_jwt_or_pat)):
     """Resolve address of a blueprint to its type path.
 
-    - **address**: <data_source</<blueprint_uuid>
+    - **address**: <protocol>://<data_source</$<blueprint_uuid>
     """
     return resolve_blueprint_use_case(user=user, address=address)

--- a/src/features/blueprint/use_cases/resolve_blueprint_use_case.py
+++ b/src/features/blueprint/use_cases/resolve_blueprint_use_case.py
@@ -24,7 +24,7 @@ def resolve_references(values: list, data_source_id: str, user: User) -> list:
     data_source: DataSource = get_data_source(data_source_id, user)
     return [
         resolve_reference(
-            Address(value["address"], data_source.name),  # TODO Can address contain data source and protocol?
+            Address.fromrelative(value["address"], None, data_source.name),
             lambda data_source_name: get_data_source(data_source_name, user),
         ).entity
         for value in values

--- a/src/features/blueprint/use_cases/resolve_blueprint_use_case.py
+++ b/src/features/blueprint/use_cases/resolve_blueprint_use_case.py
@@ -54,4 +54,4 @@ def resolve_blueprint_use_case(user: User, address: str):
         root_package_found = package["isRoot"]
         next_document_id = f"${package['_id']}"
     path_elements.reverse()
-    return address_obj.protocol + "://" + address_obj.data_source + "/" + "/".join(path_elements)
+    return f"{address_obj.protocol}://{address_obj.data_source}/{'/'.join(path_elements)}"

--- a/src/features/blueprint/use_cases/resolve_blueprint_use_case.py
+++ b/src/features/blueprint/use_cases/resolve_blueprint_use_case.py
@@ -24,7 +24,7 @@ def resolve_references(values: list, data_source_id: str, user: User) -> list:
     data_source: DataSource = get_data_source(data_source_id, user)
     return [
         resolve_reference(
-            Address.fromrelative(value["address"], None, data_source.name),
+            Address.from_relative(value["address"], None, data_source.name),
             lambda data_source_name: get_data_source(data_source_name, user),
         ).entity
         for value in values
@@ -32,7 +32,7 @@ def resolve_references(values: list, data_source_id: str, user: User) -> list:
 
 
 def resolve_blueprint_use_case(user: User, address: str):
-    address_obj = Address.fromabsolute(address)
+    address_obj = Address.from_absolute(address)
     path_elements = []
     if not address_obj.path or not re.search(r"^\$[a-z0-9]+$", address_obj.path):
         raise ApplicationException(f"Incorrect address {address}. Address should point directly to an id")

--- a/src/features/blueprint/use_cases/resolve_blueprint_use_case.py
+++ b/src/features/blueprint/use_cases/resolve_blueprint_use_case.py
@@ -1,10 +1,10 @@
+import re
 from typing import List
 
 from authentication.models import User
-from common.exceptions import NotFoundException
-from common.reference import Reference
+from common.address import Address
+from common.exceptions import ApplicationException, NotFoundException
 from common.utils.resolve_reference import resolve_reference
-from common.utils.string_helpers import split_dmss_ref
 from enums import SIMOS
 from storage.data_source_class import DataSource
 from storage.internal.data_source_repository import get_data_source
@@ -24,33 +24,34 @@ def resolve_references(values: list, data_source_id: str, user: User) -> list:
     data_source: DataSource = get_data_source(data_source_id, user)
     return [
         resolve_reference(
-            Reference(value["address"], data_source.name),  # TODO Can address contain data source and protocol?
+            Address(value["address"], data_source.name),  # TODO Can address contain data source and protocol?
             lambda data_source_name: get_data_source(data_source_name, user),
         ).entity
         for value in values
     ]
 
 
-def resolve_blueprint_use_case(user: User, absolute_id: str):
-    data_source_id, document_id, attr = split_dmss_ref(absolute_id)
+def resolve_blueprint_use_case(user: User, address: str):
+    address_obj = Address.fromabsolute(address)
     path_elements = []
-    protocol_prefix = "dmss://"
-    package = find_package_with_document(data_source_id, document_id, user)
+    if not address_obj.path or not re.search(r"^\$[a-z0-9]+$", address_obj.path):
+        raise ApplicationException(f"Incorrect address {address}. Address should point directly to an id")
+    package = find_package_with_document(address_obj.data_source, address_obj.path, user)
     root_package_found = package["isRoot"]
     blueprint_name = next(
         (
             c["name"]
-            for c in resolve_references(package["content"], data_source_id, user)
-            if f"${c['_id']}" == document_id
+            for c in resolve_references(package["content"], address_obj.data_source, user)
+            if f"${c['_id']}" == address_obj.path
         )
     )
     path_elements.append(blueprint_name)
     path_elements.append(package["name"])
     next_document_id = f"${package['_id']}"
     while not root_package_found:
-        package = find_package_with_document(data_source_id, next_document_id, user)
+        package = find_package_with_document(address_obj.data_source, next_document_id, user)
         path_elements.append(package["name"])
         root_package_found = package["isRoot"]
         next_document_id = f"${package['_id']}"
     path_elements.reverse()
-    return protocol_prefix + data_source_id + "/" + "/".join(path_elements)
+    return address_obj.protocol + "://" + address_obj.data_source + "/" + "/".join(path_elements)

--- a/src/features/blueprint/use_cases/resolve_blueprint_use_case.py
+++ b/src/features/blueprint/use_cases/resolve_blueprint_use_case.py
@@ -2,6 +2,7 @@ from typing import List
 
 from authentication.models import User
 from common.exceptions import NotFoundException
+from common.reference import Reference
 from common.utils.resolve_reference import resolve_reference
 from common.utils.string_helpers import split_dmss_ref
 from enums import SIMOS
@@ -23,7 +24,8 @@ def resolve_references(values: list, data_source_id: str, user: User) -> list:
     data_source: DataSource = get_data_source(data_source_id, user)
     return [
         resolve_reference(
-            f"{data_source.name}/{value['address']}", lambda data_source_name: get_data_source(data_source_name, user)
+            Reference(value["address"], data_source.name),  # TODO Can address contain data source and protocol?
+            lambda data_source_name: get_data_source(data_source_name, user),
         ).entity
         for value in values
     ]

--- a/src/features/document/document_feature.py
+++ b/src/features/document/document_feature.py
@@ -17,10 +17,10 @@ from .use_cases.update_document_use_case import update_document_use_case
 router = APIRouter(tags=["default", "document"], prefix="/documents")
 
 
-@router.get("/{reference:path}", operation_id="document_get", response_model=dict, responses=responses)
+@router.get("/{address:path}", operation_id="document_get", response_model=dict, responses=responses)
 @create_response(JSONResponse)
 def get(
-    reference: str,
+    address: str,
     depth: conint(gt=-1, lt=1000) = 0,  # type: ignore
     resolve_links: bool = False,
     user: User = Depends(auth_w_jwt_or_pat),
@@ -28,7 +28,7 @@ def get(
     """
     Get document as JSON string.
 
-    - **reference**: A reference to a package or a data source
+    - **address**: An address to a package or a data source
       - By id: PROTOCOL://DATA SOURCE/$ID.Attribute
       - By path: PROTOCOL://DATA SOURCE/ROOT PACKAGE/SUB PACKAGE/ENTITY.Attribute
       - By query: PROTOCOL://DATA SOURCE/$ID.list(key=value)
@@ -37,43 +37,43 @@ def get(
 
     - **depth**: Maximum depth for resolving nested documents.
     """
-    return get_document_use_case(user=user, reference=reference, depth=depth, resolve_links=resolve_links)
+    return get_document_use_case(user=user, address=address, depth=depth, resolve_links=resolve_links)
 
 
-@router.put("/{id_reference:path}", operation_id="document_update", responses=responses)
+@router.put("/{id_address:path}", operation_id="document_update", responses=responses)
 @create_response(JSONResponse)
 def update(
-    id_reference: str,
+    id_address: str,
     data: Json = Form(...),
     files: Optional[List[UploadFile]] = File(None),
     update_uncontained: Optional[bool] = False,
     user: User = Depends(auth_w_jwt_or_pat),
 ):
     """Update document
-    - **id_reference**: <data_source>/<document_uuid> (can also include an optional .<attribute> after <document_uuid>)
+    - **id_address**: <data_source>/<document_uuid> (can also include an optional .<attribute> after <document_uuid>)
     """
     return update_document_use_case(
         user=user,
-        reference=id_reference,
+        address=id_address,
         data=data,
         files=files,
         update_uncontained=update_uncontained,
     )
 
 
-@router.post("/{reference:path}", operation_id="document_add", response_model=dict, responses=responses)
+@router.post("/{address:path}", operation_id="document_add", response_model=dict, responses=responses)
 @create_response(JSONResponse)
 def add_document(
-    reference: str,
+    address: str,
     document: Json = Form(...),
     files: Optional[List[UploadFile]] = File(None),
     update_uncontained: Optional[bool] = False,
     user: User = Depends(auth_w_jwt_or_pat),
 ):
     """
-    Add a document to a package (or a data source) using a reference.
+    Add a document to a package (or a data source) using an address.
 
-    - **reference**:
+    - **address**:
       - Reference to data source: PROTOCOL://DATA SOURCE
       - Reference to package by id: PROTOCOL://DATA SOURCE/$ID
       - Reference to package by path: PROTOCOL://DATA SOURCE/ROOT PACKAGE/SUB PACKAGE
@@ -81,7 +81,7 @@ def add_document(
     """
     return add_document_use_case(
         user=user,
-        reference=reference,
+        address=address,
         document=document,
         files=files,
         update_uncontained=update_uncontained,
@@ -102,8 +102,8 @@ def add_raw(data_source_id: str, document: dict, user: User = Depends(auth_w_jwt
     return add_raw_use_case(user=user, document=document, data_source_id=data_source_id)
 
 
-@router.delete("/{reference:path}", operation_id="document_remove", responses=responses)
+@router.delete("/{address:path}", operation_id="document_remove", responses=responses)
 @create_response(PlainTextResponse)
-def remove(reference: str, user: User = Depends(auth_w_jwt_or_pat)):
+def remove(address: str, user: User = Depends(auth_w_jwt_or_pat)):
     """Remove a document from DMSS."""
-    return remove_use_case(user=user, reference=reference)
+    return remove_use_case(user=user, address=address)

--- a/src/features/document/document_feature.py
+++ b/src/features/document/document_feature.py
@@ -50,7 +50,7 @@ def update(
     user: User = Depends(auth_w_jwt_or_pat),
 ):
     """Update document
-    - **id_address**: <data_source>/<document_uuid> (can also include an optional .<attribute> after <document_uuid>)
+    - **id_address**: <protocol>://<data_source>/$<document_uuid> (can also include an optional .<attribute> after <document_uuid>)
     """
     return update_document_use_case(
         user=user,

--- a/src/features/document/use_cases/add_document_to_path_use_case.py
+++ b/src/features/document/use_cases/add_document_to_path_use_case.py
@@ -3,6 +3,7 @@ from typing import List, Optional
 from fastapi import UploadFile
 
 from authentication.models import User
+from common.reference import Reference
 from services.document_service import DocumentService
 from storage.internal.data_source_repository import get_data_source
 
@@ -17,11 +18,8 @@ def add_document_use_case(
 ):
     document_service = DocumentService(repository_provider=repository_provider, user=user)
 
-    if "/" in reference and "://" not in reference:
-        reference = f"/{reference}"
-
     document = document_service.add(
-        reference=reference,
+        reference=Reference.fromabsolute(reference),
         document=document,
         files={f.filename: f.file for f in files} if files else None,
         update_uncontained=update_uncontained,

--- a/src/features/document/use_cases/add_document_to_path_use_case.py
+++ b/src/features/document/use_cases/add_document_to_path_use_case.py
@@ -19,7 +19,7 @@ def add_document_use_case(
     document_service = DocumentService(repository_provider=repository_provider, user=user)
 
     document = document_service.add(
-        address=Address.fromabsolute(address),
+        address=Address.from_absolute(address),
         document=document,
         files={f.filename: f.file for f in files} if files else None,
         update_uncontained=update_uncontained,

--- a/src/features/document/use_cases/add_document_to_path_use_case.py
+++ b/src/features/document/use_cases/add_document_to_path_use_case.py
@@ -3,7 +3,7 @@ from typing import List, Optional
 from fastapi import UploadFile
 
 from authentication.models import User
-from common.reference import Reference
+from common.address import Address
 from services.document_service import DocumentService
 from storage.internal.data_source_repository import get_data_source
 
@@ -11,7 +11,7 @@ from storage.internal.data_source_repository import get_data_source
 def add_document_use_case(
     user: User,
     document: dict,
-    reference: str,
+    address: str,
     files: Optional[List[UploadFile]] = None,
     update_uncontained: Optional[bool] = False,
     repository_provider=get_data_source,
@@ -19,7 +19,7 @@ def add_document_use_case(
     document_service = DocumentService(repository_provider=repository_provider, user=user)
 
     document = document_service.add(
-        reference=Reference.fromabsolute(reference),
+        address=Address.fromabsolute(address),
         document=document,
         files={f.filename: f.file for f in files} if files else None,
         update_uncontained=update_uncontained,

--- a/src/features/document/use_cases/get_document_use_case.py
+++ b/src/features/document/use_cases/get_document_use_case.py
@@ -1,7 +1,7 @@
 from pydantic import conint
 
 from authentication.models import User
-from common.reference import Reference
+from common.address import Address
 from common.tree_node_serializer import tree_node_to_dict
 from domain_classes.tree_node import ListNode, Node
 from services.document_service import DocumentService
@@ -10,13 +10,13 @@ from storage.internal.data_source_repository import get_data_source
 
 def get_document_use_case(
     user: User,
-    reference: str,
+    address: str,
     depth: conint(gt=-1, lt=1000) = 999,  # type: ignore
     resolve_links: bool = False,
     repository_provider=get_data_source,
 ):
     """Get document by reference."""
     document_service = DocumentService(repository_provider=repository_provider, user=user)
-    reference_object = Reference.fromabsolute(reference)
-    node: Node | ListNode = document_service.get_document(reference_object, depth, resolve_links)
+    address_object = Address.fromabsolute(address)
+    node: Node | ListNode = document_service.get_document(address_object, depth, resolve_links)
     return tree_node_to_dict(node)

--- a/src/features/document/use_cases/get_document_use_case.py
+++ b/src/features/document/use_cases/get_document_use_case.py
@@ -1,8 +1,9 @@
 from pydantic import conint
 
 from authentication.models import User
+from common.reference import Reference
 from common.tree_node_serializer import tree_node_to_dict
-from domain_classes.tree_node import Node
+from domain_classes.tree_node import ListNode, Node
 from services.document_service import DocumentService
 from storage.internal.data_source_repository import get_data_source
 
@@ -16,7 +17,6 @@ def get_document_use_case(
 ):
     """Get document by reference."""
     document_service = DocumentService(repository_provider=repository_provider, user=user)
-    if "://" not in reference:
-        reference = f"/{reference}"
-    node: Node = document_service.get_document(reference, depth, resolve_links)
+    reference_object = Reference.fromabsolute(reference)
+    node: Node | ListNode = document_service.get_document(reference_object, depth, resolve_links)
     return tree_node_to_dict(node)

--- a/src/features/document/use_cases/get_document_use_case.py
+++ b/src/features/document/use_cases/get_document_use_case.py
@@ -17,6 +17,6 @@ def get_document_use_case(
 ):
     """Get document by reference."""
     document_service = DocumentService(repository_provider=repository_provider, user=user)
-    address_object = Address.fromabsolute(address)
+    address_object = Address.from_absolute(address)
     node: Node | ListNode = document_service.get_document(address_object, depth, resolve_links)
     return tree_node_to_dict(node)

--- a/src/features/document/use_cases/remove.py
+++ b/src/features/document/use_cases/remove.py
@@ -1,11 +1,11 @@
 from authentication.models import User
-from common.reference import Reference
+from common.address import Address
 from services.document_service import DocumentService
 from storage.internal.data_source_repository import get_data_source
 
 
-def remove_use_case(user: User, reference: str, repository_provider=get_data_source) -> str:
+def remove_use_case(user: User, address: str, repository_provider=get_data_source) -> str:
     document_service = DocumentService(repository_provider=repository_provider, user=user)
-    document_service.remove(Reference.fromabsolute(reference))
+    document_service.remove(Address.fromabsolute(address))
     document_service.invalidate_cache()
     return "OK"

--- a/src/features/document/use_cases/remove.py
+++ b/src/features/document/use_cases/remove.py
@@ -1,10 +1,11 @@
 from authentication.models import User
+from common.reference import Reference
 from services.document_service import DocumentService
 from storage.internal.data_source_repository import get_data_source
 
 
 def remove_use_case(user: User, reference: str, repository_provider=get_data_source) -> str:
     document_service = DocumentService(repository_provider=repository_provider, user=user)
-    document_service.remove(reference)
+    document_service.remove(Reference.fromabsolute(reference))
     document_service.invalidate_cache()
     return "OK"

--- a/src/features/document/use_cases/remove.py
+++ b/src/features/document/use_cases/remove.py
@@ -6,6 +6,6 @@ from storage.internal.data_source_repository import get_data_source
 
 def remove_use_case(user: User, address: str, repository_provider=get_data_source) -> str:
     document_service = DocumentService(repository_provider=repository_provider, user=user)
-    document_service.remove(Address.fromabsolute(address))
+    document_service.remove(Address.from_absolute(address))
     document_service.invalidate_cache()
     return "OK"

--- a/src/features/document/use_cases/update_document_use_case.py
+++ b/src/features/document/use_cases/update_document_use_case.py
@@ -3,7 +3,7 @@ from typing import List, Optional, Union
 from fastapi import File, UploadFile
 
 from authentication.models import User
-from common.reference import Reference
+from common.address import Address
 from enums import SIMOS
 from services.document_service import DocumentService
 from storage.internal.data_source_repository import get_data_source
@@ -11,7 +11,7 @@ from storage.internal.data_source_repository import get_data_source
 
 def update_document_use_case(
     user: User,
-    reference: str,
+    address: str,
     data: Union[dict, list],
     files: Optional[List[UploadFile]] = File(None),
     update_uncontained: Optional[bool] = True,
@@ -19,7 +19,7 @@ def update_document_use_case(
 ):
     document_service = DocumentService(repository_provider=repository_provider, user=user)
     document = document_service.update_document(
-        Reference.fromabsolute(reference),
+        Address.fromabsolute(address),
         data,
         files={f.filename: f.file for f in files} if files else None,
         update_uncontained=update_uncontained,

--- a/src/features/document/use_cases/update_document_use_case.py
+++ b/src/features/document/use_cases/update_document_use_case.py
@@ -19,7 +19,7 @@ def update_document_use_case(
 ):
     document_service = DocumentService(repository_provider=repository_provider, user=user)
     document = document_service.update_document(
-        Address.fromabsolute(address),
+        Address.from_absolute(address),
         data,
         files={f.filename: f.file for f in files} if files else None,
         update_uncontained=update_uncontained,

--- a/src/features/document/use_cases/update_document_use_case.py
+++ b/src/features/document/use_cases/update_document_use_case.py
@@ -3,6 +3,7 @@ from typing import List, Optional, Union
 from fastapi import File, UploadFile
 
 from authentication.models import User
+from common.reference import Reference
 from enums import SIMOS
 from services.document_service import DocumentService
 from storage.internal.data_source_repository import get_data_source
@@ -18,7 +19,7 @@ def update_document_use_case(
 ):
     document_service = DocumentService(repository_provider=repository_provider, user=user)
     document = document_service.update_document(
-        reference,
+        Reference.fromabsolute(reference),
         data,
         files={f.filename: f.file for f in files} if files else None,
         update_uncontained=update_uncontained,

--- a/src/features/export/export_feature.py
+++ b/src/features/export/export_feature.py
@@ -24,13 +24,13 @@ class ExportMetaResponse(BaseModel):
 
 
 @router.get(
-    "/meta/{address:path}",
+    "/meta/{path_address:path}",
     operation_id="export-meta",
     response_class=JSONResponse,
     responses={**responses, 200: {"content": {"application/json": {}}}},
 )
 @create_response(JSONResponse)
-def export_meta(address: str, user: User = Depends(auth_w_jwt_or_pat)):
+def export_meta(path_address: str, user: User = Depends(auth_w_jwt_or_pat)):
     """
     Export only the metadata of an entity.
     An entities metadata is concatenated from the "top down". Inheriting parents meta, and overriding for any
@@ -43,16 +43,16 @@ def export_meta(address: str, user: User = Depends(auth_w_jwt_or_pat)):
 
       The PROTOCOL is optional, and the default is dmss.
     """
-    return ExportMetaResponse(**export_meta_use_case(user=user, address=address)).dict()
+    return ExportMetaResponse(**export_meta_use_case(user=user, path_address=path_address)).dict()
 
 
 @router.get(
-    "/{address:path}",
+    "/{path_address:path}",
     operation_id="export",
     response_class=FileResponse,
     responses={**responses, 200: {"content": {"application/zip": {}}}},
 )
-def export(address: str, user: User = Depends(auth_w_jwt_or_pat)):
+def export(path_address: str, user: User = Depends(auth_w_jwt_or_pat)):
     """
     Download a zip-folder with one or more documents as json file(s).
 
@@ -62,7 +62,7 @@ def export(address: str, user: User = Depends(auth_w_jwt_or_pat)):
       The PROTOCOL is optional, and the default is dmss.
     """
     # TODO add proper error handling. The create_response() wrapper does not work with FileResponse.
-    memory_file_path = export_use_case(user=user, document_address=address)
+    memory_file_path = export_use_case(user=user, address=path_address)
     directory_to_remove = Path(memory_file_path).parent
     response = FileResponse(
         memory_file_path, media_type="application/zip", background=BackgroundTask(shutil.rmtree, directory_to_remove)

--- a/src/features/export/export_feature.py
+++ b/src/features/export/export_feature.py
@@ -24,13 +24,13 @@ class ExportMetaResponse(BaseModel):
 
 
 @router.get(
-    "/meta/{reference:path}",
+    "/meta/{address:path}",
     operation_id="export-meta",
     response_class=JSONResponse,
     responses={**responses, 200: {"content": {"application/json": {}}}},
 )
 @create_response(JSONResponse)
-def export_meta(reference: str, user: User = Depends(auth_w_jwt_or_pat)):
+def export_meta(address: str, user: User = Depends(auth_w_jwt_or_pat)):
     """
     Export only the metadata of an entity.
     An entities metadata is concatenated from the "top down". Inheriting parents meta, and overriding for any
@@ -38,31 +38,31 @@ def export_meta(reference: str, user: User = Depends(auth_w_jwt_or_pat)):
 
     If no metadata is defined anywhere in the tree, an empty object is returned.
 
-    - **reference**:
+    - **address**:
       - By path: PROTOCOL://DATA SOURCE/ROOT PACKAGE/SUB PACKAGE/ENTITY
 
       The PROTOCOL is optional, and the default is dmss.
     """
-    return ExportMetaResponse(**export_meta_use_case(user=user, reference=reference)).dict()
+    return ExportMetaResponse(**export_meta_use_case(user=user, address=address)).dict()
 
 
 @router.get(
-    "/{reference:path}",
+    "/{address:path}",
     operation_id="export",
     response_class=FileResponse,
     responses={**responses, 200: {"content": {"application/zip": {}}}},
 )
-def export(reference: str, user: User = Depends(auth_w_jwt_or_pat)):
+def export(address: str, user: User = Depends(auth_w_jwt_or_pat)):
     """
     Download a zip-folder with one or more documents as json file(s).
 
-    - **reference**:
+    - **address**:
       - By path: PROTOCOL://DATA SOURCE/ROOT PACKAGE/SUB PACKAGE/ENTITY
 
       The PROTOCOL is optional, and the default is dmss.
     """
     # TODO add proper error handling. The create_response() wrapper does not work with FileResponse.
-    memory_file_path = export_use_case(user=user, document_reference=reference)
+    memory_file_path = export_use_case(user=user, document_address=address)
     directory_to_remove = Path(memory_file_path).parent
     response = FileResponse(
         memory_file_path, media_type="application/zip", background=BackgroundTask(shutil.rmtree, directory_to_remove)

--- a/src/features/export/use_cases/export_meta_use_case.py
+++ b/src/features/export/use_cases/export_meta_use_case.py
@@ -74,18 +74,18 @@ def _collect_entity_meta_by_path(
     return _collect_entity_meta_by_path(next_package, path_elements, data_source, collected_meta, user)
 
 
-def export_meta_use_case(user: User, address: str) -> dict:
+def export_meta_use_case(user: User, path_address: str) -> dict:
     """Export meta.
 
     This function assumes that reference is on a path format, without any id.
     Also, a reference must be on the format PROTOCOL://DATASOURCE_NAME/ROOT_PACKAGE/*path to document or package*.
     (Protocol is optional)
     """
-    address_object = Address.from_absolute(address)
+    address_object = Address.from_absolute(path_address)
 
     data_source = get_data_source(address_object.data_source, user)
     if not address_object.path:
-        raise NotFoundException(f"Could not find a root package from reference '{address}'")
+        raise NotFoundException(f"Could not find a root package from reference '{path_address}'")
     reference_items = reference_to_reference_items(address_object.path)
     if (
         len(reference_items) >= 1
@@ -94,7 +94,7 @@ def export_meta_use_case(user: User, address: str) -> dict:
     ):
         root_package_name = reference_items[0].query_as_dict["name"]
     else:
-        raise NotFoundException(f"Could not find a root package from reference '{address}'")
+        raise NotFoundException(f"Could not find a root package from reference '{path_address}'")
 
     root_package: dict = resolve_reference(
         Address(root_package_name, address_object.data_source),

--- a/src/features/export/use_cases/export_meta_use_case.py
+++ b/src/features/export/use_cases/export_meta_use_case.py
@@ -32,7 +32,7 @@ def concat_meta_data(meta: dict | None, new_meta: dict | None) -> dict:
 def resolve_references(values: list, data_source: DataSource, user: User) -> list:
     return [
         resolve_reference(
-            Address.fromrelative(value["address"], None, data_source.name),
+            Address.from_relative(value["address"], None, data_source.name),
             lambda data_source_name: get_data_source(data_source_name, user),
         ).entity
         for value in values
@@ -81,7 +81,7 @@ def export_meta_use_case(user: User, address: str) -> dict:
     Also, a reference must be on the format PROTOCOL://DATASOURCE_NAME/ROOT_PACKAGE/*path to document or package*.
     (Protocol is optional)
     """
-    address_object = Address.fromabsolute(address)
+    address_object = Address.from_absolute(address)
 
     data_source = get_data_source(address_object.data_source, user)
     if not address_object.path:

--- a/src/features/export/use_cases/export_meta_use_case.py
+++ b/src/features/export/use_cases/export_meta_use_case.py
@@ -32,7 +32,7 @@ def concat_meta_data(meta: dict | None, new_meta: dict | None) -> dict:
 def resolve_references(values: list, data_source: DataSource, user: User) -> list:
     return [
         resolve_reference(
-            Address(value["address"], data_source.name),  # TODO Can address contain data source and protocol?
+            Address.fromrelative(value["address"], None, data_source.name),
             lambda data_source_name: get_data_source(data_source_name, user),
         ).entity
         for value in values

--- a/src/features/export/use_cases/export_use_case.py
+++ b/src/features/export/use_cases/export_use_case.py
@@ -60,6 +60,6 @@ def create_zip_export(document_service: DocumentService, address: Address, user:
 
 def export_use_case(user: User, document_address: str):
     memory_file = create_zip_export(
-        document_service=DocumentService(user=user), address=Address.fromabsolute(document_address), user=user
+        document_service=DocumentService(user=user), address=Address.from_absolute(document_address), user=user
     )
     return memory_file

--- a/src/features/export/use_cases/export_use_case.py
+++ b/src/features/export/use_cases/export_use_case.py
@@ -3,7 +3,7 @@ import tempfile
 import zipfile
 
 from authentication.models import User
-from common.reference import Reference
+from common.address import Address
 from common.utils.resolve_reference import ResolvedReference, resolve_reference
 from domain_classes.tree_node import Node
 from enums import SIMOS
@@ -32,17 +32,17 @@ def save_node_to_zipfile(
         )
 
 
-def create_zip_export(document_service: DocumentService, reference: Reference, user: User) -> str:
+def create_zip_export(document_service: DocumentService, address: Address, user: User) -> str:
     """Create a temporary folder on the host that contains a zip file."""
     tmpdir = tempfile.mkdtemp()
     archive_path = os.path.join(tmpdir, "temp_zip_archive.zip")
-    resolved_reference: ResolvedReference = resolve_reference(reference, document_service.get_data_source)
-    document_node: Node = document_service.get_document(reference, depth=999, resolve_links=True)
+    resolved_reference: ResolvedReference = resolve_reference(address, document_service.get_data_source)
+    document_node: Node = document_service.get_document(address, depth=999, resolve_links=True)
 
     # non-root packages and single documents will inherit the meta information from all parents.
     document_meta = {}
     if not (document_node.entity["type"] == SIMOS.PACKAGE.value and document_node.entity["isRoot"]):
-        document_meta = export_meta_use_case(user=user, reference=str(reference))
+        document_meta = export_meta_use_case(user=user, address=str(address))
     elif "_meta_" in document_node.entity:
         document_meta = document_node.entity["_meta_"]
 
@@ -58,8 +58,8 @@ def create_zip_export(document_service: DocumentService, reference: Reference, u
     return archive_path
 
 
-def export_use_case(user: User, document_reference: str):
+def export_use_case(user: User, document_address: str):
     memory_file = create_zip_export(
-        document_service=DocumentService(user=user), reference=Reference.fromabsolute(document_reference), user=user
+        document_service=DocumentService(user=user), address=Address.fromabsolute(document_address), user=user
     )
     return memory_file

--- a/src/features/export/use_cases/export_use_case.py
+++ b/src/features/export/use_cases/export_use_case.py
@@ -42,7 +42,7 @@ def create_zip_export(document_service: DocumentService, address: Address, user:
     # non-root packages and single documents will inherit the meta information from all parents.
     document_meta = {}
     if not (document_node.entity["type"] == SIMOS.PACKAGE.value and document_node.entity["isRoot"]):
-        document_meta = export_meta_use_case(user=user, address=str(address))
+        document_meta = export_meta_use_case(user=user, path_address=str(address))
     elif "_meta_" in document_node.entity:
         document_meta = document_node.entity["_meta_"]
 
@@ -58,8 +58,8 @@ def create_zip_export(document_service: DocumentService, address: Address, user:
     return archive_path
 
 
-def export_use_case(user: User, document_address: str):
+def export_use_case(user: User, address: str):
     memory_file = create_zip_export(
-        document_service=DocumentService(user=user), address=Address.from_absolute(document_address), user=user
+        document_service=DocumentService(user=user), address=Address.from_absolute(address), user=user
     )
     return memory_file

--- a/src/features/export/use_cases/export_use_case.py
+++ b/src/features/export/use_cases/export_use_case.py
@@ -3,6 +3,7 @@ import tempfile
 import zipfile
 
 from authentication.models import User
+from common.reference import Reference
 from common.utils.resolve_reference import ResolvedReference, resolve_reference
 from domain_classes.tree_node import Node
 from enums import SIMOS
@@ -31,7 +32,7 @@ def save_node_to_zipfile(
         )
 
 
-def create_zip_export(document_service: DocumentService, reference: str, user: User) -> str:
+def create_zip_export(document_service: DocumentService, reference: Reference, user: User) -> str:
     """Create a temporary folder on the host that contains a zip file."""
     tmpdir = tempfile.mkdtemp()
     archive_path = os.path.join(tmpdir, "temp_zip_archive.zip")
@@ -41,7 +42,7 @@ def create_zip_export(document_service: DocumentService, reference: str, user: U
     # non-root packages and single documents will inherit the meta information from all parents.
     document_meta = {}
     if not (document_node.entity["type"] == SIMOS.PACKAGE.value and document_node.entity["isRoot"]):
-        document_meta = export_meta_use_case(user=user, reference=reference)
+        document_meta = export_meta_use_case(user=user, reference=str(reference))
     elif "_meta_" in document_node.entity:
         document_meta = document_node.entity["_meta_"]
 
@@ -59,6 +60,6 @@ def create_zip_export(document_service: DocumentService, reference: str, user: U
 
 def export_use_case(user: User, document_reference: str):
     memory_file = create_zip_export(
-        document_service=DocumentService(user=user), reference=document_reference, user=user
+        document_service=DocumentService(user=user), reference=Reference.fromabsolute(document_reference), user=user
     )
     return memory_file

--- a/src/features/lookup_table/use_cases/create_lookup_table.py
+++ b/src/features/lookup_table/use_cases/create_lookup_table.py
@@ -1,5 +1,6 @@
 from authentication.access_control import DEFAULT_ACL, access_control
 from authentication.models import AccessLevel, User
+from common.reference import Reference
 from domain_classes.lookup import Lookup
 from domain_classes.storage_recipe import StorageAttribute, StorageRecipe
 from domain_classes.ui_recipe import Recipe
@@ -21,7 +22,9 @@ def create_lookup_table_use_case(
     lookup_class_attributes = list(Lookup.__annotations__.keys())
     combined_lookup = Lookup().dict()
     for path in recipe_package_paths:
-        recipe_package = document_service.get_document(f"/{path}", depth=999, resolve_links=True)
+        recipe_package = document_service.get_document(
+            Reference(*path.split("/", 1)[::-1]), depth=999, resolve_links=True
+        )
 
         lookup: Lookup = Lookup()
 

--- a/src/features/lookup_table/use_cases/create_lookup_table.py
+++ b/src/features/lookup_table/use_cases/create_lookup_table.py
@@ -1,6 +1,6 @@
 from authentication.access_control import DEFAULT_ACL, access_control
 from authentication.models import AccessLevel, User
-from common.reference import Reference
+from common.address import Address
 from domain_classes.lookup import Lookup
 from domain_classes.storage_recipe import StorageAttribute, StorageRecipe
 from domain_classes.ui_recipe import Recipe
@@ -23,7 +23,7 @@ def create_lookup_table_use_case(
     combined_lookup = Lookup().dict()
     for path in recipe_package_paths:
         recipe_package = document_service.get_document(
-            Reference(*path.split("/", 1)[::-1]), depth=999, resolve_links=True
+            Address(*path.split("/", 1)[::-1]), depth=999, resolve_links=True
         )
 
         lookup: Lookup = Lookup()

--- a/src/features/reference/reference_feature.py
+++ b/src/features/reference/reference_feature.py
@@ -12,13 +12,10 @@ from .use_cases.insert_reference_use_case import insert_reference_use_case
 router = APIRouter(tags=["default", "reference"], prefix="/reference")
 
 
-@router.put(
-    "/{data_source_id}/{document_dotted_id}", operation_id="reference_insert", response_model=dict, responses=responses
-)
+@router.put("/{address:path}", operation_id="reference_insert", response_model=dict, responses=responses)
 @create_response(JSONResponse)
 def insert_reference(
-    data_source_id: str,
-    document_dotted_id: str,
+    address: str,
     reference: ReferenceEntity,
     user: User = Depends(auth_w_jwt_or_pat),
 ):
@@ -29,20 +26,16 @@ def insert_reference(
     - **document_dotted_id**: <data_source>/<path_to_entity>/<entity_name>.<attribute>
     - **reference**: a reference object in JSON format
     """
-    return insert_reference_use_case(
-        user=user, data_source_id=data_source_id, document_dotted_id=document_dotted_id, reference=reference
-    )
+    return insert_reference_use_case(user=user, address=address, reference=reference)
 
 
-@router.delete(
-    "/{data_source_id}/{document_dotted_id}", operation_id="reference_delete", response_model=dict, responses=responses
-)
+@router.delete("/{address:path}", operation_id="reference_delete", response_model=dict, responses=responses)
 @create_response(JSONResponse)
-def delete_reference(data_source_id: str, document_dotted_id: str, user: User = Depends(auth_w_jwt_or_pat)):
+def delete_reference(address: str, user: User = Depends(auth_w_jwt_or_pat)):
     """Delete a reference in an entity.
 
     Used to delete uncontained attributes in an entity.
 
     - **document_dotted_id**: <data_source>/<path_to_entity>/<entity_name>.<attribute>
     """
-    return delete_reference_use_case(user=user, data_source_id=data_source_id, document_dotted_id=document_dotted_id)
+    return delete_reference_use_case(user=user, address=address)

--- a/src/features/reference/reference_feature.py
+++ b/src/features/reference/reference_feature.py
@@ -29,9 +29,8 @@ def insert_reference(
     - **document_dotted_id**: <data_source>/<path_to_entity>/<entity_name>.<attribute>
     - **reference**: a reference object in JSON format
     """
-    document_id, attribute = document_dotted_id.split(".", 1)
     return insert_reference_use_case(
-        user=user, data_source_id=data_source_id, document_id=document_id, reference=reference, attribute=attribute
+        user=user, data_source_id=data_source_id, document_dotted_id=document_dotted_id, reference=reference
     )
 
 
@@ -46,7 +45,4 @@ def delete_reference(data_source_id: str, document_dotted_id: str, user: User = 
 
     - **document_dotted_id**: <data_source>/<path_to_entity>/<entity_name>.<attribute>
     """
-    document_id, attribute = document_dotted_id.split(".", 1)
-    return delete_reference_use_case(
-        user=user, document_id=document_id, data_source_id=data_source_id, attribute=attribute
-    )
+    return delete_reference_use_case(user=user, data_source_id=data_source_id, document_dotted_id=document_dotted_id)

--- a/src/features/reference/reference_feature.py
+++ b/src/features/reference/reference_feature.py
@@ -4,7 +4,7 @@ from fastapi.responses import JSONResponse
 from authentication.authentication import auth_w_jwt_or_pat
 from authentication.models import User
 from common.responses import create_response, responses
-from restful.request_types.shared import Reference
+from restful.request_types.shared import ReferenceEntity
 
 from .use_cases.delete_reference_use_case import delete_reference_use_case
 from .use_cases.insert_reference_use_case import insert_reference_use_case
@@ -19,7 +19,7 @@ router = APIRouter(tags=["default", "reference"], prefix="/reference")
 def insert_reference(
     data_source_id: str,
     document_dotted_id: str,
-    reference: Reference,
+    reference: ReferenceEntity,
     user: User = Depends(auth_w_jwt_or_pat),
 ):
     """Add reference to an entity.

--- a/src/features/reference/use_cases/delete_reference_use_case.py
+++ b/src/features/reference/use_cases/delete_reference_use_case.py
@@ -1,8 +1,8 @@
 from authentication.models import User
-from common.reference import Reference
+from common.address import Address
 from services.document_service import DocumentService
 
 
-def delete_reference_use_case(user: User, data_source_id: str, document_dotted_id: str):
+def delete_reference_use_case(user: User, address: str):
     document_service = DocumentService(user=user)
-    return document_service.remove_reference(Reference(document_dotted_id, data_source_id))
+    return document_service.remove_reference(Address.fromabsolute(address))

--- a/src/features/reference/use_cases/delete_reference_use_case.py
+++ b/src/features/reference/use_cases/delete_reference_use_case.py
@@ -5,4 +5,4 @@ from services.document_service import DocumentService
 
 def delete_reference_use_case(user: User, address: str):
     document_service = DocumentService(user=user)
-    return document_service.remove_reference(Address.fromabsolute(address))
+    return document_service.remove_reference(Address.from_absolute(address))

--- a/src/features/reference/use_cases/delete_reference_use_case.py
+++ b/src/features/reference/use_cases/delete_reference_use_case.py
@@ -1,12 +1,8 @@
 from authentication.models import User
+from common.reference import Reference
 from services.document_service import DocumentService
 
 
-def delete_reference_use_case(user: User, data_source_id: str, document_id: str, attribute: str):
+def delete_reference_use_case(user: User, data_source_id: str, document_dotted_id: str):
     document_service = DocumentService(user=user)
-    document = document_service.remove_reference(
-        data_source_id=data_source_id,
-        document_id=document_id,
-        attribute_path=attribute,
-    )
-    return document
+    return document_service.remove_reference(Reference(document_dotted_id, data_source_id))

--- a/src/features/reference/use_cases/insert_reference_use_case.py
+++ b/src/features/reference/use_cases/insert_reference_use_case.py
@@ -6,4 +6,4 @@ from services.document_service import DocumentService
 
 def insert_reference_use_case(user: User, address: str, reference: ReferenceEntity):
     document_service = DocumentService(user=user)
-    return document_service.insert_reference(Address.fromabsolute(address), reference)
+    return document_service.insert_reference(Address.from_absolute(address), reference)

--- a/src/features/reference/use_cases/insert_reference_use_case.py
+++ b/src/features/reference/use_cases/insert_reference_use_case.py
@@ -1,16 +1,9 @@
 from authentication.models import User
+from common.reference import Reference
 from restful.request_types.shared import ReferenceEntity
 from services.document_service import DocumentService
 
 
-def insert_reference_use_case(
-    user: User, data_source_id: str, document_id: str, reference: ReferenceEntity, attribute: str
-):
+def insert_reference_use_case(user: User, data_source_id: str, document_dotted_id: str, reference: ReferenceEntity):
     document_service = DocumentService(user=user)
-    document = document_service.insert_reference(
-        data_source_id=data_source_id,
-        document_id=document_id,
-        reference=reference,
-        attribute_path=attribute,
-    )
-    return document
+    return document_service.insert_reference(Reference(document_dotted_id, data_source_id), reference)

--- a/src/features/reference/use_cases/insert_reference_use_case.py
+++ b/src/features/reference/use_cases/insert_reference_use_case.py
@@ -1,9 +1,11 @@
 from authentication.models import User
-from restful.request_types.shared import Reference
+from restful.request_types.shared import ReferenceEntity
 from services.document_service import DocumentService
 
 
-def insert_reference_use_case(user: User, data_source_id: str, document_id: str, reference: Reference, attribute: str):
+def insert_reference_use_case(
+    user: User, data_source_id: str, document_id: str, reference: ReferenceEntity, attribute: str
+):
     document_service = DocumentService(user=user)
     document = document_service.insert_reference(
         data_source_id=data_source_id,

--- a/src/features/reference/use_cases/insert_reference_use_case.py
+++ b/src/features/reference/use_cases/insert_reference_use_case.py
@@ -1,9 +1,9 @@
 from authentication.models import User
-from common.reference import Reference
+from common.address import Address
 from restful.request_types.shared import ReferenceEntity
 from services.document_service import DocumentService
 
 
-def insert_reference_use_case(user: User, data_source_id: str, document_dotted_id: str, reference: ReferenceEntity):
+def insert_reference_use_case(user: User, address: str, reference: ReferenceEntity):
     document_service = DocumentService(user=user)
-    return document_service.insert_reference(Reference(document_dotted_id, data_source_id), reference)
+    return document_service.insert_reference(Address.fromabsolute(address), reference)

--- a/src/restful/request_types/shared.py
+++ b/src/restful/request_types/shared.py
@@ -36,7 +36,7 @@ class EntityUUID(BaseModel):
     uid: UUID4 = Field(..., alias="_id")
 
 
-class Reference(BaseModel):
+class ReferenceEntity(BaseModel):
     address: str
     type: common_type_constrained_string  # type: ignore
     referenceType: str

--- a/src/services/document_service.py
+++ b/src/services/document_service.py
@@ -36,7 +36,7 @@ from domain_classes.blueprint_attribute import BlueprintAttribute
 from domain_classes.storage_recipe import StorageAttribute, StorageRecipe
 from domain_classes.tree_node import ListNode, Node
 from enums import REFERENCE_TYPES, SIMOS, BuiltinDataTypes, StorageDataTypes
-from restful.request_types.shared import Entity, Reference
+from restful.request_types.shared import Entity, ReferenceEntity
 from storage.data_source_class import DataSource
 from storage.internal.data_source_repository import get_data_source
 from storage.repositories.mongo import MongoDBClient
@@ -510,7 +510,7 @@ class DocumentService:
         return lookup.acl
 
     def insert_reference(
-        self, data_source_id: str, document_id: str, reference: Reference, attribute_path: str
+        self, data_source_id: str, document_id: str, reference: ReferenceEntity, attribute_path: str
     ) -> dict:
         root: Node = self.get_document(f"{data_source_id}/{document_id}")
         attribute_node: Node = root.get_by_path(attribute_path.split("."))

--- a/src/services/document_service.py
+++ b/src/services/document_service.py
@@ -208,13 +208,9 @@ class DocumentService:
     # TODO: Dont return Node. Doing this is ~33% slower
     def get_document(self, address: Address, depth: int = 0, resolve_links: bool = False) -> Node | ListNode:
         """
-        Get document by reference.
+        Get document by address.
 
-        :param reference: accepts multiple types of reference:
-            full path. Ex: "dmss://test_data/complex/myCarRental.cars[0]"
-            data source relative path. Ex "/$2.cars[0]"
-            document relative path. Ex "^.cars[0]"
-            path with query. Ex "^.cars[(plateNumber=456,name=Ferrari)]"
+        :param address: Address to the entity you wish to obtain
         :param depth: depth=0 means that the entire entity will be returned, except any references it may contain
             along the tree. depth=1 means that the entity's direct child references will be returned as well.
         :param resolve_links: If false, model uncontained references (ie of type link) will not be resolved, no
@@ -313,7 +309,7 @@ class DocumentService:
         """
         Update a document.
 
-        What to update is referred to with a reference string.
+        What to update is referred to with an address.
         It can either be an entire document or just an attribute inside a document.
         """
         validate_entity_against_self(data, self.get_blueprint)

--- a/src/tests/bdd/authentication/access_control.feature
+++ b/src/tests/bdd/authentication/access_control.feature
@@ -70,7 +70,7 @@ Feature: Access Control
     {
       "data": null,
       "debug": "The requested operation requires 'READ' privileges. Action denied because of insufficient permissions",
-      "message": "Failed to get document referenced with '/test-DS/$1'",
+      "message": "Failed to get document referenced with 'dmss://test-DS/$1'",
       "status": 403,
       "type": "MissingPrivilegeException"
     }

--- a/src/tests/bdd/document/add_file.feature
+++ b/src/tests/bdd/document/add_file.feature
@@ -425,7 +425,7 @@ Feature: Explorer - Add file
     {
     "data": null,
     "debug": "Document with id '-1' was not found in the 'test-DS' data-source. The requested resource could not be found",
-    "message": "Failed to get document referenced with '/test-DS/$-1.documents'",
+    "message": "Failed to get document referenced with 'dmss://test-DS/$-1.documents'",
     "status": 404,
     "type": "NotFoundException"
     }

--- a/src/tests/bdd/document/reference.feature
+++ b/src/tests/bdd/document/reference.feature
@@ -54,7 +54,7 @@ Feature: Add and remove references
       "isRoot": true
     }
     """
-    Given i access the resource url "/api/reference/test-DS/$1.content.0"
+    Given i access the resource url "/api/reference/test-DS/$1.content[0]"
     When i make a "DELETE" request
     Then the response status should be "OK"
     And the response should contain

--- a/src/tests/bdd/document/remove.feature
+++ b/src/tests/bdd/document/remove.feature
@@ -31,7 +31,7 @@ Feature: Explorer - Remove
   {
   "data": null,
   "debug": "Document with id '1' was not found in the 'data-source-name' data-source. The requested resource could not be found",
-  "message": "Failed to get document referenced with '/data-source-name/$1'",
+  "message": "Failed to get document referenced with 'dmss://data-source-name/$1'",
   "status": 404,
   "type": "NotFoundException"
   }
@@ -44,7 +44,7 @@ Feature: Explorer - Remove
   {
   "data": null,
   "debug": "Document with id '2' was not found in the 'data-source-name' data-source. The requested resource could not be found",
-  "message": "Failed to get document referenced with '/data-source-name/$2'",
+  "message": "Failed to get document referenced with 'dmss://data-source-name/$2'",
   "status": 404,
   "type": "NotFoundException"
   }
@@ -57,7 +57,7 @@ Feature: Explorer - Remove
   {
   "data": null,
   "debug": "Document with id '3' was not found in the 'data-source-name' data-source. The requested resource could not be found",
-  "message": "Failed to get document referenced with '/data-source-name/$3'",
+  "message": "Failed to get document referenced with 'dmss://data-source-name/$3'",
   "status": 404,
   "type": "NotFoundException"
   }
@@ -79,7 +79,7 @@ Feature: Explorer - Remove
     {
     "data": null,
     "debug": "Document with id '2' was not found in the 'data-source-name' data-source. The requested resource could not be found",
-    "message": "Failed to get document referenced with '/data-source-name/$2'",
+    "message": "Failed to get document referenced with 'dmss://data-source-name/$2'",
     "status": 404,
     "type": "NotFoundException"
     }
@@ -97,7 +97,7 @@ Feature: Explorer - Remove
     {
     "data": null,
     "debug": "Document with id '3' was not found in the 'data-source-name' data-source. The requested resource could not be found",
-    "message": "Failed to get document referenced with '/data-source-name/$3'",
+    "message": "Failed to get document referenced with 'dmss://data-source-name/$3'",
     "status": 404,
     "type": "NotFoundException"
     }
@@ -115,7 +115,7 @@ Feature: Explorer - Remove
   {
   "data": null,
   "debug": "Document with id '2' was not found in the 'data-source-name' data-source. The requested resource could not be found",
-  "message": "Failed to get document referenced with '/data-source-name/$2'",
+  "message": "Failed to get document referenced with 'dmss://data-source-name/$2'",
   "status": 404,
   "type": "NotFoundException"
   }
@@ -128,7 +128,7 @@ Feature: Explorer - Remove
   {
   "data": null,
   "debug": "Document with id '3' was not found in the 'data-source-name' data-source. The requested resource could not be found",
-  "message": "Failed to get document referenced with '/data-source-name/$3'",
+  "message": "Failed to get document referenced with 'dmss://data-source-name/$3'",
   "status": 404,
   "type": "NotFoundException"
   }

--- a/src/tests/bdd/document/remove_2.feature
+++ b/src/tests/bdd/document/remove_2.feature
@@ -25,7 +25,7 @@ Feature: Explorer - Remove by path
   {
   "data": null,
   "debug": "Document with id '1' was not found in the 'data-source-name' data-source. The requested resource could not be found",
-  "message": "Failed to get document referenced with '/data-source-name/$1'",
+  "message": "Failed to get document referenced with 'dmss://data-source-name/$1'",
   "status": 404,
   "type": "NotFoundException"
   }
@@ -38,7 +38,7 @@ Feature: Explorer - Remove by path
   {
   "data": null,
   "debug": "Document with id '2' was not found in the 'data-source-name' data-source. The requested resource could not be found",
-  "message": "Failed to get document referenced with '/data-source-name/$2'",
+  "message": "Failed to get document referenced with 'dmss://data-source-name/$2'",
   "status": 404,
   "type": "NotFoundException"
   }
@@ -51,7 +51,7 @@ Feature: Explorer - Remove by path
   {
   "data": null,
   "debug": "Document with id '3' was not found in the 'data-source-name' data-source. The requested resource could not be found",
-  "message": "Failed to get document referenced with '/data-source-name/$3'",
+  "message": "Failed to get document referenced with 'dmss://data-source-name/$3'",
   "status": 404,
   "type": "NotFoundException"
   }
@@ -74,7 +74,7 @@ Feature: Explorer - Remove by path
     {
     "data": null,
     "debug": "Document with id '2' was not found in the 'data-source-name' data-source. The requested resource could not be found",
-    "message": "Failed to get document referenced with '/data-source-name/$2'",
+    "message": "Failed to get document referenced with 'dmss://data-source-name/$2'",
     "status": 404,
     "type": "NotFoundException"
     }
@@ -92,7 +92,7 @@ Feature: Explorer - Remove by path
     {
     "data": null,
     "debug": "Document with id '3' was not found in the 'data-source-name' data-source. The requested resource could not be found",
-    "message": "Failed to get document referenced with '/data-source-name/$3'",
+    "message": "Failed to get document referenced with 'dmss://data-source-name/$3'",
     "status": 404,
     "type": "NotFoundException"
     }
@@ -110,7 +110,7 @@ Feature: Explorer - Remove by path
   {
     "data": null,
     "debug": "Document with id '2' was not found in the 'data-source-name' data-source. The requested resource could not be found",
-    "message": "Failed to get document referenced with '/data-source-name/$2'",
+    "message": "Failed to get document referenced with 'dmss://data-source-name/$2'",
     "status": 404,
     "type": "NotFoundException"
   }
@@ -123,7 +123,7 @@ Feature: Explorer - Remove by path
   {
   "data": null,
   "debug": "Document with id '3' was not found in the 'data-source-name' data-source. The requested resource could not be found",
-  "message": "Failed to get document referenced with '/data-source-name/$3'",
+  "message": "Failed to get document referenced with 'dmss://data-source-name/$3'",
   "status": 404,
   "type": "NotFoundException"
   }

--- a/src/tests/unit/common/utils/test_resolve_reference.py
+++ b/src/tests/unit/common/utils/test_resolve_reference.py
@@ -4,8 +4,8 @@ from unittest import mock
 
 import pytest
 
+from common.address import Address
 from common.exceptions import ApplicationException, NotFoundException
-from common.reference import Reference
 from common.utils.resolve_reference import resolve_reference
 from enums import REFERENCE_TYPES, SIMOS
 from tests.unit.mock_utils import get_mock_document_service
@@ -98,14 +98,14 @@ class ResolveReferenceTestCase(unittest.TestCase):
         return documents
 
     def test_id(self):
-        ref = resolve_reference(Reference.fromabsolute("datasource/$1"), self.document_service.get_data_source)
+        ref = resolve_reference(Address.fromabsolute("datasource/$1"), self.document_service.get_data_source)
         assert ref.data_source_id == "datasource"
         assert ref.document_id == "1"
         assert ref.attribute_path == []
         assert ref.entity == self.car_rental_company
 
     def test_with_attributes(self):
-        ref = resolve_reference(Reference.fromabsolute("datasource/$1.cars[0]"), self.document_service.get_data_source)
+        ref = resolve_reference(Address.fromabsolute("datasource/$1.cars[0]"), self.document_service.get_data_source)
         assert ref.data_source_id == "datasource"
         assert ref.document_id == "1"
         assert ref.attribute_path == ["cars", "[0]"]
@@ -113,7 +113,7 @@ class ResolveReferenceTestCase(unittest.TestCase):
 
     def test_with_attributes_to_uncontained(self):
         ref = resolve_reference(
-            Reference.fromabsolute("datasource/$1.cars[0].engine"), self.document_service.get_data_source
+            Address.fromabsolute("datasource/$1.cars[0].engine"), self.document_service.get_data_source
         )
         assert ref.data_source_id == "datasource"
         assert ref.document_id == "1"
@@ -122,7 +122,7 @@ class ResolveReferenceTestCase(unittest.TestCase):
 
     def test_with_attributes_to_uncontained_child(self):
         ref = resolve_reference(
-            Reference.fromabsolute("datasource/$1.cars[0].engine.fuelPump"), self.document_service.get_data_source
+            Address.fromabsolute("datasource/$1.cars[0].engine.fuelPump"), self.document_service.get_data_source
         )
         assert ref.data_source_id == "datasource"
         assert ref.document_id == "2"
@@ -131,7 +131,7 @@ class ResolveReferenceTestCase(unittest.TestCase):
 
     def test_with_attributes_via_relative_ref(self):
         ref = resolve_reference(
-            Reference.fromabsolute("datasource/$1.customers[1].car.engine"), self.document_service.get_data_source
+            Address.fromabsolute("datasource/$1.customers[1].car.engine"), self.document_service.get_data_source
         )
         assert ref.data_source_id == "datasource"
         assert ref.document_id == "1"
@@ -140,7 +140,7 @@ class ResolveReferenceTestCase(unittest.TestCase):
 
     def test_with_query_to_uncontained(self):
         ref = resolve_reference(
-            Reference.fromabsolute("datasource/$1.customers(name=Jane)"), self.document_service.get_data_source
+            Address.fromabsolute("datasource/$1.customers(name=Jane)"), self.document_service.get_data_source
         )
         assert ref.data_source_id == "datasource"
         assert ref.document_id == "1"
@@ -149,7 +149,7 @@ class ResolveReferenceTestCase(unittest.TestCase):
 
     def test_with_query_to_uncontained_child(self):
         ref = resolve_reference(
-            Reference.fromabsolute("datasource/$1.customers(name=Jane).car"), self.document_service.get_data_source
+            Address.fromabsolute("datasource/$1.customers(name=Jane).car"), self.document_service.get_data_source
         )
         assert ref.data_source_id == "datasource"
         assert ref.document_id == "4"
@@ -160,19 +160,19 @@ class ResolveReferenceTestCase(unittest.TestCase):
         with pytest.raises(
             NotFoundException, match=re.escape("No document with id '5' could be found in data source 'datasource'.")
         ):
-            resolve_reference(Reference.fromabsolute("datasource/$5"), self.document_service.get_data_source)
+            resolve_reference(Address.fromabsolute("datasource/$5"), self.document_service.get_data_source)
 
     def test_invalid_query_no_document(self):
         with pytest.raises(
             NotFoundException,
             match=re.escape("No document that match '_id=5' could be found in data source 'datasource'."),
         ):
-            resolve_reference(Reference.fromabsolute("datasource/[(_id=5)]"), self.document_service.get_data_source)
+            resolve_reference(Address.fromabsolute("datasource/[(_id=5)]"), self.document_service.get_data_source)
 
     def test_invalid_query_no_attribute(self):
         with pytest.raises(ApplicationException, match=re.escape("No object matches filter 'name=Peter'")):
             resolve_reference(
-                Reference.fromabsolute("datasource/$1.customers[(name=Peter)]"), self.document_service.get_data_source
+                Address.fromabsolute("datasource/$1.customers[(name=Peter)]"), self.document_service.get_data_source
             )
 
     def test_invalid_attribute(self):
@@ -182,19 +182,19 @@ class ResolveReferenceTestCase(unittest.TestCase):
                 f"Invalid attribute 'cers'. Valid attributes are '{list(self.car_rental_company.keys())}'."
             ),
         ):
-            resolve_reference(Reference.fromabsolute("datasource/$1.cers"), self.document_service.get_data_source)
+            resolve_reference(Address.fromabsolute("datasource/$1.cers"), self.document_service.get_data_source)
 
     def test_invalid_index(self):
         with pytest.raises(
             NotFoundException,
             match=re.escape(f"Invalid index '[1]'. Valid indices are < {len(self.car_rental_company['cars'])}."),
         ):
-            resolve_reference(Reference.fromabsolute("datasource/$1.cars[1]"), self.document_service.get_data_source)
+            resolve_reference(Address.fromabsolute("datasource/$1.cars[1]"), self.document_service.get_data_source)
 
     def test_invalid_reference_to_primitive(self):
         with pytest.raises(
             NotFoundException, match=re.escape("Path ['1', 'cars', '[0]', 'plateNumber'] leads to a primitive value.")
         ):
             resolve_reference(
-                Reference.fromabsolute("datasource/$1.cars[0].plateNumber"), self.document_service.get_data_source
+                Address.fromabsolute("datasource/$1.cars[0].plateNumber"), self.document_service.get_data_source
             )

--- a/src/tests/unit/common/utils/test_resolve_reference.py
+++ b/src/tests/unit/common/utils/test_resolve_reference.py
@@ -98,14 +98,14 @@ class ResolveReferenceTestCase(unittest.TestCase):
         return documents
 
     def test_id(self):
-        ref = resolve_reference(Address.fromabsolute("datasource/$1"), self.document_service.get_data_source)
+        ref = resolve_reference(Address.from_absolute("datasource/$1"), self.document_service.get_data_source)
         assert ref.data_source_id == "datasource"
         assert ref.document_id == "1"
         assert ref.attribute_path == []
         assert ref.entity == self.car_rental_company
 
     def test_with_attributes(self):
-        ref = resolve_reference(Address.fromabsolute("datasource/$1.cars[0]"), self.document_service.get_data_source)
+        ref = resolve_reference(Address.from_absolute("datasource/$1.cars[0]"), self.document_service.get_data_source)
         assert ref.data_source_id == "datasource"
         assert ref.document_id == "1"
         assert ref.attribute_path == ["cars", "[0]"]
@@ -113,7 +113,7 @@ class ResolveReferenceTestCase(unittest.TestCase):
 
     def test_with_attributes_to_uncontained(self):
         ref = resolve_reference(
-            Address.fromabsolute("datasource/$1.cars[0].engine"), self.document_service.get_data_source
+            Address.from_absolute("datasource/$1.cars[0].engine"), self.document_service.get_data_source
         )
         assert ref.data_source_id == "datasource"
         assert ref.document_id == "1"
@@ -122,7 +122,7 @@ class ResolveReferenceTestCase(unittest.TestCase):
 
     def test_with_attributes_to_uncontained_child(self):
         ref = resolve_reference(
-            Address.fromabsolute("datasource/$1.cars[0].engine.fuelPump"), self.document_service.get_data_source
+            Address.from_absolute("datasource/$1.cars[0].engine.fuelPump"), self.document_service.get_data_source
         )
         assert ref.data_source_id == "datasource"
         assert ref.document_id == "2"
@@ -131,7 +131,7 @@ class ResolveReferenceTestCase(unittest.TestCase):
 
     def test_with_attributes_via_relative_ref(self):
         ref = resolve_reference(
-            Address.fromabsolute("datasource/$1.customers[1].car.engine"), self.document_service.get_data_source
+            Address.from_absolute("datasource/$1.customers[1].car.engine"), self.document_service.get_data_source
         )
         assert ref.data_source_id == "datasource"
         assert ref.document_id == "1"
@@ -140,7 +140,7 @@ class ResolveReferenceTestCase(unittest.TestCase):
 
     def test_with_query_to_uncontained(self):
         ref = resolve_reference(
-            Address.fromabsolute("datasource/$1.customers(name=Jane)"), self.document_service.get_data_source
+            Address.from_absolute("datasource/$1.customers(name=Jane)"), self.document_service.get_data_source
         )
         assert ref.data_source_id == "datasource"
         assert ref.document_id == "1"
@@ -149,7 +149,7 @@ class ResolveReferenceTestCase(unittest.TestCase):
 
     def test_with_query_to_uncontained_child(self):
         ref = resolve_reference(
-            Address.fromabsolute("datasource/$1.customers(name=Jane).car"), self.document_service.get_data_source
+            Address.from_absolute("datasource/$1.customers(name=Jane).car"), self.document_service.get_data_source
         )
         assert ref.data_source_id == "datasource"
         assert ref.document_id == "4"
@@ -160,19 +160,19 @@ class ResolveReferenceTestCase(unittest.TestCase):
         with pytest.raises(
             NotFoundException, match=re.escape("No document with id '5' could be found in data source 'datasource'.")
         ):
-            resolve_reference(Address.fromabsolute("datasource/$5"), self.document_service.get_data_source)
+            resolve_reference(Address.from_absolute("datasource/$5"), self.document_service.get_data_source)
 
     def test_invalid_query_no_document(self):
         with pytest.raises(
             NotFoundException,
             match=re.escape("No document that match '_id=5' could be found in data source 'datasource'."),
         ):
-            resolve_reference(Address.fromabsolute("datasource/[(_id=5)]"), self.document_service.get_data_source)
+            resolve_reference(Address.from_absolute("datasource/[(_id=5)]"), self.document_service.get_data_source)
 
     def test_invalid_query_no_attribute(self):
         with pytest.raises(ApplicationException, match=re.escape("No object matches filter 'name=Peter'")):
             resolve_reference(
-                Address.fromabsolute("datasource/$1.customers[(name=Peter)]"), self.document_service.get_data_source
+                Address.from_absolute("datasource/$1.customers[(name=Peter)]"), self.document_service.get_data_source
             )
 
     def test_invalid_attribute(self):
@@ -182,19 +182,19 @@ class ResolveReferenceTestCase(unittest.TestCase):
                 f"Invalid attribute 'cers'. Valid attributes are '{list(self.car_rental_company.keys())}'."
             ),
         ):
-            resolve_reference(Address.fromabsolute("datasource/$1.cers"), self.document_service.get_data_source)
+            resolve_reference(Address.from_absolute("datasource/$1.cers"), self.document_service.get_data_source)
 
     def test_invalid_index(self):
         with pytest.raises(
             NotFoundException,
             match=re.escape(f"Invalid index '[1]'. Valid indices are < {len(self.car_rental_company['cars'])}."),
         ):
-            resolve_reference(Address.fromabsolute("datasource/$1.cars[1]"), self.document_service.get_data_source)
+            resolve_reference(Address.from_absolute("datasource/$1.cars[1]"), self.document_service.get_data_source)
 
     def test_invalid_reference_to_primitive(self):
         with pytest.raises(
             NotFoundException, match=re.escape("Path ['1', 'cars', '[0]', 'plateNumber'] leads to a primitive value.")
         ):
             resolve_reference(
-                Address.fromabsolute("datasource/$1.cars[0].plateNumber"), self.document_service.get_data_source
+                Address.from_absolute("datasource/$1.cars[0].plateNumber"), self.document_service.get_data_source
             )

--- a/src/tests/unit/common/utils/test_resolve_reference.py
+++ b/src/tests/unit/common/utils/test_resolve_reference.py
@@ -5,6 +5,7 @@ from unittest import mock
 import pytest
 
 from common.exceptions import ApplicationException, NotFoundException
+from common.reference import Reference
 from common.utils.resolve_reference import resolve_reference
 from enums import REFERENCE_TYPES, SIMOS
 from tests.unit.mock_utils import get_mock_document_service
@@ -33,7 +34,16 @@ class ResolveReferenceTestCase(unittest.TestCase):
                     "address": "$4",
                     "type": SIMOS.REFERENCE.value,
                     "referenceType": REFERENCE_TYPES.LINK.value,
-                }
+                },
+                {
+                    "type": "test_data/complex/Customer",
+                    "name": "Jon",
+                    "car": {
+                        "address": "^.cars[0]",
+                        "type": SIMOS.REFERENCE.value,
+                        "referenceType": REFERENCE_TYPES.LINK.value,
+                    },
+                },
             ],
         }
         self.customer = {
@@ -88,42 +98,59 @@ class ResolveReferenceTestCase(unittest.TestCase):
         return documents
 
     def test_id(self):
-        ref = resolve_reference("datasource/$1", self.document_service.get_data_source)
+        ref = resolve_reference(Reference.fromabsolute("datasource/$1"), self.document_service.get_data_source)
         assert ref.data_source_id == "datasource"
         assert ref.document_id == "1"
         assert ref.attribute_path == []
         assert ref.entity == self.car_rental_company
 
     def test_with_attributes(self):
-        ref = resolve_reference("datasource/$1.cars[0]", self.document_service.get_data_source)
+        ref = resolve_reference(Reference.fromabsolute("datasource/$1.cars[0]"), self.document_service.get_data_source)
         assert ref.data_source_id == "datasource"
         assert ref.document_id == "1"
         assert ref.attribute_path == ["cars", "[0]"]
         assert ref.entity == self.car_rental_company["cars"][0]
 
     def test_with_attributes_to_uncontained(self):
-        ref = resolve_reference("datasource/$1.cars[0].engine", self.document_service.get_data_source)
+        ref = resolve_reference(
+            Reference.fromabsolute("datasource/$1.cars[0].engine"), self.document_service.get_data_source
+        )
         assert ref.data_source_id == "datasource"
         assert ref.document_id == "1"
         assert ref.attribute_path == ["cars", "[0]", "engine"]
         assert ref.entity == self.car_rental_company["cars"][0]["engine"]
 
     def test_with_attributes_to_uncontained_child(self):
-        ref = resolve_reference("datasource/$1.cars[0].engine.fuelPump", self.document_service.get_data_source)
+        ref = resolve_reference(
+            Reference.fromabsolute("datasource/$1.cars[0].engine.fuelPump"), self.document_service.get_data_source
+        )
         assert ref.data_source_id == "datasource"
         assert ref.document_id == "2"
         assert ref.attribute_path == ["fuelPump"]
         assert ref.entity == self.engine["fuelPump"]
 
+    def test_with_attributes_via_relative_ref(self):
+        ref = resolve_reference(
+            Reference.fromabsolute("datasource/$1.customers[1].car.engine"), self.document_service.get_data_source
+        )
+        assert ref.data_source_id == "datasource"
+        assert ref.document_id == "1"
+        assert ref.attribute_path == ["cars", "[0]", "engine"]
+        assert ref.entity == self.car_rental_company["cars"][0]["engine"]
+
     def test_with_query_to_uncontained(self):
-        ref = resolve_reference("datasource/$1.customers(name=Jane)", self.document_service.get_data_source)
+        ref = resolve_reference(
+            Reference.fromabsolute("datasource/$1.customers(name=Jane)"), self.document_service.get_data_source
+        )
         assert ref.data_source_id == "datasource"
         assert ref.document_id == "1"
         assert ref.attribute_path == ["customers", "[0]"]
         assert ref.entity == self.car_rental_company["customers"][0]
 
     def test_with_query_to_uncontained_child(self):
-        ref = resolve_reference("datasource/$1.customers(name=Jane).car", self.document_service.get_data_source)
+        ref = resolve_reference(
+            Reference.fromabsolute("datasource/$1.customers(name=Jane).car"), self.document_service.get_data_source
+        )
         assert ref.data_source_id == "datasource"
         assert ref.document_id == "4"
         assert ref.attribute_path == ["car"]
@@ -133,18 +160,20 @@ class ResolveReferenceTestCase(unittest.TestCase):
         with pytest.raises(
             NotFoundException, match=re.escape("No document with id '5' could be found in data source 'datasource'.")
         ):
-            resolve_reference("datasource/$5", self.document_service.get_data_source)
+            resolve_reference(Reference.fromabsolute("datasource/$5"), self.document_service.get_data_source)
 
     def test_invalid_query_no_document(self):
         with pytest.raises(
             NotFoundException,
             match=re.escape("No document that match '_id=5' could be found in data source 'datasource'."),
         ):
-            resolve_reference("datasource/[(_id=5)]", self.document_service.get_data_source)
+            resolve_reference(Reference.fromabsolute("datasource/[(_id=5)]"), self.document_service.get_data_source)
 
     def test_invalid_query_no_attribute(self):
         with pytest.raises(ApplicationException, match=re.escape("No object matches filter 'name=Peter'")):
-            resolve_reference("datasource/$1.customers[(name=Peter)]", self.document_service.get_data_source)
+            resolve_reference(
+                Reference.fromabsolute("datasource/$1.customers[(name=Peter)]"), self.document_service.get_data_source
+            )
 
     def test_invalid_attribute(self):
         with pytest.raises(
@@ -153,17 +182,19 @@ class ResolveReferenceTestCase(unittest.TestCase):
                 f"Invalid attribute 'cers'. Valid attributes are '{list(self.car_rental_company.keys())}'."
             ),
         ):
-            resolve_reference("datasource/$1.cers", self.document_service.get_data_source)
+            resolve_reference(Reference.fromabsolute("datasource/$1.cers"), self.document_service.get_data_source)
 
     def test_invalid_index(self):
         with pytest.raises(
             NotFoundException,
             match=re.escape(f"Invalid index '[1]'. Valid indices are < {len(self.car_rental_company['cars'])}."),
         ):
-            resolve_reference("datasource/$1.cars[1]", self.document_service.get_data_source)
+            resolve_reference(Reference.fromabsolute("datasource/$1.cars[1]"), self.document_service.get_data_source)
 
     def test_invalid_reference_to_primitive(self):
         with pytest.raises(
             NotFoundException, match=re.escape("Path ['1', 'cars', '[0]', 'plateNumber'] leads to a primitive value.")
         ):
-            resolve_reference("datasource/$1.cars[0].plateNumber", self.document_service.get_data_source)
+            resolve_reference(
+                Reference.fromabsolute("datasource/$1.cars[0].plateNumber"), self.document_service.get_data_source
+            )

--- a/src/tests/unit/test_complex_arrays.py
+++ b/src/tests/unit/test_complex_arrays.py
@@ -266,7 +266,7 @@ class ArraysDocumentServiceTestCase(unittest.TestCase):
         document_service = get_mock_document_service(repository_provider, blueprint_provider=blueprint_provider)
         # fmt: off
         document_service.update_document(
-            address=Address.fromabsolute("dmss://testing/$1"),
+            address=Address.from_absolute("dmss://testing/$1"),
             data={
                 "_id": "1",
                 "name": "complexArraysEntity",

--- a/src/tests/unit/test_complex_arrays.py
+++ b/src/tests/unit/test_complex_arrays.py
@@ -3,6 +3,7 @@ from copy import deepcopy
 from unittest import mock, skip
 
 from authentication.models import User
+from common.reference import Reference
 from common.utils.data_structure.compare import get_and_print_diff
 from domain_classes.blueprint import Blueprint
 from enums import SIMOS
@@ -265,7 +266,7 @@ class ArraysDocumentServiceTestCase(unittest.TestCase):
         document_service = get_mock_document_service(repository_provider, blueprint_provider=blueprint_provider)
         # fmt: off
         document_service.update_document(
-            reference="dmss://testing/$1",
+            reference=Reference.fromabsolute("dmss://testing/$1"),
             data={
                 "_id": "1",
                 "name": "complexArraysEntity",

--- a/src/tests/unit/test_complex_arrays.py
+++ b/src/tests/unit/test_complex_arrays.py
@@ -3,7 +3,7 @@ from copy import deepcopy
 from unittest import mock, skip
 
 from authentication.models import User
-from common.reference import Reference
+from common.address import Address
 from common.utils.data_structure.compare import get_and_print_diff
 from domain_classes.blueprint import Blueprint
 from enums import SIMOS
@@ -266,7 +266,7 @@ class ArraysDocumentServiceTestCase(unittest.TestCase):
         document_service = get_mock_document_service(repository_provider, blueprint_provider=blueprint_provider)
         # fmt: off
         document_service.update_document(
-            reference=Reference.fromabsolute("dmss://testing/$1"),
+            address=Address.fromabsolute("dmss://testing/$1"),
             data={
                 "_id": "1",
                 "name": "complexArraysEntity",

--- a/src/tests/unit/test_get_document/test_inputs.py
+++ b/src/tests/unit/test_get_document/test_inputs.py
@@ -1,7 +1,7 @@
 import unittest
 from unittest import mock
 
-from common.reference import Reference
+from common.address import Address
 from common.tree_node_serializer import tree_node_to_dict
 from common.utils.data_structure.compare import get_and_print_diff
 from enums import REFERENCE_TYPES, SIMOS
@@ -88,7 +88,7 @@ class GetDocumentInputTestCase(unittest.TestCase):
     def test_attribute_no_resolve(self):
         root = tree_node_to_dict(
             self.document_service.get_document(
-                Reference.fromabsolute("datasource/$1.cars[0].engine"), 0, resolve_links=False
+                Address.fromabsolute("datasource/$1.cars[0].engine"), 0, resolve_links=False
             )
         )
         assert get_and_print_diff(root, self.car_rental_company["cars"][0]["engine"]) == []
@@ -96,7 +96,7 @@ class GetDocumentInputTestCase(unittest.TestCase):
     def test_attribute_resolve(self):
         root = tree_node_to_dict(
             self.document_service.get_document(
-                Reference.fromabsolute("datasource/$1.cars[0].engine"), 0, resolve_links=True
+                Address.fromabsolute("datasource/$1.cars[0].engine"), 0, resolve_links=True
             )
         )
         assert get_and_print_diff(root, self.engine) == []
@@ -104,7 +104,7 @@ class GetDocumentInputTestCase(unittest.TestCase):
     def test_query_no_resolve(self):
         root = tree_node_to_dict(
             self.document_service.get_document(
-                Reference.fromabsolute("datasource/$1.customers(name=Jane)"), 0, resolve_links=False
+                Address.fromabsolute("datasource/$1.customers(name=Jane)"), 0, resolve_links=False
             )
         )
         assert get_and_print_diff(root, self.car_rental_company["customers"][0]) == []
@@ -112,26 +112,26 @@ class GetDocumentInputTestCase(unittest.TestCase):
     def test_query_resolve(self):
         root = tree_node_to_dict(
             self.document_service.get_document(
-                Reference.fromabsolute("datasource/$1.customers(name=Jane)"), 0, resolve_links=True
+                Address.fromabsolute("datasource/$1.customers(name=Jane)"), 0, resolve_links=True
             )
         )
         assert get_and_print_diff(root, self.customer) == []
 
     def test_depth_0(self):
         root = tree_node_to_dict(
-            self.document_service.get_document(Reference.fromabsolute("datasource/$1"), 0, resolve_links=True)
+            self.document_service.get_document(Address.fromabsolute("datasource/$1"), 0, resolve_links=True)
         )
         assert get_and_print_diff(root, self.car_rental_company) == []
 
     def test_depth_1(self):
         root = tree_node_to_dict(
-            self.document_service.get_document(Reference.fromabsolute("datasource/$1"), 1, resolve_links=True)
+            self.document_service.get_document(Address.fromabsolute("datasource/$1"), 1, resolve_links=True)
         )
         assert get_and_print_diff(root, {**self.car_rental_company, "customers": [self.customer]}) == []
 
     def test_depth_2(self):
         root = tree_node_to_dict(
-            self.document_service.get_document(Reference.fromabsolute("datasource/$1"), 2, resolve_links=True)
+            self.document_service.get_document(Address.fromabsolute("datasource/$1"), 2, resolve_links=True)
         )
         assert (
             get_and_print_diff(
@@ -147,19 +147,19 @@ class GetDocumentInputTestCase(unittest.TestCase):
 
     def test_nested_depth_0(self):
         root = tree_node_to_dict(
-            self.document_service.get_document(Reference.fromabsolute("datasource/$1.cars[0]"), 0, resolve_links=True)
+            self.document_service.get_document(Address.fromabsolute("datasource/$1.cars[0]"), 0, resolve_links=True)
         )
         assert get_and_print_diff(root, self.car_rental_company["cars"][0]) == []
 
     def test_nested_depth_1(self):
         root = tree_node_to_dict(
-            self.document_service.get_document(Reference.fromabsolute("datasource/$1.cars[0]"), 1, resolve_links=True)
+            self.document_service.get_document(Address.fromabsolute("datasource/$1.cars[0]"), 1, resolve_links=True)
         )
         assert get_and_print_diff(root, {**self.car_rental_company["cars"][0], "engine": self.engine}) == []
 
     def test_nested_depth_2(self):
         root = tree_node_to_dict(
-            self.document_service.get_document(Reference.fromabsolute("datasource/$1.cars[0]"), 2, resolve_links=True)
+            self.document_service.get_document(Address.fromabsolute("datasource/$1.cars[0]"), 2, resolve_links=True)
         )
         assert (
             get_and_print_diff(

--- a/src/tests/unit/test_get_document/test_inputs.py
+++ b/src/tests/unit/test_get_document/test_inputs.py
@@ -88,7 +88,7 @@ class GetDocumentInputTestCase(unittest.TestCase):
     def test_attribute_no_resolve(self):
         root = tree_node_to_dict(
             self.document_service.get_document(
-                Address.fromabsolute("datasource/$1.cars[0].engine"), 0, resolve_links=False
+                Address.from_absolute("datasource/$1.cars[0].engine"), 0, resolve_links=False
             )
         )
         assert get_and_print_diff(root, self.car_rental_company["cars"][0]["engine"]) == []
@@ -96,7 +96,7 @@ class GetDocumentInputTestCase(unittest.TestCase):
     def test_attribute_resolve(self):
         root = tree_node_to_dict(
             self.document_service.get_document(
-                Address.fromabsolute("datasource/$1.cars[0].engine"), 0, resolve_links=True
+                Address.from_absolute("datasource/$1.cars[0].engine"), 0, resolve_links=True
             )
         )
         assert get_and_print_diff(root, self.engine) == []
@@ -104,7 +104,7 @@ class GetDocumentInputTestCase(unittest.TestCase):
     def test_query_no_resolve(self):
         root = tree_node_to_dict(
             self.document_service.get_document(
-                Address.fromabsolute("datasource/$1.customers(name=Jane)"), 0, resolve_links=False
+                Address.from_absolute("datasource/$1.customers(name=Jane)"), 0, resolve_links=False
             )
         )
         assert get_and_print_diff(root, self.car_rental_company["customers"][0]) == []
@@ -112,26 +112,26 @@ class GetDocumentInputTestCase(unittest.TestCase):
     def test_query_resolve(self):
         root = tree_node_to_dict(
             self.document_service.get_document(
-                Address.fromabsolute("datasource/$1.customers(name=Jane)"), 0, resolve_links=True
+                Address.from_absolute("datasource/$1.customers(name=Jane)"), 0, resolve_links=True
             )
         )
         assert get_and_print_diff(root, self.customer) == []
 
     def test_depth_0(self):
         root = tree_node_to_dict(
-            self.document_service.get_document(Address.fromabsolute("datasource/$1"), 0, resolve_links=True)
+            self.document_service.get_document(Address.from_absolute("datasource/$1"), 0, resolve_links=True)
         )
         assert get_and_print_diff(root, self.car_rental_company) == []
 
     def test_depth_1(self):
         root = tree_node_to_dict(
-            self.document_service.get_document(Address.fromabsolute("datasource/$1"), 1, resolve_links=True)
+            self.document_service.get_document(Address.from_absolute("datasource/$1"), 1, resolve_links=True)
         )
         assert get_and_print_diff(root, {**self.car_rental_company, "customers": [self.customer]}) == []
 
     def test_depth_2(self):
         root = tree_node_to_dict(
-            self.document_service.get_document(Address.fromabsolute("datasource/$1"), 2, resolve_links=True)
+            self.document_service.get_document(Address.from_absolute("datasource/$1"), 2, resolve_links=True)
         )
         assert (
             get_and_print_diff(
@@ -147,19 +147,19 @@ class GetDocumentInputTestCase(unittest.TestCase):
 
     def test_nested_depth_0(self):
         root = tree_node_to_dict(
-            self.document_service.get_document(Address.fromabsolute("datasource/$1.cars[0]"), 0, resolve_links=True)
+            self.document_service.get_document(Address.from_absolute("datasource/$1.cars[0]"), 0, resolve_links=True)
         )
         assert get_and_print_diff(root, self.car_rental_company["cars"][0]) == []
 
     def test_nested_depth_1(self):
         root = tree_node_to_dict(
-            self.document_service.get_document(Address.fromabsolute("datasource/$1.cars[0]"), 1, resolve_links=True)
+            self.document_service.get_document(Address.from_absolute("datasource/$1.cars[0]"), 1, resolve_links=True)
         )
         assert get_and_print_diff(root, {**self.car_rental_company["cars"][0], "engine": self.engine}) == []
 
     def test_nested_depth_2(self):
         root = tree_node_to_dict(
-            self.document_service.get_document(Address.fromabsolute("datasource/$1.cars[0]"), 2, resolve_links=True)
+            self.document_service.get_document(Address.from_absolute("datasource/$1.cars[0]"), 2, resolve_links=True)
         )
         assert (
             get_and_print_diff(

--- a/src/tests/unit/test_get_document/test_inputs.py
+++ b/src/tests/unit/test_get_document/test_inputs.py
@@ -1,6 +1,7 @@
 import unittest
 from unittest import mock
 
+from common.reference import Reference
 from common.tree_node_serializer import tree_node_to_dict
 from common.utils.data_structure.compare import get_and_print_diff
 from enums import REFERENCE_TYPES, SIMOS
@@ -86,38 +87,52 @@ class GetDocumentInputTestCase(unittest.TestCase):
 
     def test_attribute_no_resolve(self):
         root = tree_node_to_dict(
-            self.document_service.get_document("datasource/$1.cars[0].engine", 0, resolve_links=False)
+            self.document_service.get_document(
+                Reference.fromabsolute("datasource/$1.cars[0].engine"), 0, resolve_links=False
+            )
         )
         assert get_and_print_diff(root, self.car_rental_company["cars"][0]["engine"]) == []
 
     def test_attribute_resolve(self):
         root = tree_node_to_dict(
-            self.document_service.get_document("datasource/$1.cars[0].engine", 0, resolve_links=True)
+            self.document_service.get_document(
+                Reference.fromabsolute("datasource/$1.cars[0].engine"), 0, resolve_links=True
+            )
         )
         assert get_and_print_diff(root, self.engine) == []
 
     def test_query_no_resolve(self):
         root = tree_node_to_dict(
-            self.document_service.get_document("datasource/$1.customers(name=Jane)", 0, resolve_links=False)
+            self.document_service.get_document(
+                Reference.fromabsolute("datasource/$1.customers(name=Jane)"), 0, resolve_links=False
+            )
         )
         assert get_and_print_diff(root, self.car_rental_company["customers"][0]) == []
 
     def test_query_resolve(self):
         root = tree_node_to_dict(
-            self.document_service.get_document("datasource/$1.customers(name=Jane)", 0, resolve_links=True)
+            self.document_service.get_document(
+                Reference.fromabsolute("datasource/$1.customers(name=Jane)"), 0, resolve_links=True
+            )
         )
         assert get_and_print_diff(root, self.customer) == []
 
     def test_depth_0(self):
-        root = tree_node_to_dict(self.document_service.get_document("datasource/$1", 0, resolve_links=True))
+        root = tree_node_to_dict(
+            self.document_service.get_document(Reference.fromabsolute("datasource/$1"), 0, resolve_links=True)
+        )
         assert get_and_print_diff(root, self.car_rental_company) == []
 
     def test_depth_1(self):
-        root = tree_node_to_dict(self.document_service.get_document("datasource/$1", 1, resolve_links=True))
+        root = tree_node_to_dict(
+            self.document_service.get_document(Reference.fromabsolute("datasource/$1"), 1, resolve_links=True)
+        )
         assert get_and_print_diff(root, {**self.car_rental_company, "customers": [self.customer]}) == []
 
     def test_depth_2(self):
-        root = tree_node_to_dict(self.document_service.get_document("datasource/$1", 2, resolve_links=True))
+        root = tree_node_to_dict(
+            self.document_service.get_document(Reference.fromabsolute("datasource/$1"), 2, resolve_links=True)
+        )
         assert (
             get_and_print_diff(
                 root,
@@ -131,15 +146,21 @@ class GetDocumentInputTestCase(unittest.TestCase):
         )
 
     def test_nested_depth_0(self):
-        root = tree_node_to_dict(self.document_service.get_document("datasource/$1.cars[0]", 0, resolve_links=True))
+        root = tree_node_to_dict(
+            self.document_service.get_document(Reference.fromabsolute("datasource/$1.cars[0]"), 0, resolve_links=True)
+        )
         assert get_and_print_diff(root, self.car_rental_company["cars"][0]) == []
 
     def test_nested_depth_1(self):
-        root = tree_node_to_dict(self.document_service.get_document("datasource/$1.cars[0]", 1, resolve_links=True))
+        root = tree_node_to_dict(
+            self.document_service.get_document(Reference.fromabsolute("datasource/$1.cars[0]"), 1, resolve_links=True)
+        )
         assert get_and_print_diff(root, {**self.car_rental_company["cars"][0], "engine": self.engine}) == []
 
     def test_nested_depth_2(self):
-        root = tree_node_to_dict(self.document_service.get_document("datasource/$1.cars[0]", 2, resolve_links=True))
+        root = tree_node_to_dict(
+            self.document_service.get_document(Reference.fromabsolute("datasource/$1.cars[0]"), 2, resolve_links=True)
+        )
         assert (
             get_and_print_diff(
                 root, {**self.car_rental_company["cars"][0], "engine": {**self.engine, "fuelPump": self.fuel_pump}}

--- a/src/tests/unit/test_get_document/test_reference_resolve.py
+++ b/src/tests/unit/test_get_document/test_reference_resolve.py
@@ -4,7 +4,7 @@ from unittest import mock
 
 import pytest
 
-from common.reference import Reference
+from common.address import Address
 from common.tree_node_serializer import tree_node_to_dict
 from common.utils.data_structure.compare import get_and_print_diff
 from common.utils.data_structure.has_key_value_pairs import has_key_value_pairs
@@ -57,7 +57,7 @@ class GetDocumentResolveTestCase(unittest.TestCase):
         document_service = get_mock_document_service(lambda x, y: document_repository)
         with pytest.raises(Exception, match=r"The protocol 'wrong' is not supported"):
             tree_node_to_dict(
-                document_service.get_document(Reference.fromabsolute("datasource/$1"), resolve_links=True, depth=9)
+                document_service.get_document(Address.fromabsolute("datasource/$1"), resolve_links=True, depth=9)
             )
 
     def test_references(self):
@@ -253,10 +253,10 @@ class GetDocumentResolveTestCase(unittest.TestCase):
 
         document_service = get_mock_document_service(mock_data_source)
         actual = tree_node_to_dict(
-            document_service.get_document(Reference.fromabsolute("test_data/$2"), resolve_links=True, depth=99)
+            document_service.get_document(Address.fromabsolute("test_data/$2"), resolve_links=True, depth=99)
         )
         complex_package = tree_node_to_dict(
-            document_service.get_document(Reference.fromabsolute("test_data/$1"), resolve_links=True, depth=99)
+            document_service.get_document(Address.fromabsolute("test_data/$1"), resolve_links=True, depth=99)
         )
 
         assert isinstance(actual, dict)

--- a/src/tests/unit/test_get_document/test_reference_resolve.py
+++ b/src/tests/unit/test_get_document/test_reference_resolve.py
@@ -4,6 +4,7 @@ from unittest import mock
 
 import pytest
 
+from common.reference import Reference
 from common.tree_node_serializer import tree_node_to_dict
 from common.utils.data_structure.compare import get_and_print_diff
 from common.utils.data_structure.has_key_value_pairs import has_key_value_pairs
@@ -55,7 +56,9 @@ class GetDocumentResolveTestCase(unittest.TestCase):
 
         document_service = get_mock_document_service(lambda x, y: document_repository)
         with pytest.raises(Exception, match=r"The protocol 'wrong' is not supported"):
-            tree_node_to_dict(document_service.get_document("datasource/$1", resolve_links=True, depth=9))
+            tree_node_to_dict(
+                document_service.get_document(Reference.fromabsolute("datasource/$1"), resolve_links=True, depth=9)
+            )
 
     def test_references(self):
         my_car_rental = {
@@ -249,9 +252,11 @@ class GetDocumentResolveTestCase(unittest.TestCase):
             return document_repository
 
         document_service = get_mock_document_service(mock_data_source)
-        actual = tree_node_to_dict(document_service.get_document("test_data/$2", resolve_links=True, depth=99))
+        actual = tree_node_to_dict(
+            document_service.get_document(Reference.fromabsolute("test_data/$2"), resolve_links=True, depth=99)
+        )
         complex_package = tree_node_to_dict(
-            document_service.get_document("test_data/$1", resolve_links=True, depth=99)
+            document_service.get_document(Reference.fromabsolute("test_data/$1"), resolve_links=True, depth=99)
         )
 
         assert isinstance(actual, dict)

--- a/src/tests/unit/test_get_document/test_reference_resolve.py
+++ b/src/tests/unit/test_get_document/test_reference_resolve.py
@@ -57,7 +57,7 @@ class GetDocumentResolveTestCase(unittest.TestCase):
         document_service = get_mock_document_service(lambda x, y: document_repository)
         with pytest.raises(Exception, match=r"The protocol 'wrong' is not supported"):
             tree_node_to_dict(
-                document_service.get_document(Address.fromabsolute("datasource/$1"), resolve_links=True, depth=9)
+                document_service.get_document(Address.from_absolute("datasource/$1"), resolve_links=True, depth=9)
             )
 
     def test_references(self):
@@ -253,10 +253,10 @@ class GetDocumentResolveTestCase(unittest.TestCase):
 
         document_service = get_mock_document_service(mock_data_source)
         actual = tree_node_to_dict(
-            document_service.get_document(Address.fromabsolute("test_data/$2"), resolve_links=True, depth=99)
+            document_service.get_document(Address.from_absolute("test_data/$2"), resolve_links=True, depth=99)
         )
         complex_package = tree_node_to_dict(
-            document_service.get_document(Address.fromabsolute("test_data/$1"), resolve_links=True, depth=99)
+            document_service.get_document(Address.from_absolute("test_data/$1"), resolve_links=True, depth=99)
         )
 
         assert isinstance(actual, dict)

--- a/src/tests/unit/test_get_extended.py
+++ b/src/tests/unit/test_get_extended.py
@@ -53,7 +53,7 @@ class GetExtendedBlueprintTestCase(unittest.TestCase):
         repository.update = mock_update
         document_service = get_mock_document_service(lambda x, y: repository)
 
-        node: Node = document_service.get_document(Address.fromabsolute("testing/$1"))
+        node: Node = document_service.get_document(Address.from_absolute("testing/$1"))
         node.update(doc_1_after)
         document_service.save(node, "testing")
 

--- a/src/tests/unit/test_get_extended.py
+++ b/src/tests/unit/test_get_extended.py
@@ -1,6 +1,7 @@
 import unittest
 from unittest import mock
 
+from common.reference import Reference
 from common.utils.data_structure.compare import get_and_print_diff
 from domain_classes.blueprint import Blueprint
 from domain_classes.tree_node import Node
@@ -52,7 +53,7 @@ class GetExtendedBlueprintTestCase(unittest.TestCase):
         repository.update = mock_update
         document_service = get_mock_document_service(lambda x, y: repository)
 
-        node: Node = document_service.get_document("testing/$1")
+        node: Node = document_service.get_document(Reference.fromabsolute("testing/$1"))
         node.update(doc_1_after)
         document_service.save(node, "testing")
 

--- a/src/tests/unit/test_get_extended.py
+++ b/src/tests/unit/test_get_extended.py
@@ -1,7 +1,7 @@
 import unittest
 from unittest import mock
 
-from common.reference import Reference
+from common.address import Address
 from common.utils.data_structure.compare import get_and_print_diff
 from domain_classes.blueprint import Blueprint
 from domain_classes.tree_node import Node
@@ -53,7 +53,7 @@ class GetExtendedBlueprintTestCase(unittest.TestCase):
         repository.update = mock_update
         document_service = get_mock_document_service(lambda x, y: repository)
 
-        node: Node = document_service.get_document(Reference.fromabsolute("testing/$1"))
+        node: Node = document_service.get_document(Address.fromabsolute("testing/$1"))
         node.update(doc_1_after)
         document_service.save(node, "testing")
 

--- a/src/tests/unit/test_reference.py
+++ b/src/tests/unit/test_reference.py
@@ -3,8 +3,8 @@ from unittest import mock
 
 from pydantic import ValidationError
 
+from common.address import Address
 from common.exceptions import BadRequestException, NotFoundException
-from common.reference import Reference
 from enums import REFERENCE_TYPES, SIMOS
 from restful.request_types.shared import ReferenceEntity
 from tests.unit.mock_utils import get_mock_document_service
@@ -43,7 +43,7 @@ class ReferenceTestCase(unittest.TestCase):
             "referenceType": REFERENCE_TYPES.LINK.value,
         }
         document_service.insert_reference(
-            Reference("$1.uncontained_in_every_way", "testing"),
+            Address("$1.uncontained_in_every_way", "testing"),
             ReferenceEntity.parse_obj(reference),
         )
         assert doc_storage["1"]["uncontained_in_every_way"] == reference
@@ -77,7 +77,7 @@ class ReferenceTestCase(unittest.TestCase):
 
         with self.assertRaises(NotFoundException):
             document_service.insert_reference(
-                Reference("$1.uncontained_in_every_way", "testing"),
+                Address("$1.uncontained_in_every_way", "testing"),
                 ReferenceEntity.parse_obj(
                     {
                         "address": "$2d7c3249-985d-43d2-83cf-a887e440825a",
@@ -116,7 +116,7 @@ class ReferenceTestCase(unittest.TestCase):
 
         with self.assertRaises(BadRequestException):
             document_service.insert_reference(
-                Reference("$1.uncontained_in_every_way", "testing"),
+                Address("$1.uncontained_in_every_way", "testing"),
                 ReferenceEntity.parse_obj(
                     {
                         "address": "$2d7c3249-985d-43d2-83cf-a887e440825a",
@@ -157,7 +157,7 @@ class ReferenceTestCase(unittest.TestCase):
         document_service = get_mock_document_service(lambda x, y: repository)
 
         document_service.insert_reference(
-            Reference("$1.uncontained_in_every_way", "testing"),
+            Address("$1.uncontained_in_every_way", "testing"),
             ReferenceEntity.parse_obj(
                 {
                     "address": "$2d7c3249-985d-43d2-83cf-a887e440825a",
@@ -200,7 +200,7 @@ class ReferenceTestCase(unittest.TestCase):
 
         with self.assertRaises(ValidationError):
             document_service.insert_reference(
-                Reference("$1.uncontained_in_every_way", "testing"),
+                Address("$1.uncontained_in_every_way", "testing"),
                 ReferenceEntity.parse_obj({"_id": "something", "type": "something"}),
             )
 
@@ -236,7 +236,7 @@ class ReferenceTestCase(unittest.TestCase):
         repository.update = mock_update
         document_service = get_mock_document_service(lambda x, y: repository)
 
-        document_service.remove_reference(Reference("$1.uncontained_in_every_way", "testing"))
+        document_service.remove_reference(Address("$1.uncontained_in_every_way", "testing"))
         assert doc_storage["1"]["uncontained_in_every_way"] == {}
 
     def test_remove_nested_reference(self):
@@ -277,7 +277,7 @@ class ReferenceTestCase(unittest.TestCase):
         document_service = get_mock_document_service(lambda x, y: repository)
 
         document_service.remove_reference(
-            Reference("$1.i_have_a_uncontained_attribute.uncontained_in_every_way", "testing")
+            Address("$1.i_have_a_uncontained_attribute.uncontained_in_every_way", "testing")
         )
         assert doc_storage["1"]["i_have_a_uncontained_attribute"]["uncontained_in_every_way"] == {}
 
@@ -322,7 +322,7 @@ class ReferenceTestCase(unittest.TestCase):
         repository.update = mock_update
         document_service = get_mock_document_service(lambda x, y: repository)
 
-        document_service.remove_reference(Reference("$1.uncontained_in_every_way[0]", "testing"))
+        document_service.remove_reference(Address("$1.uncontained_in_every_way[0]", "testing"))
         assert len(doc_storage["1"]["uncontained_in_every_way"]) == 1
         assert doc_storage["1"]["uncontained_in_every_way"][0] == {
             "address": "$42dbe4a5-0eb0-4ee2-826c-695172c3c35a",
@@ -371,7 +371,7 @@ class ReferenceTestCase(unittest.TestCase):
             "referenceType": REFERENCE_TYPES.LINK.value,
         }
         document_service.insert_reference(
-            Reference("$1.uncontained_in_every_way", "testing"), ReferenceEntity(**reference)
+            Address("$1.uncontained_in_every_way", "testing"), ReferenceEntity(**reference)
         )
         assert len(doc_storage["1"]["uncontained_in_every_way"]) == 2
         assert doc_storage["1"]["uncontained_in_every_way"][1] == reference

--- a/src/tests/unit/test_reference.py
+++ b/src/tests/unit/test_reference.py
@@ -5,7 +5,7 @@ from pydantic import ValidationError
 
 from common.exceptions import BadRequestException, NotFoundException
 from enums import REFERENCE_TYPES, SIMOS
-from restful.request_types.shared import Reference
+from restful.request_types.shared import ReferenceEntity
 from tests.unit.mock_utils import get_mock_document_service
 
 
@@ -36,7 +36,7 @@ class ReferenceTestCase(unittest.TestCase):
         repository.get = lambda x: doc_storage[str(x)]
         repository.update = mock_update
         document_service = get_mock_document_service(lambda x, y: repository)
-        reference = Reference.parse_obj(
+        reference = ReferenceEntity.parse_obj(
             {
                 "address": "$2d7c3249-985d-43d2-83cf-a887e440825a",
                 "type": SIMOS.REFERENCE.value,
@@ -86,7 +86,7 @@ class ReferenceTestCase(unittest.TestCase):
             document_service.insert_reference(
                 "testing",
                 document_id="$1",
-                reference=Reference.parse_obj(
+                reference=ReferenceEntity.parse_obj(
                     {
                         "address": "$2d7c3249-985d-43d2-83cf-a887e440825a",
                         "type": SIMOS.REFERENCE.value,
@@ -127,7 +127,7 @@ class ReferenceTestCase(unittest.TestCase):
             document_service.insert_reference(
                 "testing",
                 document_id="$1",
-                reference=Reference.parse_obj(
+                reference=ReferenceEntity.parse_obj(
                     {
                         "address": "$2d7c3249-985d-43d2-83cf-a887e440825a",
                         "type": SIMOS.REFERENCE.value,
@@ -170,7 +170,7 @@ class ReferenceTestCase(unittest.TestCase):
         document_service.insert_reference(
             "testing",
             document_id="$1",
-            reference=Reference.parse_obj(
+            reference=ReferenceEntity.parse_obj(
                 {
                     "address": "$2d7c3249-985d-43d2-83cf-a887e440825a",
                     "description": "hallO",
@@ -215,7 +215,7 @@ class ReferenceTestCase(unittest.TestCase):
             document_service.insert_reference(
                 "testing",
                 document_id="1",
-                reference=Reference.parse_obj({"_id": "something", "type": "something"}),
+                reference=ReferenceEntity.parse_obj({"_id": "something", "type": "something"}),
                 attribute_path="uncontained_in_every_way",
             )
 
@@ -393,7 +393,7 @@ class ReferenceTestCase(unittest.TestCase):
         document_service.insert_reference(
             "testing",
             document_id="$1",
-            reference=Reference(
+            reference=ReferenceEntity(
                 **{
                     "address": "$42dbe4a5-0eb0-4ee2-826c-695172c3c35a",
                     "type": SIMOS.REFERENCE.value,

--- a/src/tests/unit/test_remove.py
+++ b/src/tests/unit/test_remove.py
@@ -2,7 +2,7 @@ import unittest
 from copy import deepcopy
 from unittest import mock
 
-from common.reference import Reference
+from common.address import Address
 from common.utils.data_structure.compare import get_and_print_diff
 from enums import REFERENCE_TYPES, SIMOS
 from tests.unit.mock_utils import get_mock_document_service
@@ -35,7 +35,7 @@ class DocumentServiceTestCase(unittest.TestCase):
         document_repository.get = lambda id: document_1.copy()
 
         document_service = get_mock_document_service(lambda id, user: document_repository)
-        document_service.remove(Reference("$1", "testing"))
+        document_service.remove(Address("$1", "testing"))
         document_repository.delete.assert_called_with("1")
 
     def test_remove_document_wo_existing_blueprint(self):
@@ -51,7 +51,7 @@ class DocumentServiceTestCase(unittest.TestCase):
             blueprint_provider=NoBlueprints(),
             repository_provider=lambda x, y: self.repository,
         )
-        self.document_service.remove(Reference("$1", "testing"))
+        self.document_service.remove(Address("$1", "testing"))
         assert self.storage == {}
 
     def test_remove_document_with_model_and_storage_uncontained_children(self):
@@ -65,7 +65,7 @@ class DocumentServiceTestCase(unittest.TestCase):
         doc_2 = {"uid": "2", "_id": "2", "name": "a_reference", "description": "", "type": "basic_blueprint"}
         self.storage = {"1": doc_1, "2": doc_2}
 
-        self.document_service.remove(Reference("$1", "testing"))
+        self.document_service.remove(Address("$1", "testing"))
         assert get_and_print_diff(self.storage, {"2": doc_2}) == []
 
     def test_remove_child_dict(self):
@@ -84,7 +84,7 @@ class DocumentServiceTestCase(unittest.TestCase):
             "2": {"name": "Nested", "description": "", "type": "basic_blueprint"},
         }
 
-        self.document_service.remove(Reference("$1.nested", "testing"))
+        self.document_service.remove(Address("$1.nested", "testing"))
         assert self.storage["1"].get("nested") is None
         assert self.storage.get("2") is None
 
@@ -106,7 +106,7 @@ class DocumentServiceTestCase(unittest.TestCase):
             "2": {"name": "Nested", "description": "", "type": "basic_blueprint"},
         }
 
-        self.document_service.remove(Reference("$1.references", "testing"))
+        self.document_service.remove(Address("$1.references", "testing"))
         assert self.storage["1"].get("references") is None
         assert self.storage.get("2") is None
 
@@ -136,7 +136,7 @@ class DocumentServiceTestCase(unittest.TestCase):
             },
         }
 
-        self.document_service.remove(Reference("$1", "testing"))
+        self.document_service.remove(Address("$1", "testing"))
         assert self.storage.get("1") is None
         assert self.storage.get("2") is None
 
@@ -191,7 +191,7 @@ class DocumentServiceTestCase(unittest.TestCase):
             },
         }
 
-        self.document_service.remove(Reference("$1", "testing"))
+        self.document_service.remove(Address("$1", "testing"))
         assert self.storage.get("1") is None
         assert self.storage.get("2") is None
         assert self.storage.get("3") is None
@@ -212,7 +212,7 @@ class DocumentServiceTestCase(unittest.TestCase):
             "2": {"_id": "2", "name": "Reference", "description": "", "type": "basic_blueprint"},
         }
 
-        self.document_service.remove(Reference("$1.reference", "testing"))
+        self.document_service.remove(Address("$1.reference", "testing"))
         assert self.storage["1"] == {
             "_id": "1",
             "name": "Parent",
@@ -236,7 +236,7 @@ class DocumentServiceTestCase(unittest.TestCase):
             }
         }
 
-        self.document_service.remove(Reference("$1.im_optional", "testing"))
+        self.document_service.remove(Address("$1.im_optional", "testing"))
         assert {
             "_id": "1",
             "name": "Parent",
@@ -256,5 +256,5 @@ class DocumentServiceTestCase(unittest.TestCase):
             "blob_object": "someData",
         }
 
-        self.document_service.remove(Reference("$1", "testing"))
+        self.document_service.remove(Address("$1", "testing"))
         assert self.storage.get("blob_object") is None

--- a/src/tests/unit/test_remove.py
+++ b/src/tests/unit/test_remove.py
@@ -2,6 +2,7 @@ import unittest
 from copy import deepcopy
 from unittest import mock
 
+from common.reference import Reference
 from common.utils.data_structure.compare import get_and_print_diff
 from enums import REFERENCE_TYPES, SIMOS
 from tests.unit.mock_utils import get_mock_document_service
@@ -34,7 +35,7 @@ class DocumentServiceTestCase(unittest.TestCase):
         document_repository.get = lambda id: document_1.copy()
 
         document_service = get_mock_document_service(lambda id, user: document_repository)
-        document_service.remove("/testing/$1")
+        document_service.remove(Reference("$1", "testing"))
         document_repository.delete.assert_called_with("1")
 
     def test_remove_document_wo_existing_blueprint(self):
@@ -50,7 +51,7 @@ class DocumentServiceTestCase(unittest.TestCase):
             blueprint_provider=NoBlueprints(),
             repository_provider=lambda x, y: self.repository,
         )
-        self.document_service.remove("/testing/$1")
+        self.document_service.remove(Reference("$1", "testing"))
         assert self.storage == {}
 
     def test_remove_document_with_model_and_storage_uncontained_children(self):
@@ -64,7 +65,7 @@ class DocumentServiceTestCase(unittest.TestCase):
         doc_2 = {"uid": "2", "_id": "2", "name": "a_reference", "description": "", "type": "basic_blueprint"}
         self.storage = {"1": doc_1, "2": doc_2}
 
-        self.document_service.remove("/testing/$1")
+        self.document_service.remove(Reference("$1", "testing"))
         assert get_and_print_diff(self.storage, {"2": doc_2}) == []
 
     def test_remove_child_dict(self):
@@ -83,7 +84,7 @@ class DocumentServiceTestCase(unittest.TestCase):
             "2": {"name": "Nested", "description": "", "type": "basic_blueprint"},
         }
 
-        self.document_service.remove("/testing/$1.nested")
+        self.document_service.remove(Reference("$1.nested", "testing"))
         assert self.storage["1"].get("nested") is None
         assert self.storage.get("2") is None
 
@@ -105,7 +106,7 @@ class DocumentServiceTestCase(unittest.TestCase):
             "2": {"name": "Nested", "description": "", "type": "basic_blueprint"},
         }
 
-        self.document_service.remove("/testing/$1.references")
+        self.document_service.remove(Reference("$1.references", "testing"))
         assert self.storage["1"].get("references") is None
         assert self.storage.get("2") is None
 
@@ -135,7 +136,7 @@ class DocumentServiceTestCase(unittest.TestCase):
             },
         }
 
-        self.document_service.remove("/testing/$1")
+        self.document_service.remove(Reference("$1", "testing"))
         assert self.storage.get("1") is None
         assert self.storage.get("2") is None
 
@@ -190,7 +191,7 @@ class DocumentServiceTestCase(unittest.TestCase):
             },
         }
 
-        self.document_service.remove("/testing/$1")
+        self.document_service.remove(Reference("$1", "testing"))
         assert self.storage.get("1") is None
         assert self.storage.get("2") is None
         assert self.storage.get("3") is None
@@ -211,7 +212,7 @@ class DocumentServiceTestCase(unittest.TestCase):
             "2": {"_id": "2", "name": "Reference", "description": "", "type": "basic_blueprint"},
         }
 
-        self.document_service.remove("/testing/$1.reference")
+        self.document_service.remove(Reference("$1.reference", "testing"))
         assert self.storage["1"] == {
             "_id": "1",
             "name": "Parent",
@@ -235,7 +236,7 @@ class DocumentServiceTestCase(unittest.TestCase):
             }
         }
 
-        self.document_service.remove("/testing/$1.im_optional")
+        self.document_service.remove(Reference("$1.im_optional", "testing"))
         assert {
             "_id": "1",
             "name": "Parent",
@@ -255,5 +256,5 @@ class DocumentServiceTestCase(unittest.TestCase):
             "blob_object": "someData",
         }
 
-        self.document_service.remove("/testing/$1")
+        self.document_service.remove(Reference("$1", "testing"))
         assert self.storage.get("blob_object") is None

--- a/src/tests/unit/test_save.py
+++ b/src/tests/unit/test_save.py
@@ -3,6 +3,7 @@ from copy import deepcopy
 from unittest import mock
 
 from authentication.models import User
+from common.reference import Reference
 from common.tree_node_serializer import tree_node_from_dict
 from common.utils.data_structure.compare import get_and_print_diff
 from domain_classes.blueprint_attribute import BlueprintAttribute
@@ -47,7 +48,7 @@ class DocumentServiceTestCase(unittest.TestCase):
         repository.update = mock_update
         document_service = get_mock_document_service(lambda x, y: repository)
 
-        node: Node = document_service.get_document("testing/$1")
+        node: Node = document_service.get_document(Reference("$1", "testing"))
         contained_node: Node = node.get_by_path("references.1".split("."))
         contained_node.update({"_id": "4", "name": "ref2", "description": "TEST_MODIFY", "type": "basic_blueprint"})
         document_service.save(node, "testing", update_uncontained=True)
@@ -83,7 +84,7 @@ class DocumentServiceTestCase(unittest.TestCase):
         repository.update = mock_update
         document_service = get_mock_document_service(lambda x, y: repository)
 
-        contained_node: Node = document_service.get_document("testing/$1.nested")
+        contained_node: Node = document_service.get_document(Reference("$1.nested", "testing"))
         contained_node.update({"name": "RENAMED", "description": "TEST_MODIFY", "type": "basic_blueprint"})
         document_service.save(contained_node, "testing", update_uncontained=True, initial=True)
 
@@ -117,7 +118,7 @@ class DocumentServiceTestCase(unittest.TestCase):
 
         document_service = get_mock_document_service(lambda x, y: repository)
 
-        node: Node = document_service.get_document("testing/$1")
+        node: Node = document_service.get_document(Reference("$1", "testing"))
         contained_node: Node = node.search("1.references")
         contained_node.children.append(
             Node(
@@ -197,7 +198,7 @@ class DocumentServiceTestCase(unittest.TestCase):
 
         document_service = get_mock_document_service(repository_provider)
 
-        node: Node = document_service.get_document("testing/$1")
+        node: Node = document_service.get_document(Reference("$1", "testing"))
         contained_node: Node = node.search("1.references")
         contained_node.remove_by_path(["1"])
         document_service.save(node, "testing")
@@ -253,7 +254,7 @@ class DocumentServiceTestCase(unittest.TestCase):
         )
 
         # Testing updating the reference
-        node: Node = document_service.get_document("testing/$1")
+        node: Node = document_service.get_document(Reference("$1", "testing"))
         target_node = node.get_by_path(["i_have_a_uncontained_attribute", "uncontained_in_every_way"])
         target_node.update(doc_storage["3"])
         document_service.save(node, "testing")
@@ -300,7 +301,7 @@ class DocumentServiceTestCase(unittest.TestCase):
         document_service = get_mock_document_service(lambda x, y: repository)
 
         document_service.update_document(
-            "dmss://test/$1",
+            Reference("$1", "test"),
             data={
                 "_id": "1",
                 "name": "Root",
@@ -369,7 +370,7 @@ class DocumentServiceTestCase(unittest.TestCase):
             "nested": {},
             "references": [],
         }
-        document_service.update_document("dmss://testing/$1.a", new_data, update_uncontained=True)
+        document_service.update_document(Reference("$1.a", "testing"), new_data, update_uncontained=True)
 
         assert doc_storage["1"]["a"]["description"] == "SOME DESCRIPTION"
         assert doc_storage["1"]["a"]["reference"]["description"] == "A NEW DESCRIPTION HERE"

--- a/src/tests/unit/test_save.py
+++ b/src/tests/unit/test_save.py
@@ -3,7 +3,7 @@ from copy import deepcopy
 from unittest import mock
 
 from authentication.models import User
-from common.reference import Reference
+from common.address import Address
 from common.tree_node_serializer import tree_node_from_dict
 from common.utils.data_structure.compare import get_and_print_diff
 from domain_classes.blueprint_attribute import BlueprintAttribute
@@ -48,7 +48,7 @@ class DocumentServiceTestCase(unittest.TestCase):
         repository.update = mock_update
         document_service = get_mock_document_service(lambda x, y: repository)
 
-        node: Node = document_service.get_document(Reference("$1", "testing"))
+        node: Node = document_service.get_document(Address("$1", "testing"))
         contained_node: Node = node.get_by_path("references.1".split("."))
         contained_node.update({"_id": "4", "name": "ref2", "description": "TEST_MODIFY", "type": "basic_blueprint"})
         document_service.save(node, "testing", update_uncontained=True)
@@ -84,7 +84,7 @@ class DocumentServiceTestCase(unittest.TestCase):
         repository.update = mock_update
         document_service = get_mock_document_service(lambda x, y: repository)
 
-        contained_node: Node = document_service.get_document(Reference("$1.nested", "testing"))
+        contained_node: Node = document_service.get_document(Address("$1.nested", "testing"))
         contained_node.update({"name": "RENAMED", "description": "TEST_MODIFY", "type": "basic_blueprint"})
         document_service.save(contained_node, "testing", update_uncontained=True, initial=True)
 
@@ -118,7 +118,7 @@ class DocumentServiceTestCase(unittest.TestCase):
 
         document_service = get_mock_document_service(lambda x, y: repository)
 
-        node: Node = document_service.get_document(Reference("$1", "testing"))
+        node: Node = document_service.get_document(Address("$1", "testing"))
         contained_node: Node = node.search("1.references")
         contained_node.children.append(
             Node(
@@ -198,7 +198,7 @@ class DocumentServiceTestCase(unittest.TestCase):
 
         document_service = get_mock_document_service(repository_provider)
 
-        node: Node = document_service.get_document(Reference("$1", "testing"))
+        node: Node = document_service.get_document(Address("$1", "testing"))
         contained_node: Node = node.search("1.references")
         contained_node.remove_by_path(["1"])
         document_service.save(node, "testing")
@@ -254,7 +254,7 @@ class DocumentServiceTestCase(unittest.TestCase):
         )
 
         # Testing updating the reference
-        node: Node = document_service.get_document(Reference("$1", "testing"))
+        node: Node = document_service.get_document(Address("$1", "testing"))
         target_node = node.get_by_path(["i_have_a_uncontained_attribute", "uncontained_in_every_way"])
         target_node.update(doc_storage["3"])
         document_service.save(node, "testing")
@@ -301,7 +301,7 @@ class DocumentServiceTestCase(unittest.TestCase):
         document_service = get_mock_document_service(lambda x, y: repository)
 
         document_service.update_document(
-            Reference("$1", "test"),
+            Address("$1", "test"),
             data={
                 "_id": "1",
                 "name": "Root",
@@ -370,7 +370,7 @@ class DocumentServiceTestCase(unittest.TestCase):
             "nested": {},
             "references": [],
         }
-        document_service.update_document(Reference("$1.a", "testing"), new_data, update_uncontained=True)
+        document_service.update_document(Address("$1.a", "testing"), new_data, update_uncontained=True)
 
         assert doc_storage["1"]["a"]["description"] == "SOME DESCRIPTION"
         assert doc_storage["1"]["a"]["reference"]["description"] == "A NEW DESCRIPTION HERE"

--- a/src/tests/unit/test_tree_functionality/test_tree_node_update.py
+++ b/src/tests/unit/test_tree_functionality/test_tree_node_update.py
@@ -4,6 +4,7 @@ from unittest import mock
 
 from authentication.models import User
 from common.exceptions import BadRequestException, ValidationException
+from common.reference import Reference
 from common.utils.data_structure.compare import get_and_print_diff
 from domain_classes.blueprint import Blueprint
 from domain_classes.tree_node import Node
@@ -182,7 +183,7 @@ class DocumentServiceTestCase(unittest.TestCase):
         repository.update = mock_update
         document_service = get_mock_document_service(repository_provider)
 
-        node: Node = document_service.get_document("testing/$1")
+        node: Node = document_service.get_document(Reference("$1", "testing"))
         node.update(
             {
                 "_id": "1",
@@ -232,7 +233,7 @@ class DocumentServiceTestCase(unittest.TestCase):
         repository.update = mock_update
         document_service = get_mock_document_service(repository_provider)
         document_service.add(
-            "testing/$1.im_optional",
+            Reference("$1.im_optional", "testing"),
             document={"type": "basic_blueprint", "name": "new_entity", "description": "This is my new entity"},
             files=[],
         )
@@ -266,7 +267,7 @@ class DocumentServiceTestCase(unittest.TestCase):
         )
         with self.assertRaises(ValidationException) as error:
             document_service.update_document(
-                reference="dmss://testing/$1.SomeChild",
+                reference=Reference("$1.SomeChild", "testing"),
                 data={"name": "whatever", "type": "special_child_no_inherit", "AnExtraValue": "Hallo there!"},
             )
         assert (
@@ -325,7 +326,7 @@ class DocumentServiceTestCase(unittest.TestCase):
         repository.update = mock_update
         document_service = get_mock_document_service(repository_provider)
         document_service.add(
-            "testing/$1.nested_with_optional.im_optional",
+            Reference("$1.nested_with_optional.im_optional", "testing"),
             document={"name": "new_entity", "description": "This is my new entity", "type": "basic_blueprint"},
             files=[],
         )
@@ -362,7 +363,7 @@ class DocumentServiceTestCase(unittest.TestCase):
 
         with self.assertRaises(BadRequestException):
             document_service.add(
-                "testing/$1.im_optional",
+                Reference("$1.im_optional", "testing"),
                 document={"type": "basic_blueprint", "name": "duplicate", "description": "This is my new entity"},
                 files=[],
             )
@@ -384,7 +385,7 @@ class DocumentServiceTestCase(unittest.TestCase):
             lambda id, user: repository, blueprint_provider=MultiTypeBlueprintProvider()
         )
         document_service.update_document(
-            reference="dmss://testing/$1.SomeChild",
+            reference=Reference("$1.SomeChild", "testing"),
             data={"name": "whatever", "type": "special_child", "AnExtraValue": "Hallo there!", "AValue": 13},
         )
         assert doc_storage["1"]["SomeChild"] == {
@@ -411,7 +412,7 @@ class DocumentServiceTestCase(unittest.TestCase):
             lambda id, user: repository, blueprint_provider=MultiTypeBlueprintProvider()
         )
         document_service.update_document(
-            reference="dmss://testing/$1.SomeChild",
+            reference=Reference("$1.SomeChild", "testing"),
             data={
                 "name": "whatever",
                 "type": "extra_special_child",
@@ -447,7 +448,7 @@ class DocumentServiceTestCase(unittest.TestCase):
             lambda id, user: repository, blueprint_provider=MultiTypeBlueprintProvider()
         )
         document_service.update_document(
-            reference="dmss://testing/$1.SomeChild",
+            reference=Reference("$1.SomeChild", "testing"),
             data=[
                 {"name": "whatever", "type": "special_child", "AnExtraValue": "Hallo there!", "AValue": 13},
                 {
@@ -491,7 +492,7 @@ class DocumentServiceTestCase(unittest.TestCase):
 
         with self.assertRaises(ValidationException) as error:
             document_service.update_document(
-                reference="dmss://testing/$1.SomeChild",
+                reference=Reference("$1.SomeChild", "testing"),
                 data=[
                     {"name": "whatever", "type": "special_child", "AnExtraValue": "Hallo there!", "AValue": 13},
                     {
@@ -527,7 +528,7 @@ class DocumentServiceTestCase(unittest.TestCase):
         )
 
         document_service.update_document(
-            reference="dmss://testing/$1",
+            reference=Reference("$1", "testing"),
             data={
                 "_id": "1",
                 "name": "parent",

--- a/src/tests/unit/test_tree_functionality/test_tree_node_update.py
+++ b/src/tests/unit/test_tree_functionality/test_tree_node_update.py
@@ -3,8 +3,8 @@ from copy import deepcopy
 from unittest import mock
 
 from authentication.models import User
+from common.address import Address
 from common.exceptions import BadRequestException, ValidationException
-from common.reference import Reference
 from common.utils.data_structure.compare import get_and_print_diff
 from domain_classes.blueprint import Blueprint
 from domain_classes.tree_node import Node
@@ -183,7 +183,7 @@ class DocumentServiceTestCase(unittest.TestCase):
         repository.update = mock_update
         document_service = get_mock_document_service(repository_provider)
 
-        node: Node = document_service.get_document(Reference("$1", "testing"))
+        node: Node = document_service.get_document(Address("$1", "testing"))
         node.update(
             {
                 "_id": "1",
@@ -233,7 +233,7 @@ class DocumentServiceTestCase(unittest.TestCase):
         repository.update = mock_update
         document_service = get_mock_document_service(repository_provider)
         document_service.add(
-            Reference("$1.im_optional", "testing"),
+            Address("$1.im_optional", "testing"),
             document={"type": "basic_blueprint", "name": "new_entity", "description": "This is my new entity"},
             files=[],
         )
@@ -267,7 +267,7 @@ class DocumentServiceTestCase(unittest.TestCase):
         )
         with self.assertRaises(ValidationException) as error:
             document_service.update_document(
-                reference=Reference("$1.SomeChild", "testing"),
+                address=Address("$1.SomeChild", "testing"),
                 data={"name": "whatever", "type": "special_child_no_inherit", "AnExtraValue": "Hallo there!"},
             )
         assert (
@@ -326,7 +326,7 @@ class DocumentServiceTestCase(unittest.TestCase):
         repository.update = mock_update
         document_service = get_mock_document_service(repository_provider)
         document_service.add(
-            Reference("$1.nested_with_optional.im_optional", "testing"),
+            Address("$1.nested_with_optional.im_optional", "testing"),
             document={"name": "new_entity", "description": "This is my new entity", "type": "basic_blueprint"},
             files=[],
         )
@@ -363,7 +363,7 @@ class DocumentServiceTestCase(unittest.TestCase):
 
         with self.assertRaises(BadRequestException):
             document_service.add(
-                Reference("$1.im_optional", "testing"),
+                Address("$1.im_optional", "testing"),
                 document={"type": "basic_blueprint", "name": "duplicate", "description": "This is my new entity"},
                 files=[],
             )
@@ -385,7 +385,7 @@ class DocumentServiceTestCase(unittest.TestCase):
             lambda id, user: repository, blueprint_provider=MultiTypeBlueprintProvider()
         )
         document_service.update_document(
-            reference=Reference("$1.SomeChild", "testing"),
+            address=Address("$1.SomeChild", "testing"),
             data={"name": "whatever", "type": "special_child", "AnExtraValue": "Hallo there!", "AValue": 13},
         )
         assert doc_storage["1"]["SomeChild"] == {
@@ -412,7 +412,7 @@ class DocumentServiceTestCase(unittest.TestCase):
             lambda id, user: repository, blueprint_provider=MultiTypeBlueprintProvider()
         )
         document_service.update_document(
-            reference=Reference("$1.SomeChild", "testing"),
+            address=Address("$1.SomeChild", "testing"),
             data={
                 "name": "whatever",
                 "type": "extra_special_child",
@@ -448,7 +448,7 @@ class DocumentServiceTestCase(unittest.TestCase):
             lambda id, user: repository, blueprint_provider=MultiTypeBlueprintProvider()
         )
         document_service.update_document(
-            reference=Reference("$1.SomeChild", "testing"),
+            address=Address("$1.SomeChild", "testing"),
             data=[
                 {"name": "whatever", "type": "special_child", "AnExtraValue": "Hallo there!", "AValue": 13},
                 {
@@ -492,7 +492,7 @@ class DocumentServiceTestCase(unittest.TestCase):
 
         with self.assertRaises(ValidationException) as error:
             document_service.update_document(
-                reference=Reference("$1.SomeChild", "testing"),
+                address=Address("$1.SomeChild", "testing"),
                 data=[
                     {"name": "whatever", "type": "special_child", "AnExtraValue": "Hallo there!", "AValue": 13},
                     {
@@ -528,7 +528,7 @@ class DocumentServiceTestCase(unittest.TestCase):
         )
 
         document_service.update_document(
-            reference=Reference("$1", "testing"),
+            address=Address("$1", "testing"),
             data={
                 "_id": "1",
                 "name": "parent",


### PR DESCRIPTION
## What does this pull request change?

- The Reference class was renamed to ReferenceEntity
- The new Reference class was created
- Started using it in resolve_reference and adjacent functions. Can probably be added more places.

## Why is this pull request needed?

The reference string could have multiple formats, and it was often not documented which format was needed.

## Issues related to this change:

Refs #389
