### PR TITLE
fix: for instantiate entity feature, optional attributes with a default value are included

### DIFF
--- a/src/common/utils/arrays.py
+++ b/src/common/utils/arrays.py
@@ -1,0 +1,74 @@
+from typing import Any, Callable, Type
+
+from domain_classes.blueprint_attribute import BlueprintAttribute
+from domain_classes.dimension import Dimension
+
+
+def create_default_array(
+    dimension: Dimension,
+    blueprint_provider: Callable,
+    create_entity_class: Type[
+        Any
+    ],  # TODO use Type[CreateEntity]. can't use it now due to circular import. Needs refactoring.
+    blueprint_attribute: BlueprintAttribute,
+) -> list:
+    dimensions = dimension.dimensions
+    if dimensions == [""]:
+        raise Exception("This attribute is not an array!")
+    if len(dimensions) == 1:
+        if dimensions[0] == "*":
+            return blueprint_attribute.default if blueprint_attribute.default is not None else []
+
+        # TODO use default value from blueprint if it exists for cases other than dimensions[0] == "*"
+        # Return a list initialized with default values for the size of the array.
+        if dimension.type is int:
+            return [0 for n in range(int(dimensions[0]))]
+        if dimension.type is float:
+            return [0.00 for n in range(int(dimensions[0]))]
+        if dimension.type is str:
+            return ["" for n in range(int(dimensions[0]))]
+        if dimension.type is bool:
+            return [False for n in range(int(dimensions[0]))]
+        else:
+            # For fixed complex types, create the entity with default values. Set name from list index.
+            return [create_entity_class(blueprint_provider, dimension.type).entity for n in range(int(dimensions[0]))]
+
+    if dimensions[0] == "*":
+        # If the size of the rank is "*" we only create one nested list.
+        nested_list = [
+            create_default_array(
+                Dimension(remove_first_and_join(dimensions), dimension.type),
+                blueprint_provider,
+                create_entity_class,
+                blueprint_attribute,
+            )
+        ]
+    else:
+        # If the size of the rank in NOT "*", we expect an Integer, and create n number of nested lists.
+        nested_list = [
+            create_default_array(
+                Dimension(remove_first_and_join(dimensions), dimension.type),
+                blueprint_provider,
+                create_entity_class,
+                blueprint_attribute,
+            )
+            for n in range(int(dimensions[0]))
+        ]
+    return nested_list
+
+
+def remove_first_and_join(input_list: list[str]) -> str:
+    """
+    Remove the first element of the list and convert to a string equivalent.
+    Examples:
+    ["1","2","3","4"] -> "2,3,4"
+    ["0","0"] -> "0"
+    ["4"] -> ""
+    [""] -> ""
+    """
+    if len(input_list) == 1:
+        return ""
+    if len(input_list) <= 1:
+        return ",".join(input_list)
+    else:
+        return ",".join(input_list[1:])

--- a/src/common/utils/create_entity.py
+++ b/src/common/utils/create_entity.py
@@ -70,7 +70,6 @@ class CreateEntity:
             ""
         ]  # type(attr.default) == dict or type(attr.default) == list
 
-    # add all non optional attributes with default value.
     # type is inserted based on the parent attributes type, or the initial type for root entity.
     def _get_entity(self, blueprint: Blueprint, entity: dict):
         """
@@ -79,16 +78,13 @@ class CreateEntity:
           If the required attribute has a default value, that value will be used.
           If not, an 'empty' value will be used. For example empty string,
           an empty list, the number 0, etc.
-        - optional attributes with a default value are included
-        - optional attributes without a default value are not included.
+        - optional attributes value are not included (also true if default value is provided).
         """
         for attr in blueprint.attributes:
             if attr.attribute_type == BuiltinDataTypes.BINARY.value:
                 continue
-            if attr.is_optional and attr.default is not None:
-                entity[attr.name] = attr.default
-            if attr.is_optional and attr.default is None:
-                # skip attribute if it is optional and does not have default value
+            if attr.is_optional:
+                # skip attribute if it is optional
                 continue
             if attr.attribute_type in PRIMITIVES:
                 if not attr.is_optional and attr.name not in entity:

--- a/src/common/utils/string_helpers.py
+++ b/src/common/utils/string_helpers.py
@@ -14,7 +14,9 @@ from enums import BuiltinDataTypes
 
 
 # Convert dmt attribute_types to python types. If complex, return type as string.
-def get_data_type_from_dmt_type(attribute_type: str):
+def get_data_type_from_dmt_type(
+    attribute_type: str,
+) -> type[bool] | type[int] | type[float] | type[str] | str:
     try:
         type_enum = BuiltinDataTypes(attribute_type)
         return type_enum.to_py_type()

--- a/src/features/entity/entity_feature.py
+++ b/src/features/entity/entity_feature.py
@@ -19,6 +19,13 @@ def instantiate(entity: Entity, user: User = Depends(auth_w_jwt_or_pat)):
     """Create a new entity and return it.
 
     (entity is not saved in DMSS)
+    Rules for instantiation:
+    - all required attributes, as defined in the blueprint, are included.
+      If the required attribute has a default value, that value will be used.
+      If not, an 'empty' value will be used. For example empty string,
+      an empty list, the number 0, etc.
+    - optional attributes with a default value are included
+    - optional attributes without a default value are not included.
     """
     return instantiate_entity_use_case(basic_entity=entity, user=user)
 

--- a/src/tests/bdd/entity/instantiate_entity.feature
+++ b/src/tests/bdd/entity/instantiate_entity.feature
@@ -1,0 +1,131 @@
+Feature: Instantiate entity
+
+  Background: There are data sources in the system
+    Given the system data source and SIMOS core package are available
+    Given there are data sources
+      | name             |
+      | data-source-name |
+    Given there are repositories in the data sources
+      | data-source       | host | port  | username | password | tls   | name     | database  | collection | type     | dataTypes |
+      | data-source-name  | db   | 27017 | maf      | maf      | false | repo1    |  bdd-test | entities   | mongo-db | default   |
+
+    Given there exist document with id "1" in data source "data-source-name"
+    """
+    {
+      "name": "root_package",
+      "description": "",
+      "type": "dmss://system/SIMOS/Package",
+      "isRoot": true,
+      "content": [
+        {
+          "address": "$2",
+          "type": "dmss://system/SIMOS/Reference",
+          "referenceType": "storage"
+        },
+        {
+          "address": "$3",
+          "type": "dmss://system/SIMOS/Reference",
+          "referenceType": "storage"
+        }
+      ]
+    }
+    """
+
+
+    Given there exist document with id "2" in data source "data-source-name"
+    """
+    {
+      "type": "dmss://system/SIMOS/Blueprint",
+      "name": "Employee",
+      "extends": ["dmss://system/SIMOS/NamedEntity"],
+      "attributes": [
+        {
+          "name": "isManager",
+          "attributeType": "boolean",
+          "type": "dmss://system/SIMOS/BlueprintAttribute"
+        },
+        {
+          "name": "colleagues",
+          "attributeType": "dmss://data-source-name/root_package/Employee",
+          "optional": true,
+          "dimensions": "*",
+          "contained": false,
+          "default": [],
+          "type": "dmss://system/SIMOS/BlueprintAttribute"
+        },
+        {
+          "name": "salary",
+          "attributeType": "integer",
+          "type": "dmss://system/SIMOS/BlueprintAttribute",
+          "optional": true
+        },
+        {
+          "name": "managers",
+          "attributeType": "dmss://data-source-name/root_package/Employee",
+          "optional": false,
+          "dimensions": "*",
+          "contained": false,
+
+          "default": [
+            {
+              "address": "$5",
+              "type": "dmss://system/SIMOS/Reference",
+              "referenceType": "link"
+            }
+          ]
+        },
+        {
+          "name": "bestFriendAtWork",
+          "attributeType": "dmss://data-source-name/root_package/Employee",
+          "optional": true,
+          "contained": false,
+          "type": "dmss://system/SIMOS/BlueprintAttribute",
+          "default": {
+            "type": "dmss://data-source-name/root_package/Employee",
+            "name": "Kari",
+            "isManager": false
+          }
+        }
+      ]
+    }
+    """
+    Given there exist document with id "3" in data source "data-source-name"
+    """
+    {
+      "type": "dmss://data-source-name/root_package/Employee",
+      "name": "BigBossMan",
+      "isManager": true
+    }
+    """
+
+  Scenario: instantiate entity
+    Given i access the resource url "/api/entity"
+    When i make a "POST" request
+    """
+    {
+      "type": "dmss://data-source-name/root_package/Employee"
+    }
+    """
+    Then the response status should be "OK"
+    And the response should be
+    """
+    {
+      "type": "dmss://data-source-name/root_package/Employee",
+      "colleagues": [],
+      "isManager": false,
+      "description": "",
+      "name": "",
+      "managers": [
+        {
+          "address": "$5",
+          "type": "dmss://system/SIMOS/Reference",
+          "referenceType": "link"
+        }
+      ],
+      "bestFriendAtWork": {
+        "type": "dmss://data-source-name/root_package/Employee",
+        "name": "Kari",
+        "isManager": false
+      }
+    }
+    """

--- a/src/tests/bdd/entity/instantiate_entity.feature
+++ b/src/tests/bdd/entity/instantiate_entity.feature
@@ -111,9 +111,7 @@ Feature: Instantiate entity
     """
     {
       "type": "dmss://data-source-name/root_package/Employee",
-      "colleagues": [],
       "isManager": false,
-      "description": "",
       "name": "",
       "managers": [
         {
@@ -121,11 +119,6 @@ Feature: Instantiate entity
           "type": "dmss://system/SIMOS/Reference",
           "referenceType": "link"
         }
-      ],
-      "bestFriendAtWork": {
-        "type": "dmss://data-source-name/root_package/Employee",
-        "name": "Kari",
-        "isManager": false
-      }
+      ]
     }
     """

--- a/src/tests/bdd/entity/validate_existing_entity.feature
+++ b/src/tests/bdd/entity/validate_existing_entity.feature
@@ -12,7 +12,7 @@ Feature: Validate entities in database
     Given there exist document with id "1" in data source "data-source-name"
     """
     {
-      "name": "root_package",
+      "name": "root_employee_package",
       "description": "",
       "type": "dmss://system/SIMOS/Package",
       "isRoot": true,
@@ -64,7 +64,7 @@ Feature: Validate entities in database
         },
         {
           "name": "colleagues",
-          "attributeType": "dmss://data-source-name/root_package/Employee",
+          "attributeType": "dmss://data-source-name/root_employee_package/Employee",
           "optional": true,
           "dimensions": "*",
           "contained": false,
@@ -76,7 +76,7 @@ Feature: Validate entities in database
     Given there exist document with id "3" in data source "data-source-name"
     """
     {
-      "type": "dmss://data-source-name/root_package/Employee",
+      "type": "dmss://data-source-name/root_employee_package/Employee",
       "name": "Frodo",
       "isManager": false
     }
@@ -84,7 +84,7 @@ Feature: Validate entities in database
     Given there exist document with id "4" in data source "data-source-name"
     """
     {
-      "type": "dmss://data-source-name/root_package/Employee",
+      "type": "dmss://data-source-name/root_employee_package/Employee",
       "name": "John-Error",
       "age": 123
     }
@@ -92,7 +92,7 @@ Feature: Validate entities in database
     Given there exist document with id "5" in data source "data-source-name"
     """
     {
-      "type": "dmss://data-source-name/root_package/Employee",
+      "type": "dmss://data-source-name/root_employee_package/Employee",
       "name": "Sam",
       "isManager": true
     }
@@ -100,7 +100,7 @@ Feature: Validate entities in database
     Given there exist document with id "6" in data source "data-source-name"
     """
     {
-      "type": "dmss://data-source-name/root_package/Employee",
+      "type": "dmss://data-source-name/root_employee_package/Employee",
       "name": "Gandalf",
       "isManager": false,
       "colleagues": [
@@ -120,7 +120,7 @@ Feature: Validate entities in database
     Given there exist document with id "7" in data source "data-source-name"
     """
     {
-      "type": "dmss://data-source-name/root_package/Employee",
+      "type": "dmss://data-source-name/root_employee_package/Employee",
       "name": "Saruman",
       "isManager": false,
       "colleagues": [
@@ -136,7 +136,7 @@ Feature: Validate entities in database
 
 
   Scenario: Validate existing correct entity
-    Given i access the resource url "/api/entity/validate-existing-entity/data-source-name/root_package/Frodo"
+    Given i access the resource url "/api/entity/validate-existing-entity/data-source-name/root_employee_package/Frodo"
     When i make a "POST" request
     Then the response status should be "OK"
     And the response should contain
@@ -145,7 +145,7 @@ Feature: Validate entities in database
     """
 
   Scenario: Validate existing correct, complex entity
-    Given i access the resource url "/api/entity/validate-existing-entity/data-source-name/root_package/Gandalf"
+    Given i access the resource url "/api/entity/validate-existing-entity/data-source-name/root_employee_package/Gandalf"
     When i make a "POST" request
     Then the response status should be "OK"
     And the response should contain
@@ -154,19 +154,19 @@ Feature: Validate entities in database
     """
 
   Scenario: Validate existing entity with errors
-    Given i access the resource url "/api/entity/validate-existing-entity/data-source-name/root_package/John-Error"
+    Given i access the resource url "/api/entity/validate-existing-entity/data-source-name/root_employee_package/John-Error"
     When i make a "POST" request
     Then the response status should be "Bad Request"
 
 
   Scenario: Validate existing, complex entity with errors
-    Given i access the resource url "/api/entity/validate-existing-entity/data-source-name/root_package/Saruman"
+    Given i access the resource url "/api/entity/validate-existing-entity/data-source-name/root_employee_package/Saruman"
     When i make a "POST" request
     Then the response status should be "Bad Request"
 
 
   Scenario: Validate existing Package entity with errors
-    Given i access the resource url "/api/entity/validate-existing-entity/data-source-name/root_package"
+    Given i access the resource url "/api/entity/validate-existing-entity/data-source-name/root_employee_package"
     When i make a "POST" request
     Then the response status should be "Bad Request"
 

--- a/src/tests/bdd/entity/validate_non_existing_entity.feature
+++ b/src/tests/bdd/entity/validate_non_existing_entity.feature
@@ -12,7 +12,7 @@ Feature: Validate entities not in the database
     Given there exist document with id "1" in data source "data-source-name"
     """
     {
-      "name": "root_package",
+      "name": "root_employee_package",
       "description": "",
       "type": "dmss://system/SIMOS/Package",
       "isRoot": true,
@@ -39,7 +39,7 @@ Feature: Validate entities not in the database
         },
         {
           "name": "colleagues",
-          "attributeType": "dmss://data-source-name/root_package/Employee",
+          "attributeType": "dmss://data-source-name/root_employee_package/Employee",
           "optional": true,
           "dimensions": "*",
           "contained": false,
@@ -56,7 +56,7 @@ Feature: Validate entities not in the database
     When i make a "POST" request
     """
     {
-      "type": "dmss://data-source-name/root_package/Employee",
+      "type": "dmss://data-source-name/root_employee_package/Employee",
       "name": "Ola",
       "isManager": false
     }
@@ -72,7 +72,7 @@ Feature: Validate entities not in the database
     When i make a "POST" request
     """
     {
-      "type": "dmss://data-source-name/root_package/Employee",
+      "type": "dmss://data-source-name/root_employee_package/Employee",
       "name": "Kari",
       "age": 123
     }
@@ -84,7 +84,7 @@ Feature: Validate entities not in the database
     When i make a "POST" request
     """
     {
-      "type": "dmss://data-source-name/root_package/Employee",
+      "type": "dmss://data-source-name/root_employee_package/Employee",
       "name": "Nora",
       "salary": 123
     }
@@ -97,7 +97,7 @@ Feature: Validate entities not in the database
     When i make a "POST" request
     """
     {
-      "type": "dmss://data-source-name/root_package/Employee",
+      "type": "dmss://data-source-name/root_employee_package/Employee",
       "name": "Legolas",
       "isManager": false,
       "colleagues": [

--- a/src/tests/unit/test_create_default_array.py
+++ b/src/tests/unit/test_create_default_array.py
@@ -95,9 +95,7 @@ class DefaultArrayTestCase(unittest.TestCase):
             empty_string_blueprint_attribute,
         )
 
-        assert default_array == [
-            [{"description": "", "name": "", "type": "dmss://system/SIMOS/Package", "isRoot": False}]
-        ]
+        assert default_array == [[{"name": "", "type": "dmss://system/SIMOS/Package", "isRoot": False}]]
 
     def test_creation_of_default_array_unfixed_rank2(self):
         default_array = create_default_array(

--- a/src/tests/unit/test_create_default_array.py
+++ b/src/tests/unit/test_create_default_array.py
@@ -1,7 +1,9 @@
 import unittest
 
+from common.utils.arrays import create_default_array, remove_first_and_join
 from common.utils.create_entity import CreateEntity
 from domain_classes.blueprint import Blueprint
+from domain_classes.blueprint_attribute import BlueprintAttribute
 from domain_classes.dimension import Dimension
 from enums import SIMOS
 from services.document_service import DocumentService
@@ -55,6 +57,9 @@ higher_rank_array_blueprint = {
     ],
 }
 
+empty_string_blueprint_attribute = BlueprintAttribute(name="", attribute_type="string")
+empty_integer_blueprint_attribute = BlueprintAttribute(name="", attribute_type="integer")
+
 file_repository_test = LocalFileRepository()
 
 
@@ -76,24 +81,35 @@ blueprint_provider = document_service.get_blueprint
 
 class DefaultArrayTestCase(unittest.TestCase):
     def test_creation_of_default_array_simple(self):
-        default_array = Dimension("*", "integer").create_default_array(blueprint_provider, CreateEntity)
+        default_array = create_default_array(
+            Dimension("*", "integer"), blueprint_provider, CreateEntity, empty_integer_blueprint_attribute
+        )
 
         assert default_array == []
 
     def test_creation_of_default_array_complex_type(self):
-        default_array = Dimension("1,1", "dmss://system/SIMOS/Package").create_default_array(
-            blueprint_provider, CreateEntity
+        default_array = create_default_array(
+            Dimension("1,1", "dmss://system/SIMOS/Package"),
+            blueprint_provider,
+            CreateEntity,
+            empty_string_blueprint_attribute,
         )
 
-        assert default_array == [[{"name": "", "type": "dmss://system/SIMOS/Package", "isRoot": False, "content": []}]]
+        assert default_array == [
+            [{"description": "", "name": "", "type": "dmss://system/SIMOS/Package", "isRoot": False}]
+        ]
 
     def test_creation_of_default_array_unfixed_rank2(self):
-        default_array = Dimension("*,*", "integer").create_default_array(blueprint_provider, CreateEntity)
+        default_array = create_default_array(
+            Dimension("*,*", "integer"), blueprint_provider, CreateEntity, empty_integer_blueprint_attribute
+        )
 
         assert default_array == [[]]
 
     def test_creation_of_default_array_fixed_rank2(self):
-        default_array = Dimension("2,1", "integer").create_default_array(blueprint_provider, CreateEntity)
+        default_array = create_default_array(
+            Dimension("2,1", "integer"), blueprint_provider, CreateEntity, empty_integer_blueprint_attribute
+        )
         # fmt: off
         assert default_array == [
             [0],
@@ -102,7 +118,9 @@ class DefaultArrayTestCase(unittest.TestCase):
         # fmt: on
 
     def test_creation_of_default_array_mixed_rank_string(self):
-        default_array = Dimension("2,*,3", "string").create_default_array(blueprint_provider, CreateEntity)
+        default_array = create_default_array(
+            Dimension("2,*,3", "string"), blueprint_provider, CreateEntity, empty_string_blueprint_attribute
+        )
         # fmt: off
         assert default_array == [
             [["", "", ""]],
@@ -111,16 +129,26 @@ class DefaultArrayTestCase(unittest.TestCase):
         # fmt: on
 
     def test_creation_of_default_array_mixed_rank3_int(self):
-        default_array = Dimension("2,2,*", "integer").create_default_array(blueprint_provider, CreateEntity)
+        default_array = create_default_array(
+            Dimension("2,2,*", "integer"), blueprint_provider, CreateEntity, empty_integer_blueprint_attribute
+        )
         expected = [[[], []], [[], []]]
 
         assert default_array == expected
 
     def test_creation_of_default_array_mixed_rank3_bool(self):
-        default_array = Dimension("1,2,1", "boolean").create_default_array(blueprint_provider, CreateEntity)
+        default_array = create_default_array(
+            Dimension("1,2,1", "boolean"), blueprint_provider, CreateEntity, empty_string_blueprint_attribute
+        )
         expected = [[[False], [False]]]
 
         assert default_array == expected
+
+    def test_remove_first_and_join(self):
+        assert remove_first_and_join(["1", "2", "3", "4"]) == "2,3,4"
+        assert remove_first_and_join(["0", "0"]) == "0"
+        assert remove_first_and_join(["0"]) == ""
+        assert remove_first_and_join([]) == ""
 
 
 if __name__ == "__main__":

--- a/src/tests/unit/test_create_entity.py
+++ b/src/tests/unit/test_create_entity.py
@@ -28,16 +28,6 @@ class CreateEntityTestCase(unittest.TestCase):
                 "power": 120,
                 "type": "test_data/complex/EngineTest",
             },
-            "engine3": {
-                "name": "default engine",
-                "fuelPump": {
-                    "name": "fuelPump",
-                    "description": "A standard fuel pump",
-                    "type": "test_data/complex/FuelPumpTest",
-                },
-                "power": 9,
-                "type": "test_data/complex/EngineTest",
-            },
             "is_sedan": True,
             "name": "CarTest",
             "plateNumber": "",


### PR DESCRIPTION
## What does this pull request change?

The instantiate entity endpoint should follow these rules:
- all required attributes, as defined in the blueprint, are included.
  If the required attribute has a default value, that value will be used.
  If not, an 'empty' value will be used. For example empty string,
  an empty list, the number 0, etc.
- optional attributes are not included (also true if default value is provided)

This PR fixes the issue that optional attributes with default value are NOT included in the created entity

Also, a refactor of the create_default_array function - it has been moved to a new file and simplified a bit.

## Issues related to this change:
closes #469 