### PR TITLE
fix: rename plugins according to new naming

### DIFF
--- a/src/common/utils/get_storage_recipe.py
+++ b/src/common/utils/get_storage_recipe.py
@@ -23,7 +23,7 @@ default_list_recipe = Recipe(
     **{
         "name": "List",
         "type": SIMOS.UI_RECIPE.value,
-        "plugin": "@development-framework/dm-core-plugins/generic_list",
+        "plugin": "@development-framework/dm-core-plugins/list",
         "dimensions": "*",
     }
 )

--- a/src/common/utils/get_storage_recipe.py
+++ b/src/common/utils/get_storage_recipe.py
@@ -23,7 +23,7 @@ default_list_recipe = Recipe(
     **{
         "name": "List",
         "type": SIMOS.UI_RECIPE.value,
-        "plugin": "@development-framework/dm-core-plugins/generic-list",
+        "plugin": "@development-framework/dm-core-plugins/generic_list",
         "dimensions": "*",
     }
 )
@@ -32,13 +32,13 @@ default_initial_ui_recipe = Recipe(
     **{
         "name": "RecipeSelect",
         "type": SIMOS.UI_RECIPE.value,
-        "plugin": "@development-framework/dm-core-plugins/attribute-selector",
+        "plugin": "@development-framework/dm-core-plugins/view_selector",
         "config": {
-            "type": "dmss://system/Plugins/dm-core-plugins/attribute-selector/AttributeSelectorConfig",
+            "type": "dmss://system/Plugins/dm-core-plugins/view_selector/AttributeSelectorConfig",
             "asSidebar": False,
             "items": [
                 {
-                    "type": "dmss://system/Plugins/dm-core-plugins/attribute-selector/AttributeSelectorItem",
+                    "type": "dmss://system/Plugins/dm-core-plugins/view_selector/AttributeSelectorItem",
                     "label": "Yaml",
                     "view": {
                         "type": "dmss://system/SIMOS/InlineRecipeViewConfig",
@@ -53,7 +53,7 @@ default_initial_ui_recipe = Recipe(
                     },
                 },
                 {
-                    "type": "dmss://system/Plugins/dm-core-plugins/attribute-selector/AttributeSelectorItem",
+                    "type": "dmss://system/Plugins/dm-core-plugins/view_selector/AttributeSelectorItem",
                     "label": "Edit",
                     "view": {
                         "type": "dmss://system/SIMOS/InlineRecipeViewConfig",

--- a/src/tests/bdd/get_blueprints.feature
+++ b/src/tests/bdd/get_blueprints.feature
@@ -283,7 +283,7 @@ Feature: Get a blueprint
     {
       "name": "List",
       "type": "dmss://system/SIMOS/UiRecipe",
-      "plugin": "@development-framework/dm-core-plugins/generic-list",
+      "plugin": "@development-framework/dm-core-plugins/list",
       "dimensions": "*"
     }
     ],


### PR DESCRIPTION
## What does this pull request change?

attribute-selector -> view_selector
generic-lsit -> list

## Why is this pull request needed?

## Issues related to this change: