### PR TITLE
fix: bug with create entity

### DIFF
--- a/src/common/utils/create_entity.py
+++ b/src/common/utils/create_entity.py
@@ -71,7 +71,7 @@ class CreateEntity:
 
     # add all non optional attributes with default value.
     # type is inserted based on the parent attributes type, or the initial type for root entity.
-    def _get_entity(self, blueprint: Blueprint, entity):
+    def _get_entity(self, blueprint: Blueprint, entity: dict):
         for attr in blueprint.attributes:
             if attr.attribute_type == BuiltinDataTypes.BINARY.value:
                 continue
@@ -86,14 +86,14 @@ class CreateEntity:
                         attr.attribute_type != BuiltinDataTypes.OBJECT.value
                         and attr.attribute_type != BuiltinDataTypes.BINARY.value
                     )
-                    else SIMOS.ENTITY.value
+                    else self.blueprint_provider(SIMOS.ENTITY.value)
                 )
                 if attr.is_array:
                     entity[attr.name] = attr.dimensions.create_default_array(self.blueprint_provider, CreateEntity)
                 else:
                     if attr.is_optional:
-                        entity[attr.name] = {}
-
+                        if attr.default:
+                            entity[attr.name] = attr.default
                     elif CreateEntity.is_json(attr):
                         value = attr.default
                         if value is not None and len(value) > 0:

--- a/src/tests/unit/mock_utils.py
+++ b/src/tests/unit/mock_utils.py
@@ -376,6 +376,22 @@ car = {
             "optional": True,
             "attributeType": "test_data/complex/EngineTest",
         },
+        {
+            "type": "system/SIMOS/BlueprintAttribute",
+            "name": "engine3",
+            "optional": True,
+            "attributeType": "test_data/complex/EngineTest",
+            "default": {
+                "name": "default engine",
+                "fuelPump": {
+                    "name": "fuelPump",
+                    "description": "A standard fuel pump",
+                    "type": "test_data/complex/FuelPumpTest",
+                },
+                "power": 9,
+                "type": "test_data/complex/EngineTest",
+            },
+        },
     ],
 }
 wheel = {

--- a/src/tests/unit/test_create_default_array.py
+++ b/src/tests/unit/test_create_default_array.py
@@ -85,9 +85,7 @@ class DefaultArrayTestCase(unittest.TestCase):
             blueprint_provider, CreateEntity
         )
 
-        assert default_array == [
-            [{"name": "", "type": "dmss://system/SIMOS/Package", "_meta_": {}, "isRoot": False, "content": []}]
-        ]
+        assert default_array == [[{"name": "", "type": "dmss://system/SIMOS/Package", "isRoot": False, "content": []}]]
 
     def test_creation_of_default_array_unfixed_rank2(self):
         default_array = Dimension("*,*", "integer").create_default_array(blueprint_provider, CreateEntity)

--- a/src/tests/unit/test_create_entity.py
+++ b/src/tests/unit/test_create_entity.py
@@ -17,7 +17,6 @@ class CreateEntityTestCase(unittest.TestCase):
 
     def test_blueprint_entity(self):
         expected_entity = {
-            "engine2": {},
             "engine": {
                 "name": "",
                 "description": "",
@@ -27,6 +26,16 @@ class CreateEntityTestCase(unittest.TestCase):
                     "type": "test_data/complex/FuelPumpTest",
                 },
                 "power": 120,
+                "type": "test_data/complex/EngineTest",
+            },
+            "engine3": {
+                "name": "default engine",
+                "fuelPump": {
+                    "name": "fuelPump",
+                    "description": "A standard fuel pump",
+                    "type": "test_data/complex/FuelPumpTest",
+                },
+                "power": 9,
                 "type": "test_data/complex/EngineTest",
             },
             "is_sedan": True,


### PR DESCRIPTION
## What does this pull request change?
Before, create entity would create empty dicts for optional attributes. Example:
 POST request to http://localhost:5000/api/entity with payload: type: "dmss://WorkflowDS/Blueprints/Job"

Will create
```json
{
    "type": "dmss://WorkflowDS/Blueprints/Job",
    "status": "Not registered",
    "applicationInput": {},
    "result": {},
    "runner": {}
}
```

after the bug is fixed, optional attributes are not included in the created entity. However, they will be included IF the optional attribute has defined a default value.

Created entity after fix:
```json
{
    "type": "dmss://WorkflowDS/Blueprints/Job",
    "status": "Not registered"
}
```


## Issues related to this change:
closes #462 