### PR TITLE
refactor: rename reference to path

### DIFF
--- a/src/features/export/use_cases/export_meta_use_case.py
+++ b/src/features/export/use_cases/export_meta_use_case.py
@@ -5,7 +5,7 @@ from common.address import Address
 from common.exceptions import NotFoundException
 from common.utils.resolve_reference import (
     QueryItem,
-    reference_to_reference_items,
+    path_to_path_items,
     resolve_reference,
 )
 from storage.data_source_class import DataSource
@@ -86,13 +86,9 @@ def export_meta_use_case(user: User, path_address: str) -> dict:
     data_source = get_data_source(address_object.data_source, user)
     if not address_object.path:
         raise NotFoundException(f"Could not find a root package from reference '{path_address}'")
-    reference_items = reference_to_reference_items(address_object.path)
-    if (
-        len(reference_items) >= 1
-        and isinstance(reference_items[0], QueryItem)
-        and reference_items[0].query_as_dict["isRoot"]
-    ):
-        root_package_name = reference_items[0].query_as_dict["name"]
+    path_items = path_to_path_items(address_object.path)
+    if len(path_items) >= 1 and isinstance(path_items[0], QueryItem) and path_items[0].query_as_dict["isRoot"]:
+        root_package_name = path_items[0].query_as_dict["name"]
     else:
         raise NotFoundException(f"Could not find a root package from reference '{path_address}'")
 

--- a/src/services/document_service.py
+++ b/src/services/document_service.py
@@ -26,7 +26,7 @@ from common.utils.logging import logger
 from common.utils.resolve_reference import (
     ResolvedReference,
     resolve_reference,
-    split_reference,
+    split_path,
 )
 from common.utils.sort_entities_by_attribute import sort_dtos_by_attribute
 from common.utils.validators import validate_entity, validate_entity_against_self
@@ -255,11 +255,11 @@ class DocumentService:
         Note: if the node specified by reference does not exist, it will be created if and only if the attribute is
         specified as optional in the blueprint.
         """
-        reference_parts = split_reference(address.path)
-        parent_reference = "".join(reference_parts[:-1])
-        parent_node: Node = self.get_document(Address(parent_reference, address.data_source), depth=0)
+        path_parts = split_path(address.path)
+        parent_path = "".join(path_parts[:-1])
+        parent_node: Node = self.get_document(Address(parent_path, address.data_source), depth=0)
         parent_blueprint_attribute_names = [attribute.name for attribute in parent_node.blueprint.attributes]
-        attribute_to_update = reference_parts[-1].strip(".").strip("[]")
+        attribute_to_update = path_parts[-1].strip(".").strip("[]")
         node = parent_node.get_by_ref_part([attribute_to_update])
 
         attribute_to_update_does_not_exist_in_parent_document = node is None
@@ -315,11 +315,11 @@ class DocumentService:
         validate_entity_against_self(data, self.get_blueprint)
         if not address.path:
             raise Exception(f"Could not find the node on '{address}'")
-        reference_parts = split_reference(address.path)
+        path_parts = split_path(address.path)
 
         # Since the node targeted by the reference might not exist (e.g. optional complex attribute)
         # we aim for the parent node first. Then get the child.
-        if len(reference_parts) > 1:
+        if len(path_parts) > 1:
             node: Union[Node, ListNode] = self._get_node_to_update(address=address, node_entity=data)
         else:
             node: Node = self.get_document(address)  # type: ignore

--- a/src/tests/unit/common/utils/test_reference_to_reference_items.py
+++ b/src/tests/unit/common/utils/test_reference_to_reference_items.py
@@ -4,8 +4,8 @@ from common.utils.resolve_reference import (
     AttributeItem,
     IdItem,
     QueryItem,
-    _next_reference_part,
-    reference_to_reference_items,
+    _next_path_part,
+    path_to_path_items,
 )
 
 
@@ -15,26 +15,26 @@ class ReferenceToReferenceItemsTestCase(unittest.TestCase):
 
     def test_next_reference_item(self):
         # Example 0
-        self.assertEqual(_next_reference_part("$1"), ("$1", None, ""))
+        self.assertEqual(_next_path_part("$1"), ("$1", None, ""))
 
         # Example 1
-        self.assertEqual(_next_reference_part("/$1"), ("", "/", "$1"))
-        self.assertEqual(_next_reference_part("$1"), ("$1", None, ""))
+        self.assertEqual(_next_path_part("/$1"), ("", "/", "$1"))
+        self.assertEqual(_next_path_part("$1"), ("$1", None, ""))
 
         # Example 2
-        self.assertEqual(_next_reference_part("/root/package/$1"), ("", "/", "root/package/$1"))
-        self.assertEqual(_next_reference_part("root/package/$1"), ("root", "/", "package/$1"))
-        self.assertEqual(_next_reference_part("package/$1"), ("package", "/", "$1"))
-        self.assertEqual(_next_reference_part("$1"), ("$1", None, ""))
+        self.assertEqual(_next_path_part("/root/package/$1"), ("", "/", "root/package/$1"))
+        self.assertEqual(_next_path_part("root/package/$1"), ("root", "/", "package/$1"))
+        self.assertEqual(_next_path_part("package/$1"), ("package", "/", "$1"))
+        self.assertEqual(_next_path_part("$1"), ("$1", None, ""))
 
     def test_reference_with_id_only_to_reference_items(self):
-        reference = "$1234-1234-1234"
-        items = reference_to_reference_items(reference)
+        path = "$1234-1234-1234"
+        items = path_to_path_items(path)
         self.assertEqual(items, [IdItem("1234-1234-1234")])
 
     def test_reference_with_path_only_to_reference_items(self):
-        reference = "/package/subPackage/document"
-        items = reference_to_reference_items(reference)
+        path = "/package/subPackage/document"
+        items = path_to_path_items(path)
         self.assertEqual(
             items,
             [
@@ -47,8 +47,8 @@ class ReferenceToReferenceItemsTestCase(unittest.TestCase):
         )
 
     def test_reference_with_path_and_simple_attribute_to_reference_items(self):
-        reference = "/package/subPackage/document.attribute"
-        items = reference_to_reference_items(reference)
+        path = "/package/subPackage/document.attribute"
+        items = path_to_path_items(path)
         self.assertEqual(
             items,
             [
@@ -62,8 +62,8 @@ class ReferenceToReferenceItemsTestCase(unittest.TestCase):
         )
 
     def test_reference_with_path_and_list_attribute_to_reference_items(self):
-        reference = "/package/subPackage/document.attribute[0]"
-        items = reference_to_reference_items(reference)
+        path = "/package/subPackage/document.attribute[0]"
+        items = path_to_path_items(path)
         self.assertEqual(
             items,
             [
@@ -78,8 +78,8 @@ class ReferenceToReferenceItemsTestCase(unittest.TestCase):
         )
 
     def test_reference_with_id_and_list_attribute_to_reference_items(self):
-        reference = "/$1.attribute[0]"
-        items = reference_to_reference_items(reference)
+        path = "/$1.attribute[0]"
+        items = path_to_path_items(path)
         self.assertEqual(
             items,
             [
@@ -90,8 +90,8 @@ class ReferenceToReferenceItemsTestCase(unittest.TestCase):
         )
 
     def test_reference_with_query_to_reference_items(self):
-        reference = "/[(_id=1)]"
-        items = reference_to_reference_items(reference)
+        path = "/[(_id=1)]"
+        items = path_to_path_items(path)
         self.assertEqual(
             items,
             [
@@ -100,8 +100,8 @@ class ReferenceToReferenceItemsTestCase(unittest.TestCase):
         )
 
     def test_reference_with_query_and_slash_to_reference_items(self):
-        reference = "/(name=package,isRoot=True)/subPackage"
-        items = reference_to_reference_items(reference)
+        path = "/(name=package,isRoot=True)/subPackage"
+        items = path_to_path_items(path)
         self.assertEqual(
             items,
             [
@@ -112,8 +112,8 @@ class ReferenceToReferenceItemsTestCase(unittest.TestCase):
         )
 
     def test_reference_with_query_2_to_reference_items(self):
-        reference = "/(type=test_data/complex/Customer)"
-        items = reference_to_reference_items(reference)
+        path = "/(type=test_data/complex/Customer)"
+        items = path_to_path_items(path)
         self.assertEqual(
             items,
             [
@@ -122,8 +122,8 @@ class ReferenceToReferenceItemsTestCase(unittest.TestCase):
         )
 
     def test_reference_with_query_and_attribute_query_to_reference_items(self):
-        reference = "/[(_id=1)].attribute(key1=value1,key2=value2)"
-        items = reference_to_reference_items(reference)
+        path = "/[(_id=1)].attribute(key1=value1,key2=value2)"
+        items = path_to_path_items(path)
         self.assertEqual(
             items,
             [

--- a/src/tests/unit/common/utils/test_split_reference.py
+++ b/src/tests/unit/common/utils/test_split_reference.py
@@ -1,49 +1,49 @@
 import unittest
 
-from common.utils.resolve_reference import split_reference
+from common.utils.resolve_reference import split_path
 
 
 class SplitReferenceTestCase(unittest.TestCase):
     def test_remove_last_reference_part(self):
-        reference = "$123-65435634-123.content[1](name=test)(name=test,isRoot=True,yyz=rush)"
-        self.assertEqual("$123-65435634-123.content[1](name=test)", "".join(split_reference(reference)[:-1]))
+        path = "$123-65435634-123.content[1](name=test)(name=test,isRoot=True,yyz=rush)"
+        self.assertEqual("$123-65435634-123.content[1](name=test)", "".join(split_path(path)[:-1]))
 
     def test_split_complex_reference(self):
-        reference = "/[(_id=1)].content[(name=myCarRental)].cars[0]"
-        ref_pars = split_reference(reference)
-        self.assertEqual(["/", "[(_id=1)]", ".content", "[(name=myCarRental)]", ".cars", "[0]"], ref_pars)
+        path = "/[(_id=1)].content[(name=myCarRental)].cars[0]"
+        path_parts = split_path(path)
+        self.assertEqual(["/", "[(_id=1)]", ".content", "[(name=myCarRental)]", ".cars", "[0]"], path_parts)
 
     def test_split_complex_reference2(self):
-        reference = "$1234-1234-1234"
-        ref_pars = split_reference(reference)
-        self.assertEqual(["$1234-1234-1234"], ref_pars)
+        path = "$1234-1234-1234"
+        path_parts = split_path(path)
+        self.assertEqual(["$1234-1234-1234"], path_parts)
 
     def test_split_complex_reference3(self):
-        reference = "/package/subPackage/document"
-        ref_pars = split_reference(reference)
-        self.assertEqual(["/package", "/subPackage", "/document"], ref_pars)
+        path = "/package/subPackage/document"
+        path_parts = split_path(path)
+        self.assertEqual(["/package", "/subPackage", "/document"], path_parts)
 
     def test_split_complex_reference4(self):
-        reference = "/package/subPackage/document.attribute"
-        ref_pars = split_reference(reference)
-        self.assertEqual(["/package", "/subPackage", "/document", ".attribute"], ref_pars)
+        path = "/package/subPackage/document.attribute"
+        path_parts = split_path(path)
+        self.assertEqual(["/package", "/subPackage", "/document", ".attribute"], path_parts)
 
     def test_split_complex_reference5(self):
-        reference = "/package/subPackage/document.attribute[0]"
-        ref_pars = split_reference(reference)
-        self.assertEqual(["/package", "/subPackage", "/document", ".attribute", "[0]"], ref_pars)
+        path = "/package/subPackage/document.attribute[0]"
+        path_parts = split_path(path)
+        self.assertEqual(["/package", "/subPackage", "/document", ".attribute", "[0]"], path_parts)
 
     def test_split_complex_reference6(self):
-        reference = "/$1.attribute[0]"
-        ref_pars = split_reference(reference)
-        self.assertEqual(["/$1", ".attribute", "[0]"], ref_pars)
+        path = "/$1.attribute[0]"
+        path_parts = split_path(path)
+        self.assertEqual(["/$1", ".attribute", "[0]"], path_parts)
 
     def test_split_complex_reference7(self):
-        reference = "/[(_id=1)]"
-        ref_pars = split_reference(reference)
-        self.assertEqual(["/", "[(_id=1)]"], ref_pars)
+        path = "/[(_id=1)]"
+        path_parts = split_path(path)
+        self.assertEqual(["/", "[(_id=1)]"], path_parts)
 
     def test_split_complex_reference8(self):
-        reference = "/[(_id=1)].attribute(key1=value1,key2=value2)"
-        ref_pars = split_reference(reference)
-        self.assertEqual(["/", "[(_id=1)]", ".attribute", "(key1=value1,key2=value2)"], ref_pars)
+        path = "/[(_id=1)].attribute(key1=value1,key2=value2)"
+        path_parts = split_path(path)
+        self.assertEqual(["/", "[(_id=1)]", ".attribute", "(key1=value1,key2=value2)"], path_parts)


### PR DESCRIPTION
## What does this pull request change?

Rename reference to path inside resolve_reference

## Why is this pull request needed?

Reference refers to a link or storage reference. To avoid confusion, we shouldn't also use reference about what is instead an address path (ie $1.attribute1.attribute2 or [$1, attribute1, attribute2]).

## Issues related to this change:

Refs #389
