### PR TITLE
fix: package content should be storage non-contained

### DIFF
--- a/src/common/tree_node_serializer.py
+++ b/src/common/tree_node_serializer.py
@@ -72,7 +72,7 @@ def tree_node_to_ref_dict(node: Node | ListNode) -> dict:
     if node.is_empty():
         return node.entity
     data = {}
-    if node.uid:
+    if node.uid and node.type != SIMOS.REFERENCE.value:
         data = {"_id": node.uid}
 
     # Always add 'type', regardless of blueprint
@@ -108,7 +108,7 @@ def tree_node_to_ref_dict(node: Node | ListNode) -> dict:
                         "type": SIMOS.REFERENCE.value,
                         "address": f"${child.uid}",
                         "referenceType": REFERENCE_TYPES.STORAGE.value
-                        if child.contained
+                        if child.contained and not child.storage_contained
                         else REFERENCE_TYPES.LINK.value,
                     }
                     for child in child.children

--- a/src/common/utils/package_import.py
+++ b/src/common/utils/package_import.py
@@ -31,7 +31,7 @@ def _add_documents(path, documents, data_source) -> List[Dict]:
             {
                 "address": f"${document['_id']}",
                 "type": SIMOS.REFERENCE.value,
-                "referenceType": REFERENCE_TYPES.LINK.value,
+                "referenceType": REFERENCE_TYPES.STORAGE.value,
             }
         )
 
@@ -75,5 +75,5 @@ def import_package(path: str, user: User, data_source_name: str, is_root: bool =
     return {
         "address": f"${package['_id']}",
         "type": SIMOS.REFERENCE.value,
-        "referenceType": REFERENCE_TYPES.LINK.value,
+        "referenceType": REFERENCE_TYPES.STORAGE.value,
     }

--- a/src/features/document/document_feature.py
+++ b/src/features/document/document_feature.py
@@ -22,7 +22,7 @@ router = APIRouter(tags=["default", "document"], prefix="/documents")
 def get(
     address: str,
     depth: conint(gt=-1, lt=1000) = 0,  # type: ignore
-    resolve_links: bool = False,
+    resolve_references: bool = False,
     user: User = Depends(auth_w_jwt_or_pat),
 ):
     """
@@ -37,7 +37,7 @@ def get(
 
     - **depth**: Maximum depth for resolving nested documents.
     """
-    return get_document_use_case(user=user, address=address, depth=depth, resolve_links=resolve_links)
+    return get_document_use_case(user=user, address=address, depth=depth, resolve_references=resolve_references)
 
 
 @router.put("/{id_address:path}", operation_id="document_update", responses=responses)

--- a/src/features/document/document_feature.py
+++ b/src/features/document/document_feature.py
@@ -21,8 +21,7 @@ router = APIRouter(tags=["default", "document"], prefix="/documents")
 @create_response(JSONResponse)
 def get(
     address: str,
-    depth: conint(gt=-1, lt=1000) = 0,  # type: ignore
-    resolve_references: bool = False,
+    depth: conint(gt=-1, lt=1000) = 1,  # type: ignore
     user: User = Depends(auth_w_jwt_or_pat),
 ):
     """
@@ -37,7 +36,7 @@ def get(
 
     - **depth**: Maximum depth for resolving nested documents.
     """
-    return get_document_use_case(user=user, address=address, depth=depth, resolve_references=resolve_references)
+    return get_document_use_case(user=user, address=address, depth=depth)
 
 
 @router.put("/{id_address:path}", operation_id="document_update", responses=responses)

--- a/src/features/document/use_cases/get_document_use_case.py
+++ b/src/features/document/use_cases/get_document_use_case.py
@@ -11,12 +11,11 @@ from storage.internal.data_source_repository import get_data_source
 def get_document_use_case(
     user: User,
     address: str,
-    depth: conint(gt=-1, lt=1000) = 999,  # type: ignore
-    resolve_references: bool = False,
+    depth: conint(gt=-1, lt=1000),  # type: ignore
     repository_provider=get_data_source,
 ):
     """Get document by reference."""
     document_service = DocumentService(repository_provider=repository_provider, user=user)
     address_object = Address.from_absolute(address)
-    node: Node | ListNode = document_service.get_document(address_object, depth, resolve_references)
+    node: Node | ListNode = document_service.get_document(address_object, depth)
     return tree_node_to_dict(node)

--- a/src/features/document/use_cases/get_document_use_case.py
+++ b/src/features/document/use_cases/get_document_use_case.py
@@ -12,11 +12,11 @@ def get_document_use_case(
     user: User,
     address: str,
     depth: conint(gt=-1, lt=1000) = 999,  # type: ignore
-    resolve_links: bool = False,
+    resolve_references: bool = False,
     repository_provider=get_data_source,
 ):
     """Get document by reference."""
     document_service = DocumentService(repository_provider=repository_provider, user=user)
     address_object = Address.from_absolute(address)
-    node: Node | ListNode = document_service.get_document(address_object, depth, resolve_links)
+    node: Node | ListNode = document_service.get_document(address_object, depth, resolve_references)
     return tree_node_to_dict(node)

--- a/src/features/entity/use_cases/validate_existing_entity.py
+++ b/src/features/entity/use_cases/validate_existing_entity.py
@@ -8,7 +8,7 @@ from services.document_service import DocumentService
 def validate_existing_entity_use_case(address: str, user: User) -> str:
     document_service = DocumentService(user=user)
     document_as_node: Node = document_service.get_document(
-        Address.from_absolute(address), depth=999, resolve_links=True
+        Address.from_absolute(address), depth=999, resolve_references=True
     )
     # TODO resolving fails in above line. for some reason the address dmss://DemoDataSource/plugins/DemoDataSource/plugins/grid/blueprints/Dashboard
     validate_entity_against_self(document_as_node.entity, document_service.get_blueprint)

--- a/src/features/entity/use_cases/validate_existing_entity.py
+++ b/src/features/entity/use_cases/validate_existing_entity.py
@@ -7,9 +7,7 @@ from services.document_service import DocumentService
 
 def validate_existing_entity_use_case(address: str, user: User) -> str:
     document_service = DocumentService(user=user)
-    document_as_node: Node = document_service.get_document(
-        Address.from_absolute(address), depth=999, resolve_references=True
-    )
+    document_as_node: Node = document_service.get_document(Address.from_absolute(address), depth=999)
     # TODO resolving fails in above line. for some reason the address dmss://DemoDataSource/plugins/DemoDataSource/plugins/grid/blueprints/Dashboard
     validate_entity_against_self(document_as_node.entity, document_service.get_blueprint)
     return "OK"

--- a/src/features/export/use_cases/export_use_case.py
+++ b/src/features/export/use_cases/export_use_case.py
@@ -37,7 +37,7 @@ def create_zip_export(document_service: DocumentService, address: Address, user:
     tmpdir = tempfile.mkdtemp()
     archive_path = os.path.join(tmpdir, "temp_zip_archive.zip")
     resolved_address: ResolvedAddress = resolve_address(address, document_service.get_data_source)
-    document_node: Node = document_service.get_document(address, depth=999, resolve_references=True)
+    document_node: Node = document_service.get_document(address, depth=999)
 
     # non-root packages and single documents will inherit the meta information from all parents.
     document_meta = {}

--- a/src/features/export/use_cases/export_use_case.py
+++ b/src/features/export/use_cases/export_use_case.py
@@ -37,7 +37,7 @@ def create_zip_export(document_service: DocumentService, address: Address, user:
     tmpdir = tempfile.mkdtemp()
     archive_path = os.path.join(tmpdir, "temp_zip_archive.zip")
     resolved_address: ResolvedAddress = resolve_address(address, document_service.get_data_source)
-    document_node: Node = document_service.get_document(address, depth=999, resolve_links=True)
+    document_node: Node = document_service.get_document(address, depth=999, resolve_references=True)
 
     # non-root packages and single documents will inherit the meta information from all parents.
     document_meta = {}

--- a/src/features/lookup_table/use_cases/create_lookup_table.py
+++ b/src/features/lookup_table/use_cases/create_lookup_table.py
@@ -22,9 +22,7 @@ def create_lookup_table_use_case(
     lookup_class_attributes = list(Lookup.__annotations__.keys())
     combined_lookup = Lookup().dict()
     for path in recipe_package_paths:
-        recipe_package = document_service.get_document(
-            Address(*path.split("/", 1)[::-1]), depth=999, resolve_references=True
-        )
+        recipe_package = document_service.get_document(Address(*path.split("/", 1)[::-1]), depth=999)
 
         lookup: Lookup = Lookup()
 

--- a/src/features/lookup_table/use_cases/create_lookup_table.py
+++ b/src/features/lookup_table/use_cases/create_lookup_table.py
@@ -23,7 +23,7 @@ def create_lookup_table_use_case(
     combined_lookup = Lookup().dict()
     for path in recipe_package_paths:
         recipe_package = document_service.get_document(
-            Address(*path.split("/", 1)[::-1]), depth=999, resolve_links=True
+            Address(*path.split("/", 1)[::-1]), depth=999, resolve_references=True
         )
 
         lookup: Lookup = Lookup()

--- a/src/home/system/SIMOS/Package.json
+++ b/src/home/system/SIMOS/Package.json
@@ -13,7 +13,7 @@
       "attributeType": "object",
       "type": "dmss://system/SIMOS/BlueprintAttribute",
       "name": "content",
-      "contained": false,
+      "contained": true,
       "dimensions": "*",
       "optional": true
     }

--- a/src/services/document_service.py
+++ b/src/services/document_service.py
@@ -208,15 +208,16 @@ class DocumentService:
         return ref_dict
 
     # TODO: Dont return Node. Doing this is ~33% slower
-    def get_document(self, address: Address, depth: int = 0, resolve_references: bool = False) -> Node | ListNode:
+    def get_document(self, address: Address, depth: int = 0) -> Node | ListNode:
         """
         Get document by address.
 
         :param address: Address to the entity you wish to obtain
-        :param depth: depth=0 means that the entire entity will be returned, except any references it may contain
-            along the tree. depth=1 means that the entity's direct child references will be returned as well.
-        :param resolve_references: If false, references will not be resolved, no
-            matter the depth. If true, they will be resolved if the depth param allows it
+        :param depth:
+            depth is used to control if references (storage and link) should be resolved (it does not affect contained attributes)
+              depth=0 means that if the address is pointing to a reference it will be returned directly without being resolved first.
+              depth=1 means that if the address is pointing to a reference it will be resolved before returned. Child references will not be resolved.
+              depth=2 means that the entity's direct child references will be returned as well.
         """
         try:
             resolved_address: ResolvedAddress = resolve_address(address, self.get_data_source)
@@ -229,8 +230,7 @@ class DocumentService:
                 self.get_data_source,
                 resolved_address.document_id,
                 depth=depth + len(list(filter(lambda x: x[0] != "[", resolved_address.attribute_path))),
-                depth_count=0,
-                resolve_references=resolve_references,
+                depth_count=1,
             )
 
             node: Node = tree_node_from_dict(
@@ -380,7 +380,7 @@ class DocumentService:
         )
 
         try:
-            if self.get_document(Address(new_node.entity["name"], data_source_id), resolve_references=True, depth=99):
+            if self.get_document(Address(new_node.entity["name"], data_source_id), depth=99):
                 raise ValidationException(
                     message=f"A root package named '{new_node.entity['name']}' already exists",
                     data={"dataSource": data_source_id, "document": document},
@@ -413,7 +413,7 @@ class DocumentService:
         if not address.path:  # We're adding something to the dataSource itself
             return self._add_document_to_data_source(address.data_source, document, update_uncontained)
 
-        target: Node = self.get_document(address, resolve_references=True, depth=99)
+        target: Node = self.get_document(address, depth=99)
 
         if not target:
             raise NotFoundException(f"Could not find '{address}' in data source '{address.data_source}'")
@@ -496,7 +496,7 @@ class DocumentService:
 
         # TODO: Updating ACL for Links should only be additive
         # TODO: ACL for StorageReferences should always be identical to parent document
-        root_node = self.get_document(Address(document_id, data_source_id), 99, resolve_references=True)
+        root_node = self.get_document(Address(document_id, data_source_id), 99)
         data_source.update_access_control(root_node.node_id, acl)
         for child in root_node.children:
             for node in child.traverse():

--- a/src/tests/bdd/document/add_document.feature
+++ b/src/tests/bdd/document/add_document.feature
@@ -254,7 +254,7 @@ Feature: Add document with document_service
     }
     """
     Then the response status should be "OK"
-    Given i access the resource url "/api/documents/data-source-name/root_package/EntityPackage/operation2?resolve_links=true&depth=2"
+    Given i access the resource url "/api/documents/data-source-name/root_package/EntityPackage/operation2?resolve_references=true&depth=2"
     When I make a "GET" request
     Then the response status should be "OK"
     And the response should contain
@@ -282,7 +282,7 @@ Feature: Add document with document_service
     }
     """
     Then the response status should be "OK"
-    Given i access the resource url "/api/documents/data-source-name/root_package/EntityPackage/operation3?resolve_links=true&depth=2"
+    Given i access the resource url "/api/documents/data-source-name/root_package/EntityPackage/operation3?resolve_references=true&depth=2"
     When I make a "GET" request
     Then the response status should be "OK"
     And the response should contain
@@ -311,7 +311,7 @@ Feature: Add document with document_service
     }
     """
     Then the response status should be "OK"
-    Given i access the resource url "/api/documents/data-source-name/root_package/operation2?resolve_links=true&depth=2"
+    Given i access the resource url "/api/documents/data-source-name/root_package/operation2?resolve_references=true&depth=2"
     When I make a "GET" request
     Then the response status should be "OK"
     And the response should contain
@@ -340,7 +340,7 @@ Feature: Add document with document_service
     }
     """
     Then the response status should be "OK"
-    Given i access the resource url "/api/documents/data-source-name/root_package.content[7]?resolve_links=true&depth=2"
+    Given i access the resource url "/api/documents/data-source-name/root_package.content[7]?resolve_references=true&depth=2"
     When I make a "GET" request
     Then the response status should be "OK"
     And the response should contain
@@ -384,7 +384,7 @@ Feature: Add document with document_service
     }
     """
     Then the response status should be "OK"
-    Given i access the resource url "/api/documents/data-source-name/root_package/EntityPackage/operation1?resolve_links=true&depth=2"
+    Given i access the resource url "/api/documents/data-source-name/root_package/EntityPackage/operation1?resolve_references=true&depth=2"
     When I make a "GET" request
     Then the response status should be "OK"
     And the response should contain
@@ -451,7 +451,7 @@ Feature: Add document with document_service
       }
     """
 #     todo update document add use case such that id contains bracket notation for lists: 11.phases[0].containedResults[0]
-    Given i access the resource url "/api/documents/data-source-name/$11.phases[0].containedResults?resolve_links=true&depth=2"
+    Given i access the resource url "/api/documents/data-source-name/$11.phases[0].containedResults?resolve_references=true&depth=2"
     When I make a "GET" request
     Then the response status should be "OK"
     And the response should contain
@@ -492,7 +492,7 @@ Feature: Add document with document_service
     }
     """
     Then the response status should be "OK"
-    Given i access the resource url "/api/documents/data-source-name/root_package/EntityPackage/new-phase?resolve_links=true"
+    Given i access the resource url "/api/documents/data-source-name/root_package/EntityPackage/new-phase?resolve_references=true"
     When I make a "GET" request
     Then the response status should be "OK"
     And the response should contain

--- a/src/tests/bdd/document/add_document.feature
+++ b/src/tests/bdd/document/add_document.feature
@@ -254,7 +254,7 @@ Feature: Add document with document_service
     }
     """
     Then the response status should be "OK"
-    Given i access the resource url "/api/documents/data-source-name/root_package/EntityPackage/operation2?resolve_references=true&depth=2"
+    Given i access the resource url "/api/documents/data-source-name/root_package/EntityPackage/operation2?depth=2"
     When I make a "GET" request
     Then the response status should be "OK"
     And the response should contain
@@ -282,7 +282,7 @@ Feature: Add document with document_service
     }
     """
     Then the response status should be "OK"
-    Given i access the resource url "/api/documents/data-source-name/root_package/EntityPackage/operation3?resolve_references=true&depth=2"
+    Given i access the resource url "/api/documents/data-source-name/root_package/EntityPackage/operation3?depth=2"
     When I make a "GET" request
     Then the response status should be "OK"
     And the response should contain
@@ -311,7 +311,7 @@ Feature: Add document with document_service
     }
     """
     Then the response status should be "OK"
-    Given i access the resource url "/api/documents/data-source-name/root_package/operation2?resolve_references=true&depth=2"
+    Given i access the resource url "/api/documents/data-source-name/root_package/operation2?depth=2"
     When I make a "GET" request
     Then the response status should be "OK"
     And the response should contain
@@ -340,7 +340,7 @@ Feature: Add document with document_service
     }
     """
     Then the response status should be "OK"
-    Given i access the resource url "/api/documents/data-source-name/root_package.content[7]?resolve_references=true&depth=2"
+    Given i access the resource url "/api/documents/data-source-name/root_package.content[7]?depth=2"
     When I make a "GET" request
     Then the response status should be "OK"
     And the response should contain
@@ -384,7 +384,7 @@ Feature: Add document with document_service
     }
     """
     Then the response status should be "OK"
-    Given i access the resource url "/api/documents/data-source-name/root_package/EntityPackage/operation1?resolve_references=true&depth=2"
+    Given i access the resource url "/api/documents/data-source-name/root_package/EntityPackage/operation1?depth=3"
     When I make a "GET" request
     Then the response status should be "OK"
     And the response should contain
@@ -451,7 +451,7 @@ Feature: Add document with document_service
       }
     """
 #     todo update document add use case such that id contains bracket notation for lists: 11.phases[0].containedResults[0]
-    Given i access the resource url "/api/documents/data-source-name/$11.phases[0].containedResults?resolve_references=true&depth=2"
+    Given i access the resource url "/api/documents/data-source-name/$11.phases[0].containedResults?depth=2"
     When I make a "GET" request
     Then the response status should be "OK"
     And the response should contain
@@ -492,7 +492,7 @@ Feature: Add document with document_service
     }
     """
     Then the response status should be "OK"
-    Given i access the resource url "/api/documents/data-source-name/root_package/EntityPackage/new-phase?resolve_references=true"
+    Given i access the resource url "/api/documents/data-source-name/root_package/EntityPackage/new-phase?depth=2"
     When I make a "GET" request
     Then the response status should be "OK"
     And the response should contain

--- a/src/tests/bdd/document/add_file.feature
+++ b/src/tests/bdd/document/add_file.feature
@@ -350,7 +350,7 @@ Feature: Explorer - Add file
     }
     """
     Then the response status should be "OK"
-    Given I access the resource url "/api/documents/test-DS/$1?resolve_links=true&depth=99"
+    Given I access the resource url "/api/documents/test-DS/$1?resolve_references=true&depth=99"
     When I make a "GET" request
     Then the response status should be "OK"
     And the response should contain

--- a/src/tests/bdd/document/add_file.feature
+++ b/src/tests/bdd/document/add_file.feature
@@ -350,7 +350,7 @@ Feature: Explorer - Add file
     }
     """
     Then the response status should be "OK"
-    Given I access the resource url "/api/documents/test-DS/$1?resolve_references=true&depth=99"
+    Given I access the resource url "/api/documents/test-DS/$1?depth=99"
     When I make a "GET" request
     Then the response status should be "OK"
     And the response should contain

--- a/src/tests/bdd/document/get.feature
+++ b/src/tests/bdd/document/get.feature
@@ -163,7 +163,7 @@ Feature: Get document
       | 6   | 3          | container_1   |             | dmss://test-source-name/TestData/TestContainer |
 
   Scenario: Get document by id
-    Given I access the resource url "/api/documents/data-source-name/$1?depth=1"
+    Given I access the resource url "/api/documents/data-source-name/$1?depth=2&resolve_references=true"
     When I make a "GET" request
     Then the response status should be "OK"
     And the response should contain
@@ -184,7 +184,7 @@ Feature: Get document
     """
 
   Scenario: Get document by path
-    Given I access the resource url "/api/documents/dmss://data-source-name/package_1/sub_package_1/document_1"
+    Given I access the resource url "/api/documents/dmss://data-source-name/package_1/sub_package_1/document_1?resolve_references=true"
     When I make a "GET" request
     Then the response status should be "OK"
     And the response should contain
@@ -199,7 +199,7 @@ Feature: Get document
     """
 
   Scenario: Get nested resolved attribute
-    Given I access the resource url "/api/documents/data-source-name/package_1/sub_package_2/container_1"
+    Given I access the resource url "/api/documents/data-source-name/package_1/sub_package_2/container_1?resolve_references=true"
     When I make a "GET" request
     Then the response status should be "OK"
     And the response should contain
@@ -211,7 +211,7 @@ Feature: Get document
     """
 
   Scenario: Get resolved attribute
-    Given I access the resource url "/api/documents/test-source-name/$1.content[0]?resolve_links=True"
+    Given I access the resource url "/api/documents/test-source-name/$1.content[0]?resolve_references=True"
     When I make a "GET" request
     Then the response status should be "OK"
     And the response should contain
@@ -223,7 +223,7 @@ Feature: Get document
     """
 
   Scenario: Get unresolved attribute
-    Given I access the resource url "/api/documents/test-source-name/$1.content[0]?resolve_links=False"
+    Given I access the resource url "/api/documents/test-source-name/$1.content[0]?resolve_references=False"
     When I make a "GET" request
     Then the response status should be "OK"
     And the response should contain

--- a/src/tests/bdd/document/get.feature
+++ b/src/tests/bdd/document/get.feature
@@ -163,7 +163,7 @@ Feature: Get document
       | 6   | 3          | container_1   |             | dmss://test-source-name/TestData/TestContainer |
 
   Scenario: Get document by id
-    Given I access the resource url "/api/documents/data-source-name/$1?depth=2&resolve_references=true"
+    Given I access the resource url "/api/documents/data-source-name/$1?depth=2"
     When I make a "GET" request
     Then the response status should be "OK"
     And the response should contain
@@ -184,7 +184,7 @@ Feature: Get document
     """
 
   Scenario: Get document by path
-    Given I access the resource url "/api/documents/dmss://data-source-name/package_1/sub_package_1/document_1?resolve_references=true"
+    Given I access the resource url "/api/documents/dmss://data-source-name/package_1/sub_package_1/document_1"
     When I make a "GET" request
     Then the response status should be "OK"
     And the response should contain
@@ -199,7 +199,7 @@ Feature: Get document
     """
 
   Scenario: Get nested resolved attribute
-    Given I access the resource url "/api/documents/data-source-name/package_1/sub_package_2/container_1?resolve_references=true"
+    Given I access the resource url "/api/documents/data-source-name/package_1/sub_package_2/container_1"
     When I make a "GET" request
     Then the response status should be "OK"
     And the response should contain
@@ -210,8 +210,8 @@ Feature: Get document
     }
     """
 
-  Scenario: Get resolved attribute
-    Given I access the resource url "/api/documents/test-source-name/$1.content[0]?resolve_references=True"
+  Scenario: Get resolved entity
+    Given I access the resource url "/api/documents/test-source-name/$1.content[0]"
     When I make a "GET" request
     Then the response status should be "OK"
     And the response should contain
@@ -222,8 +222,8 @@ Feature: Get document
     }
     """
 
-  Scenario: Get unresolved attribute
-    Given I access the resource url "/api/documents/test-source-name/$1.content[0]?resolve_references=False"
+  Scenario: Get reference
+    Given I access the resource url "/api/documents/test-source-name/$1.content[0]?depth=0"
     When I make a "GET" request
     Then the response status should be "OK"
     And the response should contain

--- a/src/tests/bdd/document/get_entity_with_optional_attributes.feature
+++ b/src/tests/bdd/document/get_entity_with_optional_attributes.feature
@@ -113,7 +113,7 @@ Feature: Get document
     """
 
   Scenario: when fetching entity by path, optional attributes should not be included
-    Given I access the resource url "/api/documents/test-source-name/TestData/example/?depth=1&resolve_links=true"
+    Given I access the resource url "/api/documents/test-source-name/TestData/example/?depth=1&resolve_references=true"
     When I make a "GET" request
     Then the response status should be "OK"
     And the response should be

--- a/src/tests/bdd/document/get_entity_with_optional_attributes.feature
+++ b/src/tests/bdd/document/get_entity_with_optional_attributes.feature
@@ -113,7 +113,7 @@ Feature: Get document
     """
 
   Scenario: when fetching entity by path, optional attributes should not be included
-    Given I access the resource url "/api/documents/test-source-name/TestData/example/?depth=1&resolve_references=true"
+    Given I access the resource url "/api/documents/test-source-name/TestData/example/?depth=1"
     When I make a "GET" request
     Then the response status should be "OK"
     And the response should be

--- a/src/tests/bdd/document/remove_2.feature
+++ b/src/tests/bdd/document/remove_2.feature
@@ -61,7 +61,7 @@ Feature: Explorer - Remove by path
     Given i access the resource url "/api/documents/data-source-name/blueprints/sub_package_1"
     When i make a "DELETE" request
     Then the response status should be "OK"
-    Given I access the resource url "/api/documents/data-source-name/$1?resolve_links=True"
+    Given I access the resource url "/api/documents/data-source-name/$1?resolve_references=True"
     When I make a "GET" request
     Then the response status should be "OK"
     And the array at content should be of length 1

--- a/src/tests/bdd/document/remove_2.feature
+++ b/src/tests/bdd/document/remove_2.feature
@@ -61,7 +61,7 @@ Feature: Explorer - Remove by path
     Given i access the resource url "/api/documents/data-source-name/blueprints/sub_package_1"
     When i make a "DELETE" request
     Then the response status should be "OK"
-    Given I access the resource url "/api/documents/data-source-name/$1?resolve_references=True"
+    Given I access the resource url "/api/documents/data-source-name/$1"
     When I make a "GET" request
     Then the response status should be "OK"
     And the array at content should be of length 1

--- a/src/tests/unit/test_get_document/test_inputs.py
+++ b/src/tests/unit/test_get_document/test_inputs.py
@@ -88,7 +88,7 @@ class GetDocumentInputTestCase(unittest.TestCase):
     def test_attribute_no_resolve(self):
         root = tree_node_to_dict(
             self.document_service.get_document(
-                Address.from_absolute("datasource/$1.cars[0].engine"), 0, resolve_links=False
+                Address.from_absolute("datasource/$1.cars[0].engine"), 0, resolve_references=False
             )
         )
         assert get_and_print_diff(root, self.car_rental_company["cars"][0]["engine"]) == []
@@ -96,7 +96,7 @@ class GetDocumentInputTestCase(unittest.TestCase):
     def test_attribute_resolve(self):
         root = tree_node_to_dict(
             self.document_service.get_document(
-                Address.from_absolute("datasource/$1.cars[0].engine"), 0, resolve_links=True
+                Address.from_absolute("datasource/$1.cars[0].engine"), 0, resolve_references=True
             )
         )
         assert get_and_print_diff(root, self.engine) == []
@@ -104,7 +104,7 @@ class GetDocumentInputTestCase(unittest.TestCase):
     def test_query_no_resolve(self):
         root = tree_node_to_dict(
             self.document_service.get_document(
-                Address.from_absolute("datasource/$1.customers(name=Jane)"), 0, resolve_links=False
+                Address.from_absolute("datasource/$1.customers(name=Jane)"), 0, resolve_references=False
             )
         )
         assert get_and_print_diff(root, self.car_rental_company["customers"][0]) == []
@@ -112,26 +112,26 @@ class GetDocumentInputTestCase(unittest.TestCase):
     def test_query_resolve(self):
         root = tree_node_to_dict(
             self.document_service.get_document(
-                Address.from_absolute("datasource/$1.customers(name=Jane)"), 0, resolve_links=True
+                Address.from_absolute("datasource/$1.customers(name=Jane)"), 0, resolve_references=True
             )
         )
         assert get_and_print_diff(root, self.customer) == []
 
     def test_depth_0(self):
         root = tree_node_to_dict(
-            self.document_service.get_document(Address.from_absolute("datasource/$1"), 0, resolve_links=True)
+            self.document_service.get_document(Address.from_absolute("datasource/$1"), 0, resolve_references=True)
         )
         assert get_and_print_diff(root, self.car_rental_company) == []
 
     def test_depth_1(self):
         root = tree_node_to_dict(
-            self.document_service.get_document(Address.from_absolute("datasource/$1"), 1, resolve_links=True)
+            self.document_service.get_document(Address.from_absolute("datasource/$1"), 1, resolve_references=True)
         )
         assert get_and_print_diff(root, {**self.car_rental_company, "customers": [self.customer]}) == []
 
     def test_depth_2(self):
         root = tree_node_to_dict(
-            self.document_service.get_document(Address.from_absolute("datasource/$1"), 2, resolve_links=True)
+            self.document_service.get_document(Address.from_absolute("datasource/$1"), 2, resolve_references=True)
         )
         assert (
             get_and_print_diff(
@@ -147,19 +147,25 @@ class GetDocumentInputTestCase(unittest.TestCase):
 
     def test_nested_depth_0(self):
         root = tree_node_to_dict(
-            self.document_service.get_document(Address.from_absolute("datasource/$1.cars[0]"), 0, resolve_links=True)
+            self.document_service.get_document(
+                Address.from_absolute("datasource/$1.cars[0]"), 0, resolve_references=True
+            )
         )
         assert get_and_print_diff(root, self.car_rental_company["cars"][0]) == []
 
     def test_nested_depth_1(self):
         root = tree_node_to_dict(
-            self.document_service.get_document(Address.from_absolute("datasource/$1.cars[0]"), 1, resolve_links=True)
+            self.document_service.get_document(
+                Address.from_absolute("datasource/$1.cars[0]"), 1, resolve_references=True
+            )
         )
         assert get_and_print_diff(root, {**self.car_rental_company["cars"][0], "engine": self.engine}) == []
 
     def test_nested_depth_2(self):
         root = tree_node_to_dict(
-            self.document_service.get_document(Address.from_absolute("datasource/$1.cars[0]"), 2, resolve_links=True)
+            self.document_service.get_document(
+                Address.from_absolute("datasource/$1.cars[0]"), 2, resolve_references=True
+            )
         )
         assert (
             get_and_print_diff(

--- a/src/tests/unit/test_get_document/test_inputs.py
+++ b/src/tests/unit/test_get_document/test_inputs.py
@@ -85,54 +85,28 @@ class GetDocumentInputTestCase(unittest.TestCase):
             documents = list(filter(lambda x: key in x and x[key] == value, documents))
         return documents
 
-    def test_attribute_no_resolve(self):
-        root = tree_node_to_dict(
-            self.document_service.get_document(
-                Address.from_absolute("datasource/$1.cars[0].engine"), 0, resolve_references=False
-            )
-        )
-        assert get_and_print_diff(root, self.car_rental_company["cars"][0]["engine"]) == []
-
-    def test_attribute_resolve(self):
-        root = tree_node_to_dict(
-            self.document_service.get_document(
-                Address.from_absolute("datasource/$1.cars[0].engine"), 0, resolve_references=True
-            )
-        )
-        assert get_and_print_diff(root, self.engine) == []
-
     def test_query_no_resolve(self):
         root = tree_node_to_dict(
-            self.document_service.get_document(
-                Address.from_absolute("datasource/$1.customers(name=Jane)"), 0, resolve_references=False
-            )
+            self.document_service.get_document(Address.from_absolute("datasource/$1.customers(name=Jane)"), 0)
         )
         assert get_and_print_diff(root, self.car_rental_company["customers"][0]) == []
 
     def test_query_resolve(self):
         root = tree_node_to_dict(
-            self.document_service.get_document(
-                Address.from_absolute("datasource/$1.customers(name=Jane)"), 0, resolve_references=True
-            )
+            self.document_service.get_document(Address.from_absolute("datasource/$1.customers(name=Jane)"), 1)
         )
         assert get_and_print_diff(root, self.customer) == []
 
     def test_depth_0(self):
-        root = tree_node_to_dict(
-            self.document_service.get_document(Address.from_absolute("datasource/$1"), 0, resolve_references=True)
-        )
+        root = tree_node_to_dict(self.document_service.get_document(Address.from_absolute("datasource/$1"), 0))
         assert get_and_print_diff(root, self.car_rental_company) == []
 
-    def test_depth_1(self):
-        root = tree_node_to_dict(
-            self.document_service.get_document(Address.from_absolute("datasource/$1"), 1, resolve_references=True)
-        )
+    def test_depth_2(self):
+        root = tree_node_to_dict(self.document_service.get_document(Address.from_absolute("datasource/$1"), 2))
         assert get_and_print_diff(root, {**self.car_rental_company, "customers": [self.customer]}) == []
 
-    def test_depth_2(self):
-        root = tree_node_to_dict(
-            self.document_service.get_document(Address.from_absolute("datasource/$1"), 2, resolve_references=True)
-        )
+    def test_depth_3(self):
+        root = tree_node_to_dict(self.document_service.get_document(Address.from_absolute("datasource/$1"), 3))
         assert (
             get_and_print_diff(
                 root,
@@ -147,29 +121,18 @@ class GetDocumentInputTestCase(unittest.TestCase):
 
     def test_nested_depth_0(self):
         root = tree_node_to_dict(
-            self.document_service.get_document(
-                Address.from_absolute("datasource/$1.cars[0]"), 0, resolve_references=True
-            )
+            self.document_service.get_document(Address.from_absolute("datasource/$1.cars[0].engine"), 0)
         )
-        assert get_and_print_diff(root, self.car_rental_company["cars"][0]) == []
+        assert get_and_print_diff(root, self.car_rental_company["cars"][0]["engine"]) == []
 
     def test_nested_depth_1(self):
         root = tree_node_to_dict(
-            self.document_service.get_document(
-                Address.from_absolute("datasource/$1.cars[0]"), 1, resolve_references=True
-            )
+            self.document_service.get_document(Address.from_absolute("datasource/$1.cars[0].engine"), 1)
         )
-        assert get_and_print_diff(root, {**self.car_rental_company["cars"][0], "engine": self.engine}) == []
+        assert get_and_print_diff(root, self.engine) == []
 
     def test_nested_depth_2(self):
         root = tree_node_to_dict(
-            self.document_service.get_document(
-                Address.from_absolute("datasource/$1.cars[0]"), 2, resolve_references=True
-            )
+            self.document_service.get_document(Address.from_absolute("datasource/$1.cars[0].engine"), 2)
         )
-        assert (
-            get_and_print_diff(
-                root, {**self.car_rental_company["cars"][0], "engine": {**self.engine, "fuelPump": self.fuel_pump}}
-            )
-            == []
-        )
+        assert get_and_print_diff(root, {**self.engine, "fuelPump": self.fuel_pump}) == []

--- a/src/tests/unit/test_get_document/test_reference_resolve.py
+++ b/src/tests/unit/test_get_document/test_reference_resolve.py
@@ -56,9 +56,7 @@ class GetDocumentResolveTestCase(unittest.TestCase):
 
         document_service = get_mock_document_service(lambda x, y: document_repository)
         with pytest.raises(Exception, match=r"The protocol 'wrong' is not supported"):
-            tree_node_to_dict(
-                document_service.get_document(Address.from_absolute("datasource/$1"), resolve_references=True, depth=9)
-            )
+            tree_node_to_dict(document_service.get_document(Address.from_absolute("datasource/$1"), depth=9))
 
     def test_references(self):
         my_car_rental = {
@@ -209,7 +207,7 @@ class GetDocumentResolveTestCase(unittest.TestCase):
             "name": "engines",
             "isRoot": True,
             "content": [
-                {"address": "$3", "type": SIMOS.REFERENCE.value, "referenceType": REFERENCE_TYPES.LINK.value},
+                {"address": "$3", "type": SIMOS.REFERENCE.value, "referenceType": REFERENCE_TYPES.STORAGE.value},
             ],
         }
 
@@ -219,7 +217,7 @@ class GetDocumentResolveTestCase(unittest.TestCase):
                 "name": "parts",
                 "isRoot": True,
                 "content": [
-                    {"address": "$2", "type": SIMOS.REFERENCE.value, "referenceType": REFERENCE_TYPES.LINK.value},
+                    {"address": "$2", "type": SIMOS.REFERENCE.value, "referenceType": REFERENCE_TYPES.STORAGE.value},
                 ],
             },
             my_engine,
@@ -252,11 +250,9 @@ class GetDocumentResolveTestCase(unittest.TestCase):
             return document_repository
 
         document_service = get_mock_document_service(mock_data_source)
-        actual = tree_node_to_dict(
-            document_service.get_document(Address.from_absolute("test_data/$2"), resolve_references=True, depth=99)
-        )
+        actual = tree_node_to_dict(document_service.get_document(Address.from_absolute("test_data/$2"), depth=99))
         complex_package = tree_node_to_dict(
-            document_service.get_document(Address.from_absolute("test_data/$1"), resolve_references=True, depth=99)
+            document_service.get_document(Address.from_absolute("test_data/$1"), depth=99)
         )
 
         assert isinstance(actual, dict)

--- a/src/tests/unit/test_get_document/test_reference_resolve.py
+++ b/src/tests/unit/test_get_document/test_reference_resolve.py
@@ -57,7 +57,7 @@ class GetDocumentResolveTestCase(unittest.TestCase):
         document_service = get_mock_document_service(lambda x, y: document_repository)
         with pytest.raises(Exception, match=r"The protocol 'wrong' is not supported"):
             tree_node_to_dict(
-                document_service.get_document(Address.from_absolute("datasource/$1"), resolve_links=True, depth=9)
+                document_service.get_document(Address.from_absolute("datasource/$1"), resolve_references=True, depth=9)
             )
 
     def test_references(self):
@@ -253,10 +253,10 @@ class GetDocumentResolveTestCase(unittest.TestCase):
 
         document_service = get_mock_document_service(mock_data_source)
         actual = tree_node_to_dict(
-            document_service.get_document(Address.from_absolute("test_data/$2"), resolve_links=True, depth=99)
+            document_service.get_document(Address.from_absolute("test_data/$2"), resolve_references=True, depth=99)
         )
         complex_package = tree_node_to_dict(
-            document_service.get_document(Address.from_absolute("test_data/$1"), resolve_links=True, depth=99)
+            document_service.get_document(Address.from_absolute("test_data/$1"), resolve_references=True, depth=99)
         )
 
         assert isinstance(actual, dict)

--- a/src/tests/unit/test_tree_functionality/test_tree_dict_conversion.py
+++ b/src/tests/unit/test_tree_functionality/test_tree_dict_conversion.py
@@ -320,11 +320,10 @@ class TreeNodeDictConversion(unittest.TestCase):
     def test_tree_node_to_ref_dict(self):
         engine_package_node = get_engine_package_node()
         engine_package_dict = tree_node_to_ref_dict(engine_package_node)
-        expected_ref = "$123"
         assert engine_package_dict["content"][0] == {
-            "address": expected_ref,
+            "address": "$123",
             "type": SIMOS.REFERENCE.value,
-            "referenceType": REFERENCE_TYPES.LINK.value,
+            "referenceType": REFERENCE_TYPES.STORAGE.value,
         }
 
     def test_tree_node_to_ref_dict_2(self):

--- a/src/tests/unit/test_tree_functionality/test_tree_dict_conversion.py
+++ b/src/tests/unit/test_tree_functionality/test_tree_dict_conversion.py
@@ -323,7 +323,7 @@ class TreeNodeDictConversion(unittest.TestCase):
         assert engine_package_dict["content"][0] == {
             "address": "$123",
             "type": SIMOS.REFERENCE.value,
-            "referenceType": REFERENCE_TYPES.STORAGE.value,
+            "referenceType": REFERENCE_TYPES.LINK.value,
         }
 
     def test_tree_node_to_ref_dict_2(self):


### PR DESCRIPTION
## What does this pull request change?

*  Update the Package blueprint to set the content attribute to contained true (model contained).
* Rerences with reference type storage are not resolved by default. 
  * depth is used to control if references (storage and link) should be resolved (it does not affect contained attributes)
    * depth=0 means that if the address is pointing to a reference it will be returned directly without being resolved first.
    * depth=1 means that if the address is pointing to a reference it will be resolved before returned. Child references will not be resolved.
    * depth=2 means that the entity's direct child references will also be returned.

> BREAKING CHANGE: GET endpoint for documents  - resolve_links is removed 

## Why is this pull request needed?

## Issues related to this change:
