### PR TITLE
refactor: rename insert_reference to update_reference

### DIFF
--- a/src/features/reference/reference_feature.py
+++ b/src/features/reference/reference_feature.py
@@ -7,26 +7,26 @@ from common.responses import create_response, responses
 from restful.request_types.shared import ReferenceEntity
 
 from .use_cases.delete_reference_use_case import delete_reference_use_case
-from .use_cases.insert_reference_use_case import insert_reference_use_case
+from .use_cases.update_reference_use_case import update_reference_use_case
 
 router = APIRouter(tags=["default", "reference"], prefix="/reference")
 
 
-@router.put("/{address:path}", operation_id="reference_insert", response_model=dict, responses=responses)
+@router.put("/{attribute_address:path}", operation_id="update_reference", response_model=dict, responses=responses)
 @create_response(JSONResponse)
-def insert_reference(
-    address: str,
+def update_reference(
+    attribute_address: str,
     reference: ReferenceEntity,
     user: User = Depends(auth_w_jwt_or_pat),
 ):
-    """Add reference to an entity.
+    """Update reference in an entity.
 
-    Used to add uncontained attributes to an entity.
+    Used to update uncontained attributes to an entity.
 
-    - **document_dotted_id**: <data_source>/<path_to_entity>/<entity_name>.<attribute>
+    - **attribute_address**: address to an attribute inside an entity, e.g. <data_source>/<path_to_entity>/<entity_name>.<attribute>
     - **reference**: a reference object in JSON format
     """
-    return insert_reference_use_case(user=user, address=address, reference=reference)
+    return update_reference_use_case(user=user, address=attribute_address, reference=reference)
 
 
 @router.delete("/{address:path}", operation_id="reference_delete", response_model=dict, responses=responses)

--- a/src/features/reference/use_cases/update_reference_use_case.py
+++ b/src/features/reference/use_cases/update_reference_use_case.py
@@ -4,6 +4,6 @@ from restful.request_types.shared import ReferenceEntity
 from services.document_service import DocumentService
 
 
-def insert_reference_use_case(user: User, address: str, reference: ReferenceEntity):
+def update_reference_use_case(user: User, address: str, reference: ReferenceEntity):
     document_service = DocumentService(user=user)
-    return document_service.insert_reference(Address.from_absolute(address), reference)
+    return document_service.update_reference(Address.from_absolute(address), reference)

--- a/src/tests/unit/test_reference.py
+++ b/src/tests/unit/test_reference.py
@@ -11,7 +11,7 @@ from tests.unit.mock_utils import get_mock_document_service
 
 
 class ReferenceTestCase(unittest.TestCase):
-    def test_insert_reference(self):
+    def test_update_reference(self):
         repository = mock.Mock()
 
         doc_storage = {
@@ -20,7 +20,11 @@ class ReferenceTestCase(unittest.TestCase):
                 "name": "Parent",
                 "description": "",
                 "type": "uncontained_blueprint",
-                "uncontained_in_every_way": {},
+                "uncontained_in_every_way": {
+                    "address": "$old-address",
+                    "type": SIMOS.REFERENCE.value,
+                    "referenceType": REFERENCE_TYPES.LINK.value,
+                },
             },
             "2d7c3249-985d-43d2-83cf-a887e440825a": {
                 "_id": "2d7c3249-985d-43d2-83cf-a887e440825a",
@@ -42,7 +46,7 @@ class ReferenceTestCase(unittest.TestCase):
             "type": SIMOS.REFERENCE.value,
             "referenceType": REFERENCE_TYPES.LINK.value,
         }
-        document_service.insert_reference(
+        document_service.update_reference(
             Address("$1.uncontained_in_every_way", "testing"),
             ReferenceEntity.parse_obj(reference),
         )
@@ -76,7 +80,7 @@ class ReferenceTestCase(unittest.TestCase):
         document_service = get_mock_document_service(lambda x, y: repository)
 
         with self.assertRaises(NotFoundException):
-            document_service.insert_reference(
+            document_service.update_reference(
                 Address("$1.uncontained_in_every_way", "testing"),
                 ReferenceEntity.parse_obj(
                     {
@@ -115,7 +119,7 @@ class ReferenceTestCase(unittest.TestCase):
         document_service = get_mock_document_service(lambda x, y: repository)
 
         with self.assertRaises(BadRequestException):
-            document_service.insert_reference(
+            document_service.update_reference(
                 Address("$1.uncontained_in_every_way", "testing"),
                 ReferenceEntity.parse_obj(
                     {
@@ -156,7 +160,7 @@ class ReferenceTestCase(unittest.TestCase):
         repository.update = mock_update
         document_service = get_mock_document_service(lambda x, y: repository)
 
-        document_service.insert_reference(
+        document_service.update_reference(
             Address("$1.uncontained_in_every_way", "testing"),
             ReferenceEntity.parse_obj(
                 {
@@ -199,7 +203,7 @@ class ReferenceTestCase(unittest.TestCase):
         document_service = get_mock_document_service(lambda x, y: repository)
 
         with self.assertRaises(ValidationError):
-            document_service.insert_reference(
+            document_service.update_reference(
                 Address("$1.uncontained_in_every_way", "testing"),
                 ReferenceEntity.parse_obj({"_id": "something", "type": "something"}),
             )
@@ -370,7 +374,7 @@ class ReferenceTestCase(unittest.TestCase):
             "type": SIMOS.REFERENCE.value,
             "referenceType": REFERENCE_TYPES.LINK.value,
         }
-        document_service.insert_reference(
+        document_service.update_reference(
             Address("$1.uncontained_in_every_way", "testing"), ReferenceEntity(**reference)
         )
         assert len(doc_storage["1"]["uncontained_in_every_way"]) == 2


### PR DESCRIPTION
also make the function more robust

## What does this pull request change?

the old insert_reference() does not work like one expects.
It is actually an update since it is assumed that the attribute where we want to add the reference already exists. 

## Issues related to this change:
