### PR TITLE
fix: delete blobs correctly

### DIFF
--- a/src/common/utils/delete_documents.py
+++ b/src/common/utils/delete_documents.py
@@ -1,7 +1,7 @@
 from typing import Union
 
 from common.utils.data_structure.find import find
-from enums import REFERENCE_TYPES, SIMOS
+from enums import REFERENCE_TYPES, SIMOS, StorageDataTypes
 from storage.data_source_class import DataSource
 
 
@@ -61,9 +61,9 @@ def delete_document(data_source: DataSource, document_id: str):
     """
     if document_id.startswith("$"):
         document_id = document_id[1:]
-    document: dict = data_source.get(document_id)
-    if data_source._lookup(document_id).storage_affinity == "blob":
+    if data_source.get_storage_affinity(document_id) == StorageDataTypes.BLOB:
         data_source.delete_blob(document_id)
     else:
+        document: dict = data_source.get(document_id)
         _delete_dict_recursive(document, data_source)
         data_source.delete(document_id)

--- a/src/common/utils/delete_documents.py
+++ b/src/common/utils/delete_documents.py
@@ -62,5 +62,8 @@ def delete_document(data_source: DataSource, document_id: str):
     if document_id.startswith("$"):
         document_id = document_id[1:]
     document: dict = data_source.get(document_id)
-    _delete_dict_recursive(document, data_source)
-    data_source.delete(document_id)
+    if data_source._lookup(document_id).storage_affinity == "blob":
+        data_source.delete_blob(document_id)
+    else:
+        _delete_dict_recursive(document, data_source)
+        data_source.delete(document_id)

--- a/src/storage/data_source_class.py
+++ b/src/storage/data_source_class.py
@@ -77,6 +77,10 @@ class DataSource:
             message=f"Document with id '{document_id}' was not found in the '{self.name}' data-source"
         )
 
+    def get_storage_affinity(self, document_id) -> StorageDataTypes:
+        lookup = self._lookup(document_id)
+        return StorageDataTypes(lookup.storage_affinity)
+
     def _update_lookup(self, lookup: DocumentLookUp):
         return self.data_source_collection.update_one(
             filter={"_id": self.name}, update={"$set": {f"documentLookUp.{lookup.lookup_id}": lookup.dict()}}


### PR DESCRIPTION
## What does this pull request change?

* Check if an address is pointing to a blob, if so, use `.delete_blob()` method instead of `.delete()`.

## Why is this pull request needed?

Delete blobs.

## Issues related to this change:
