### PR TITLE
fix: document update bug

### DIFF
--- a/src/common/tree_node_serializer.py
+++ b/src/common/tree_node_serializer.py
@@ -87,11 +87,7 @@ def tree_node_to_ref_dict(node: Node | ListNode) -> dict:
 
     # Primitive
     # if complex attribute name is renamed in blueprint, then the blueprint is None in the entity.
-    if (
-        node.attribute.attribute_type != BuiltinDataTypes.BINARY.value
-        and node.attribute.attribute_type != BuiltinDataTypes.OBJECT.value
-        and node.blueprint is not None
-    ):
+    if node.attribute.attribute_type != BuiltinDataTypes.BINARY.value and node.blueprint is not None:
         for attribute in node.blueprint.get_primitive_types():
             if attribute.name in node.entity:
                 data[attribute.name] = node.entity[attribute.name]

--- a/src/services/document_service.py
+++ b/src/services/document_service.py
@@ -326,13 +326,16 @@ class DocumentService:
         else:
             node: Node = self.get_document(address)  # type: ignore
 
-        validate_entity(data, self.get_blueprint, self.get_blueprint(node.attribute.attribute_type), "extend")
+        if node.attribute.attribute_type != BuiltinDataTypes.OBJECT.value:
+            validate_entity(data, self.get_blueprint, self.get_blueprint(node.attribute.attribute_type), "extend")
         node.update(data)
         if files:
             self._merge_entity_and_files(node, files)
 
         self.save(node, address.data_source, update_uncontained=update_uncontained, initial=True)
-
+        if len(path_parts) > 1:
+            node.parent.children.append(node)
+            self.save(node.parent, address.data_source, update_uncontained=update_uncontained, initial=True)
         logger.info(f"Updated entity '{address}'")
         return {"data": tree_node_to_dict(node)}
 

--- a/src/tests/bdd/document/update.feature
+++ b/src/tests/bdd/document/update.feature
@@ -60,6 +60,12 @@ Feature: Document 2
           "type": "dmss://system/SIMOS/BlueprintAttribute",
           "optional": true,
           "name": "extra"
+        },
+        {
+          "attributeType": "object",
+          "type": "dmss://system/SIMOS/BlueprintAttribute",
+          "optional": true,
+          "name": "complexAttribute"
         }
       ]
     }
@@ -317,5 +323,103 @@ Feature: Document 2
             "extra": "extra_1"
           }
         ]
+    }
+    """
+    Given i access the resource url "/api/documents/data-source-name/$7"
+    When I make a "GET" request
+    Then the response status should be "OK"
+    And the response should be
+    """
+    {
+      "_id": "7",
+      "name": "document_3",
+      "type": "dmss://test-source-name/TestData/ItemType",
+      "complexList": [
+          {
+            "name": "item_1_contained",
+            "type": "dmss://test-source-name/TestData/ItemTypeTwo",
+            "extra": "extra_1"
+          }
+      ]
+    }
+    """
+    Given i access the resource url "/api/documents/data-source-name/$7.complexList"
+    When I make a "GET" request
+    Then the response status should be "OK"
+    And the response should be
+    """
+    [
+          {
+            "name": "item_1_contained",
+            "type": "dmss://test-source-name/TestData/ItemTypeTwo",
+            "extra": "extra_1"
+          }
+      ]
+    """
+    Given i access the resource url "/api/documents/data-source-name/$7.complexList[0]"
+    When I make a "GET" request
+    Then the response status should be "OK"
+        And the response should be
+    """
+    {
+      "name": "item_1_contained",
+      "type": "dmss://test-source-name/TestData/ItemTypeTwo",
+      "extra": "extra_1"
+    }
+    """
+
+
+  Scenario: Update complex attribute
+    Given i access the resource url "/api/documents/data-source-name/$7.complexList"
+    When i make a form-data "PUT" request
+    """
+    { "data":
+      [
+          {
+            "name": "item_1_contained",
+            "type": "dmss://test-source-name/TestData/ItemTypeTwo",
+            "extra": "extra_1"
+          }
+      ]
+    }
+    """
+    Then the response status should be "OK"
+    Given i access the resource url "/api/documents/data-source-name/$7.complexList[0].complexAttribute"
+    When i make a form-data "PUT" request
+    """
+    { "data":
+        {
+          "name": "itemForComplexAttribute",
+          "type": "dmss://test-source-name/TestData/ItemTypeTwo",
+          "extra": "extra_2"
+        }
+    }
+    """
+    Then the response status should be "OK"
+    Given i access the resource url "/api/documents/data-source-name/$7.complexList[0]"
+    When I make a "GET" request
+    Then the response status should be "OK"
+    And the response should contain
+    """
+    {
+      "name": "item_1_contained",
+      "type": "dmss://test-source-name/TestData/ItemTypeTwo",
+      "extra": "extra_1",
+      "complexAttribute": {
+        "name": "itemForComplexAttribute",
+        "type": "dmss://test-source-name/TestData/ItemTypeTwo",
+        "extra": "extra_2"
+      }
+    }
+    """
+    Given i access the resource url "/api/documents/data-source-name/$7.complexList[0].complexAttribute"
+    When I make a "GET" request
+    Then the response status should be "OK"
+    And the response should contain
+    """
+    {
+      "name": "itemForComplexAttribute",
+      "type": "dmss://test-source-name/TestData/ItemTypeTwo",
+      "extra": "extra_2"
     }
     """


### PR DESCRIPTION
## What does this pull request change?
Update dmss to fix bug with document update. 

the saving of complex attributes when type is "object" did not work correctly. 
example:
1) updating `data-source-name/$7.complexList[0].complexAttribute` with a PUT request (where type of `complexAttribute` is object)
2) GET `data-source-name/$7.complexList[0].complexAttribute` would give error since it did not exist


Also updated tests to make sure that the document are updated correctly.

## Issues related to this change:
bug discovered by working on https://github.com/equinor/dm-core-packages/issues/280