### PR TITLE
feat: add file support

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -20,6 +20,9 @@ from common.utils.encryption import generate_key
 from common.utils.logging import logger
 from common.utils.package_import import import_package
 from config import config
+from features.lookup_table.use_cases.create_lookup_table import (
+    create_lookup_table_use_case,
+)
 from restful.request_types.create_data_source import DataSourceRequest
 from services.database import mongo_client
 from storage.internal.data_source_repository import DataSourceRepository
@@ -36,8 +39,10 @@ def create_app() -> FastAPI:
     from features.document import document_feature
     from features.entity import entity_feature
     from features.export import export_feature
+    from features.file import file_feature
     from features.health_check import health_check_feature
     from features.lookup_table import lookup_table_feature
+    from features.meta import meta_feature
     from features.personal_access_token import personal_access_token_feature
     from features.reference import reference_feature
     from features.search import search_feature
@@ -59,6 +64,8 @@ def create_app() -> FastAPI:
     authenticated_routes.include_router(entity_feature.router)
     authenticated_routes.include_router(lookup_table_feature.router)
     authenticated_routes.include_router(attribute_feature.router)
+    authenticated_routes.include_router(file_feature.router)
+    authenticated_routes.include_router(meta_feature.router)
 
     # Some routes a PAT can not be used to authenticate. For example, to get new access tokens. That would be bad...
     jwt_only_routes = APIRouter()
@@ -142,6 +149,7 @@ def init_application():
     import_package(
         f"{config.APPLICATION_HOME}/system/SIMOS", user, data_source_name=config.CORE_DATA_SOURCE, is_root=True
     )
+    create_lookup_table_use_case(["system/SIMOS/recipe_links"], "DMSS", user)
     logger.debug("DONE")
 
 

--- a/src/common/utils/create_entity.py
+++ b/src/common/utils/create_entity.py
@@ -73,13 +73,19 @@ class CreateEntity:
     # type is inserted based on the parent attributes type, or the initial type for root entity.
     def _get_entity(self, blueprint: Blueprint, entity):
         for attr in blueprint.attributes:
+            if attr.attribute_type == BuiltinDataTypes.BINARY.value:
+                continue
+
             if attr.attribute_type in PRIMITIVES:
                 if not attr.is_optional and attr.name not in entity:
                     entity[attr.name] = CreateEntity.parse_value(attr=attr, blueprint_provider=self.blueprint_provider)
             else:
                 blueprint = (
                     self.blueprint_provider(attr.attribute_type)
-                    if attr.attribute_type != BuiltinDataTypes.OBJECT.value
+                    if (
+                        attr.attribute_type != BuiltinDataTypes.OBJECT.value
+                        and attr.attribute_type != BuiltinDataTypes.BINARY.value
+                    )
                     else SIMOS.ENTITY.value
                 )
                 if attr.is_array:

--- a/src/common/utils/resolve_reference.py
+++ b/src/common/utils/resolve_reference.py
@@ -7,6 +7,7 @@ from common.exceptions import ApplicationException, NotFoundException
 from common.utils.data_structure.find import find
 from common.utils.data_structure.has_key_value_pairs import has_key_value_pairs
 from common.utils.is_reference import is_reference
+from enums import REFERENCE_TYPES, SIMOS
 from storage.data_source_class import DataSource
 
 
@@ -59,6 +60,14 @@ class IdItem:
     id: str
 
     def get_entry_point(self, data_source: DataSource) -> Tuple[dict, str]:
+        if data_source._lookup(self.id).storage_affinity == "blob":
+            # Do not resolve any binary data, just return a reference to it.
+            # Getting the binary data needs to be handled by the consumer (e.g frontend).
+            return {
+                "type": SIMOS.REFERENCE.value,
+                "address": f"${self.id}",
+                "referenceType": REFERENCE_TYPES.STORAGE.value,
+            }, self.id
         # Get the document from the data source
         result = data_source.get(self.id)
         if not result:

--- a/src/common/utils/validators.py
+++ b/src/common/utils/validators.py
@@ -164,7 +164,11 @@ def _validate_complex_attribute(
 ):
     if type(attribute) != dict:
         raise ValidationException(f"'{attributeDefinition.name}' should be a dict", debug=_get_debug_message(key))
-    if not attribute or attributeDefinition.attribute_type == "object":
+    if (
+        not attribute
+        or attributeDefinition.attribute_type == BuiltinDataTypes.OBJECT.value
+        or attributeDefinition.attribute_type == BuiltinDataTypes.BINARY.value
+    ):
         return
     _validate_entity(
         attribute,

--- a/src/domain_classes/document_look_up.py
+++ b/src/domain_classes/document_look_up.py
@@ -8,3 +8,5 @@ class DocumentLookUp(BaseModel):
     repository: str
     database_id: str
     acl: ACL
+    storage_affinity: str
+    meta: dict | None = None

--- a/src/domain_classes/tree_node.py
+++ b/src/domain_classes/tree_node.py
@@ -141,7 +141,7 @@ class NodeBase:
         if len(nodes) > 1:
             nodes.pop(0)  # Remove first node since parent of self cannot be self
         for node in nodes:
-            if not node.storage_contained:
+            if not node.storage_contained and not isinstance(node, ListNode):
                 return node
 
     def __repr__(self):

--- a/src/enums.py
+++ b/src/enums.py
@@ -13,6 +13,7 @@ class BuiltinDataTypes(Enum):
     INT = "integer"
     BOOL = "boolean"
     OBJECT = "object"  # Any complex type (i.e. any blueprint type)
+    BINARY = "binary"
 
     def to_py_type(self):
         if self is BuiltinDataTypes.BOOL:
@@ -61,6 +62,7 @@ class SIMOS(Enum):
     RECIPE_LINK = "dmss://system/SIMOS/RecipeLink"
     DATASOURCE = "datasource"
     REFERENCE = "dmss://system/SIMOS/Reference"
+    FILE = "dmss://system/SIMOS/File"
 
 
 class REFERENCE_TYPES(Enum):

--- a/src/features/blob/use_cases/upload_blob_use_case.py
+++ b/src/features/blob/use_cases/upload_blob_use_case.py
@@ -6,5 +6,5 @@ from storage.internal.data_source_repository import get_data_source
 
 def upload_blob_use_case(user: User, data_source_id: str, blob_id: str, file: UploadFile):
     data_source = get_data_source(data_source_id, user)
-    data_source.update_blob(blob_id, file.file)
+    data_source.update_blob(blob_id, file.filename, file.content_type, file.file)
     return "OK"

--- a/src/features/file/file_feature.py
+++ b/src/features/file/file_feature.py
@@ -1,0 +1,26 @@
+from fastapi import APIRouter, Depends, File, Form, UploadFile
+from fastapi.responses import JSONResponse
+from pydantic import Json
+
+from authentication.authentication import auth_w_jwt_or_pat
+from authentication.models import User
+from common.responses import create_response, responses
+
+from .use_cases.add_file_use_case import add_file_use_case
+
+router = APIRouter(tags=["default", "file"], prefix="/files")
+
+
+@router.post("/{data_source_id}", operation_id="file_upload", response_model=dict, responses=responses)
+@create_response(JSONResponse)
+async def upload_file(
+    data_source_id: str,
+    data: Json = Form(...),
+    file: UploadFile = File(...),
+    user: User = Depends(auth_w_jwt_or_pat),
+):
+    """Upload a new binary file and create a file entity with the binary data as content.
+
+    **file_id** The data source ID to be used for the file entity that will be created.
+    """
+    return await add_file_use_case(data_source_id, data["file_id"], file, user)

--- a/src/features/file/use_cases/add_file_use_case.py
+++ b/src/features/file/use_cases/add_file_use_case.py
@@ -1,0 +1,36 @@
+from datetime import datetime
+from uuid import uuid4
+
+from fastapi import UploadFile
+
+from authentication.models import User
+from enums import REFERENCE_TYPES, SIMOS
+from storage.internal.data_source_repository import get_data_source
+
+
+async def add_file_use_case(data_source_id: str, file_id: str, file: UploadFile, user: User):
+    blob_id = str(uuid4())
+    data_source = get_data_source(data_source_id, user)
+    data_source.update_blob(blob_id, file.filename, file.content_type, file.file)
+    await file.seek(0)
+    content = await file.read()
+    file_size = len(content)
+    # The reference to the binary data needs to be of type pointer
+    # to avoid it to be resolved in get_resolved_document_by_id.
+    # TODO: Create a File and Reference class and use that
+    document = {
+        "_id": file_id,
+        "type": SIMOS.FILE.value,
+        "name": file.filename.split(".")[0],
+        "author": user.full_name,
+        "date": f"{datetime.now()}",
+        "size": file_size,
+        "filetype": file.content_type,
+        "content": {
+            "type": SIMOS.REFERENCE.value,
+            "address": f"${blob_id}",
+            "referenceType": REFERENCE_TYPES.STORAGE.value,
+        },
+    }
+    data_source.update(document)
+    return document

--- a/src/features/meta/meta_feature.py
+++ b/src/features/meta/meta_feature.py
@@ -1,0 +1,23 @@
+from fastapi import APIRouter, Depends
+from fastapi.responses import JSONResponse
+
+from authentication.authentication import auth_w_jwt_or_pat
+from authentication.models import User
+from common.responses import create_response, responses
+from features.meta.use_cases.get_meta_use_case import get_meta_use_case
+
+router = APIRouter(tags=["default", "meta"], prefix="/meta")
+
+
+@router.get(
+    "/{data_source_id}/{document_id}",
+    operation_id="meta_by_id",
+    responses={
+        **responses,
+    },
+    response_model=dict,
+)
+@create_response(JSONResponse)
+def get_meta_by_id(data_source_id: str, document_id: str, user: User = Depends(auth_w_jwt_or_pat)):
+    """Get meta information from data source id."""
+    return get_meta_use_case(user=user, data_source_id=data_source_id, document_id=document_id)

--- a/src/features/meta/use_cases/get_meta_use_case.py
+++ b/src/features/meta/use_cases/get_meta_use_case.py
@@ -1,0 +1,10 @@
+from authentication.models import User
+from storage.internal.data_source_repository import get_data_source
+
+
+def get_meta_use_case(user: User, data_source_id: str, document_id: str):
+    data_source = get_data_source(data_source_id, user)
+    if document_id.startswith("$"):
+        document_id = document_id[1:]
+    lookup = data_source._lookup(document_id)
+    return lookup.meta

--- a/src/home/system/SIMOS/File.json
+++ b/src/home/system/SIMOS/File.json
@@ -1,0 +1,44 @@
+{
+  "type": "dmss://system/SIMOS/Blueprint",
+  "name": "File",
+  "description": "This describes a file",
+  "attributes": [
+    {
+      "attributeType": "string",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "name": "type"
+    },
+    {
+      "attributeType": "string",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "name": "name"
+    },
+    {
+      "attributeType": "string",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "name": "author"
+    },
+    {
+      "attributeType": "string",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "name": "date"
+    },
+    {
+      "attributeType": "integer",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "name": "size"
+    },
+     {
+      "attributeType": "string",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "name": "filetype"
+    },
+    {
+      "attributeType": "binary",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "name": "content",
+      "optional": true,
+      "contained": false
+    }
+  ]
+}

--- a/src/home/system/SIMOS/recipe_links/file.json
+++ b/src/home/system/SIMOS/recipe_links/file.json
@@ -1,0 +1,10 @@
+{
+  "type": "dmss://system/SIMOS/RecipeLink",
+  "_blueprintPath_": "dmss://system/SIMOS/File",
+  "initialUiRecipe": {
+      "type": "dmss://system/SIMOS/UiRecipe",
+      "name": "Edit",
+      "description": "",
+      "plugin": "@development-framework/dm-core-plugins/yaml"
+    }
+}

--- a/src/services/document_service.py
+++ b/src/services/document_service.py
@@ -1,3 +1,4 @@
+import mimetypes
 import pprint
 from functools import lru_cache
 from typing import BinaryIO, Callable, Dict, List, Union
@@ -105,7 +106,8 @@ class DocumentService:
             # Get or set the "_blob_id"
             node.entity["_blob_id"] = node.entity["_blob_id"] if node.entity.get("_blob_id") else str(uuid4())
             # Save it
-            repository.update_blob(node.entity["_blob_id"], file)
+            content_type = mimetypes.guess_type(node.name)
+            repository.update_blob(node.entity["_blob_id"], node.name, content_type, file)
             node.entity["size"] = file.seek(0, 2)  # Set the size of the blob
             # Remove the temporary key containing the File
             del node.entity["_blob_"]
@@ -436,7 +438,8 @@ class DocumentService:
 
         if target.type == SIMOS.PACKAGE.value:
             target = target.children[0]  # Set target to be the packages content
-        if isinstance(target, ListNode):
+
+        if isinstance(target, ListNode) or target.parent.type == SIMOS.PACKAGE.value:
             new_node.set_uid()
             new_node.parent = target
             new_node.key = str(len(target.children))

--- a/src/tests/bdd/file.feature
+++ b/src/tests/bdd/file.feature
@@ -1,0 +1,40 @@
+Feature: Files
+
+  Background: There are data sources in the system
+    Given the system data source and SIMOS core package are available
+    Given there are data sources
+      | name    |
+      | test-DS |
+
+    Given there are repositories in the data sources
+      | data-source | host | port  | username | password | tls   | name      | database | collection | type     | dataTypes |
+      | test-DS     | db   | 27017 | maf      | maf      | false | repo1     | bdd-test | documents  | mongo-db | default   |
+      | test-DS     | db   | 27017 | maf      | maf      | false | blob-repo | bdd-test | test       | mongo-db | blob      |
+
+
+  Scenario: Add file
+    Given i access the resource url "/api/files/test-DS"
+    And adding a binary file "tests/bdd/steps/test_pdf.pdf" to the request
+    When i make a "POST" request
+    """
+    {
+      "data": {
+        "file_id": "1234"
+      }
+    }
+    """
+    Then the response status should be "OK"
+    And the response should contain
+     """
+     {
+       "_id": "1234",
+       "type": "dmss://system/SIMOS/File",
+       "name": "test_pdf",
+       "size": 531540,
+       "filetype": "application/pdf",
+       "content": {
+           "type": "dmss://system/SIMOS/Reference",
+           "referenceType": "storage"
+        }
+     }
+     """

--- a/src/tests/bdd/steps/blobs.py
+++ b/src/tests/bdd/steps/blobs.py
@@ -1,3 +1,5 @@
+import mimetypes
+
 from behave import given
 
 from storage.data_source_class import DataSource
@@ -9,7 +11,11 @@ def step_impl(context, id, data_source, path):
     data_source: DataSource = get_data_source(data_source_id=data_source, user=context.user)
     try:
         with open(path, "rb") as blob_file:
-            data_source.update_blob(id, blob_file)
+            guess = mimetypes.guess_type(blob_file.name)
+            content_type = ""
+            if guess:
+                content_type = guess[0]
+            data_source.update_blob(id, blob_file.name, content_type, blob_file)
     except FileNotFoundError:
         raise FileNotFoundError(
             f"The file {path}, was not found. Make sure the working directory of the test are set to be the source root (./src)"


### PR DESCRIPTION
## What does this pull request change?

* Added blueprint attribute type `binary`
* Added `File` blueprint 
* Added `/files/` endpoint to be able to upload files 
* Added `storage_affinity` field to the data source look-up table, to be able to know if the data source id is pointing to a binary 
* Added BDD test that upload binary and create a file using the `/files endpoint

Input parameters to the `/files/` endpoint is: 
* **data_source_id**: what data source to put the file in.
* **file_id**: what id should the file have (we need to provide a id so that the DM CLI can create packages with correct ids) 
* **file**: the actual binary file

## Why is this pull request needed?

## Issues related to this change:
