### PR TITLE
refactor: Rename string classes to convention

### DIFF
--- a/src/features/blueprint/blueprint_feature.py
+++ b/src/features/blueprint/blueprint_feature.py
@@ -4,7 +4,7 @@ from fastapi.responses import JSONResponse, PlainTextResponse
 from authentication.authentication import auth_w_jwt_or_pat
 from authentication.models import User
 from common.responses import create_response, responses
-from restful.request_types.shared import common_type_constrained_string
+from restful.request_types.shared import TypeConstrainedString
 
 from .use_cases.get_blueprint_use_case import (
     GetBlueprintResponse,
@@ -23,7 +23,7 @@ router = APIRouter(tags=["default", "blueprint"])
 )
 @create_response(JSONResponse)
 def get_blueprint(
-    type_ref: common_type_constrained_string, context: str | None = None, user: User = Depends(auth_w_jwt_or_pat)
+    type_ref: TypeConstrainedString, context: str | None = None, user: User = Depends(auth_w_jwt_or_pat)
 ):
     """
     Fetch the Blueprint and Recipes from a type reference (including inherited attributes).

--- a/src/features/blueprint/use_cases/get_blueprint_use_case.py
+++ b/src/features/blueprint/use_cases/get_blueprint_use_case.py
@@ -8,7 +8,7 @@ from common.utils.get_storage_recipe import (
     default_yaml_view,
 )
 from domain_classes.lookup import Lookup
-from restful.request_types.shared import common_type_constrained_string
+from restful.request_types.shared import TypeConstrainedString
 from services.document_service import DocumentService
 from storage.internal.lookup_tables import get_lookup
 
@@ -22,7 +22,7 @@ class GetBlueprintResponse(BaseModel):
 default_ui_recipes = [default_form_edit, default_yaml_view, default_list_recipe]
 
 
-def get_blueprint_use_case(type: common_type_constrained_string, context: str | None, user: User) -> dict:
+def get_blueprint_use_case(type: TypeConstrainedString, context: str | None, user: User) -> dict:
     document_service = DocumentService(user=user)
     blueprint = document_service.get_blueprint(type)
 

--- a/src/features/entity/entity_feature.py
+++ b/src/features/entity/entity_feature.py
@@ -4,7 +4,7 @@ from fastapi.responses import JSONResponse
 from authentication.authentication import auth_w_jwt_or_pat
 from authentication.models import User
 from common.responses import create_response, responses
-from restful.request_types.shared import Entity, common_type_constrained_string
+from restful.request_types.shared import Entity, TypeConstrainedString
 
 from .use_cases.instantiate_entity import instantiate_entity_use_case
 from .use_cases.validate_entity import validate_entity_use_case
@@ -16,9 +16,17 @@ router = APIRouter(tags=["default", "entity"], prefix="/entity")
 @router.post("", operation_id="instantiate_entity", response_model=dict, responses=responses)
 @create_response(JSONResponse)
 def instantiate(entity: Entity, user: User = Depends(auth_w_jwt_or_pat)):
-    """Create a new entity and return it.
+    """Returns a default entity of specified type. This entity is not stored in the database.
 
-    (entity is not saved in DMSS)
+
+    For storing an entity in the database, see the Post Document endpoint.
+
+    Args:
+    -
+
+    Returns
+    - dict: A JSON dictionary of the specified entity.
+
     Rules for instantiation:
     - all required attributes, as defined in the blueprint, are included.
       If the required attribute has a default value, that value will be used.
@@ -32,7 +40,7 @@ def instantiate(entity: Entity, user: User = Depends(auth_w_jwt_or_pat)):
 @router.post("/validate", operation_id="validate_entity", responses=responses)
 @create_response(JSONResponse)
 def validate(
-    entity: Entity, as_type: common_type_constrained_string | None = None, user: User = Depends(auth_w_jwt_or_pat)
+    entity: Entity, as_type: TypeConstrainedString | None = None, user: User = Depends(auth_w_jwt_or_pat)
 ):
     """Validate an entity.
     Will return detailed error messages and status code 422 if the entity is invalid.

--- a/src/features/entity/entity_feature.py
+++ b/src/features/entity/entity_feature.py
@@ -39,9 +39,7 @@ def instantiate(entity: Entity, user: User = Depends(auth_w_jwt_or_pat)):
 
 @router.post("/validate", operation_id="validate_entity", responses=responses)
 @create_response(JSONResponse)
-def validate(
-    entity: Entity, as_type: TypeConstrainedString | None = None, user: User = Depends(auth_w_jwt_or_pat)
-):
+def validate(entity: Entity, as_type: TypeConstrainedString | None = None, user: User = Depends(auth_w_jwt_or_pat)):
     """Validate an entity.
     Will return detailed error messages and status code 422 if the entity is invalid.
 

--- a/src/features/entity/entity_feature.py
+++ b/src/features/entity/entity_feature.py
@@ -18,15 +18,6 @@ router = APIRouter(tags=["default", "entity"], prefix="/entity")
 def instantiate(entity: Entity, user: User = Depends(auth_w_jwt_or_pat)):
     """Returns a default entity of specified type. This entity is not stored in the database.
 
-
-    For storing an entity in the database, see the Post Document endpoint.
-
-    Args:
-    -
-
-    Returns
-    - dict: A JSON dictionary of the specified entity.
-
     Rules for instantiation:
     - all required attributes, as defined in the blueprint, are included.
       If the required attribute has a default value, that value will be used.

--- a/src/features/entity/use_cases/validate_entity.py
+++ b/src/features/entity/use_cases/validate_entity.py
@@ -1,10 +1,10 @@
 from authentication.models import User
 from common.utils.validators import validate_entity, validate_entity_against_self
-from restful.request_types.shared import Entity, common_type_constrained_string
+from restful.request_types.shared import Entity, TypeConstrainedString
 from services.document_service import DocumentService
 
 
-def validate_entity_use_case(entity: Entity, user: User, as_type: common_type_constrained_string | None) -> str:
+def validate_entity_use_case(entity: Entity, user: User, as_type: TypeConstrainedString | None) -> str:
     document_service = DocumentService(user=user)
     if as_type:
         validate_entity(

--- a/src/restful/request_types/shared.py
+++ b/src/restful/request_types/shared.py
@@ -4,32 +4,32 @@ from pydantic import UUID4, Field, constr, root_validator
 from pydantic.main import BaseModel, Extra
 
 # Only allow characters a-9 and '_' + '-'
-common_name_constrained_string = constr(min_length=1, max_length=128, regex="^[A-Za-z0-9_-]*$", strip_whitespace=True)
+NameConstrainedString = constr(min_length=1, max_length=128, regex="^[A-Za-z0-9_-]*$", strip_whitespace=True)
 
 # Regex only allow characters a-9 and '_' + '-' + '/' for paths
-common_type_constrained_string = constr(
+TypeConstrainedString = constr(
     min_length=3, max_length=128, regex=r"^[A-Z:a-z0-9_\/-]*$", strip_whitespace=True
 )  # noqa
 
 
 class Entity(BaseModel, extra=Extra.allow):
-    type: common_type_constrained_string  # type: ignore
+    type: TypeConstrainedString  # type: ignore
 
 
 class EntityName(BaseModel):
-    name: common_name_constrained_string  # type: ignore
+    name: NameConstrainedString  # type: ignore
 
 
 class OptionalEntityName(BaseModel):
-    name: Optional[common_name_constrained_string]  # type: ignore
+    name: Optional[NameConstrainedString]  # type: ignore
 
 
 class DataSource(BaseModel):
-    data_source_id: common_name_constrained_string  # type: ignore
+    data_source_id: NameConstrainedString  # type: ignore
 
 
 class DataSourceList(BaseModel):
-    data_sources: list[common_name_constrained_string]  # type: ignore
+    data_sources: list[NameConstrainedString]  # type: ignore
 
 
 class EntityUUID(BaseModel):
@@ -38,7 +38,7 @@ class EntityUUID(BaseModel):
 
 class ReferenceEntity(BaseModel):
     address: str
-    type: common_type_constrained_string  # type: ignore
+    type: TypeConstrainedString  # type: ignore
     referenceType: str
 
 


### PR DESCRIPTION
## What does this pull request change?

Custom string types should have the CamelCase notation in order to not be confused with variables. 

## Why is this pull request needed?

Convention is key. Without it we are just swimming in spaghetti. 

## Issues related to this change:
