### PR TITLE
refactor: move add document logic to use case

### DIFF
--- a/src/common/utils/merge_entity_and_files.py
+++ b/src/common/utils/merge_entity_and_files.py
@@ -1,0 +1,21 @@
+from typing import BinaryIO, Dict
+
+from domain_classes.tree_node import Node
+from enums import SIMOS
+
+
+def merge_entity_and_files(node: Node, files: Dict[str, BinaryIO]):
+    """
+    Recursively adds the matching posted files to the system/SIMOS/Blob types in the node
+    """
+    for node in node.traverse():  # Traverse the entire Node tree
+        if not node.entity:  # Skipping empty nodes
+            continue
+        if node.type == SIMOS.BLOB.value:
+            try:  # For all Blob Nodes, add the posted file in the Node temporary '_blob_' attribute
+                node.entity["_blob_"] = files[node.entity["name"]]
+            except KeyError:
+                raise KeyError(
+                    "File referenced in entity does not match any ",
+                    f"filename posted. Posted files: {tuple(files.keys())}",
+                )

--- a/src/features/document/document_feature.py
+++ b/src/features/document/document_feature.py
@@ -6,7 +6,12 @@ from pydantic import Json, conint
 
 from authentication.authentication import auth_w_jwt_or_pat
 from authentication.models import User
+from common.address import Address
 from common.responses import create_response, responses
+from common.utils.get_blueprint import get_blueprint_provider
+from common.utils.get_storage_recipe import storage_recipe_provider
+from services.document_service import DocumentService
+from storage.internal.data_source_repository import get_data_source
 
 from .use_cases.add_document_use_case import add_document_use_case
 from .use_cases.add_raw_use_case import add_raw_use_case
@@ -83,12 +88,20 @@ def add_document(
     - Adding a new document to a package / data source
     - Adding an object to an entity (for example filling in an optional, complex attribute)
     """
-    return add_document_use_case(
+
+    document_service = DocumentService(
+        repository_provider=get_data_source,
         user=user,
-        address=address,
+        blueprint_provider=get_blueprint_provider(user),
+        recipe_provider=storage_recipe_provider,
+    )
+
+    return add_document_use_case(
+        address=Address.from_absolute(address),
         document=document,
         files=files,
         update_uncontained=update_uncontained,
+        document_service=document_service,
     )
 
 

--- a/src/features/document/use_cases/add_document_use_case.py
+++ b/src/features/document/use_cases/add_document_use_case.py
@@ -1,28 +1,220 @@
-from typing import List, Optional
+from typing import BinaryIO, List, Optional
 
 from fastapi import UploadFile
 
-from authentication.models import User
 from common.address import Address
+from common.exceptions import (
+    BadRequestException,
+    NotFoundException,
+    ValidationException,
+)
+from common.tree_node_serializer import tree_node_from_dict
+from common.utils.merge_entity_and_files import merge_entity_and_files
+from common.utils.validators import validate_entity, validate_entity_against_self
+from domain_classes.blueprint_attribute import BlueprintAttribute
+from domain_classes.tree_node import ListNode, Node
+from enums import SIMOS
+from restful.request_types.shared import Entity
 from services.document_service import DocumentService
-from storage.internal.data_source_repository import get_data_source
+
+
+def _add_document_to_data_source(
+    data_source_id: str, document: dict, update_uncontained: Optional[bool], document_service: DocumentService
+) -> dict:
+    """Add the document to an existing data source.
+
+    Args:
+       data_source_id: The data source ID
+       document: The entity to be added
+       update_uncontained: Whether to update uncontained children (deprecated)
+       document_service: The document service
+
+    Returns:
+       A dict that contains the ID of the added document.
+    """
+
+    if document.get("type") != SIMOS.PACKAGE.value and not document.get("isRoot"):
+        raise BadRequestException("Only root packages may be added without a parent.")
+
+    new_node = tree_node_from_dict(
+        document,
+        blueprint_provider=document_service.get_blueprint,
+        recipe_provider=document_service.get_storage_recipes,
+    )
+
+    try:
+        if document_service.get_document(Address(new_node.entity["name"], data_source_id), depth=99):
+            raise ValidationException(
+                message=f"A root package named '{new_node.entity['name']}' already exists",
+                data={"dataSource": data_source_id, "document": document},
+            )
+    except NotFoundException:
+        pass
+
+    new_node.set_uid()
+
+    document_service.save(new_node, data_source_id, update_uncontained=update_uncontained)
+
+    return {"uid": new_node.node_id}
+
+
+def _add_document_to_entity_or_list(
+    address: Address,
+    document: dict,
+    files: dict[str, BinaryIO] | None,
+    update_uncontained: Optional[bool],
+    document_service: DocumentService,
+) -> dict:
+    """Add the document to an existing entity.
+
+    Args:
+       address: Reference to an existing entity or to an attribute (complex or list attribute) inside an entity.
+       document: The entity to be added
+       files: Dict with names and files of the files contained in the document
+       update_uncontained: Whether to update uncontained children (deprecated)
+
+    Returns:
+       A dict that contains the ID of the added document.
+    """
+    entity: Entity = Entity(**document)
+
+    try:
+        target: Node = document_service.get_document(address, depth=99)
+    except NotFoundException:
+        target = None
+
+    if not target:
+        # If target does not exist, there are 2 cases to consider:
+        #   1) the target is an optional attribute that does not exist yet. In that case, we set the target to be
+        #      the parent of entity referenced by 'address'.
+        #   2) the address is wrong. In that case, raise Exception.
+
+        # It is assumed that address.path is to an attribute, e.g. dataSource/package/document.attribute
+        split_address_path: list[str] = address.path.rsplit(".", 1)
+
+        if len(split_address_path) <= 1 and split_address_path[0] == address.path:
+            # Raising NotFoundException, since the get_document() did not find the document
+            # with address=address.path in the above try except statement
+            raise NotFoundException(f"Could not find document {address}")
+
+        parent_address_as_string, last_attribute_in_address = split_address_path
+
+        parent_address: Address = Address(
+            protocol=address.protocol, path=parent_address_as_string, data_source=address.data_source
+        )
+        parent_node: Node = document_service.get_document(parent_address, depth=99)
+        parent_blueprint = parent_node.blueprint
+        if (
+            len(
+                [
+                    blueprint_attribute
+                    for blueprint_attribute in parent_blueprint.attributes
+                    if blueprint_attribute.name == last_attribute_in_address
+                ]
+            )
+            == 0
+        ):
+            raise NotFoundException(
+                f"Could not find attribute {last_attribute_in_address} in blueprint for {parent_blueprint.name}"
+            )
+
+        parent_document = parent_node.entity
+        attribute_to_update = [
+            blueprint_attribute
+            for blueprint_attribute in parent_blueprint.attributes
+            if blueprint_attribute.name == last_attribute_in_address
+        ][0]
+        if attribute_to_update.is_array:
+            parent_document[last_attribute_in_address] = [document]
+        else:
+            parent_document[last_attribute_in_address] = document
+
+        target = parent_node
+        new_node = tree_node_from_dict(
+            {**parent_document},
+            blueprint_provider=document_service.get_blueprint,
+            node_attribute=BlueprintAttribute(name=target.attribute.name, attribute_type=entity.type),
+            recipe_provider=document_service.get_storage_recipes,
+        )
+        document_service.save(new_node, address.data_source, update_uncontained=update_uncontained)
+
+        return {"uid": f"{new_node.node_id}.{last_attribute_in_address}"}
+
+    if target.type != SIMOS.PACKAGE.value and target.type != "object":
+        validate_entity(
+            document,
+            document_service.get_blueprint,
+            document_service.get_blueprint(target.attribute.attribute_type),
+            "extend",
+        )
+
+    new_node = tree_node_from_dict(
+        {**document},
+        blueprint_provider=document_service.get_blueprint,
+        node_attribute=BlueprintAttribute(name=target.attribute.name, attribute_type=entity.type),
+        recipe_provider=document_service.get_storage_recipes,
+    )
+
+    if not target.is_array() and target.type != SIMOS.PACKAGE.value:
+        required_attribute_names = [attribute.name for attribute in new_node.blueprint.get_required_attributes()]
+        # If entity has a name, check if a file/attribute with the same name already exists on the target
+        if "name" in required_attribute_names and target.parent.duplicate_attribute(
+            new_node.entity.get("name", new_node.attribute.name)
+        ):
+            raise BadRequestException(
+                f"The document at '{address}' already has a child with name '{new_node.entity.get('name', new_node.attribute.name)}'"
+            )
+
+    if files:
+        merge_entity_and_files(new_node, files)
+
+    if target.type == SIMOS.PACKAGE.value:
+        target = target.children[0]  # Set target to be the packages content
+
+    if isinstance(target, ListNode) or target.parent.type == SIMOS.PACKAGE.value:
+        new_node.set_uid()
+        new_node.parent = target
+        new_node.key = str(len(target.children))
+        target.add_child(new_node)
+        document_service.save(target.find_parent(), address.data_source, update_uncontained=False)
+    else:
+        new_node.parent = target.parent
+        target.parent.replace(new_node.node_id, new_node)
+        document_service.save(target.find_parent(), address.data_source, update_uncontained=False)
+
+    document_service.save(new_node, address.data_source, update_uncontained=update_uncontained)
+
+    return {"uid": new_node.node_id}
 
 
 def add_document_use_case(
-    user: User,
     document: dict,
-    address: str,
+    address: Address,
+    document_service: DocumentService,
     files: Optional[List[UploadFile]] = None,
     update_uncontained: Optional[bool] = False,
-    repository_provider=get_data_source,
-):
-    document_service = DocumentService(repository_provider=repository_provider, user=user)
+) -> dict:
+    """Add document to a data source or existing entity. Can also be used to add (complex) items to a list.
 
-    document = document_service.add(
-        address=Address.from_absolute(address),
+    Args:
+        document: The entity to be added
+        address: Reference to a package, attribute inside an entity (either a list or a complex attribute) or a data source
+        document_service: The document service
+        files: Dict with names and files of the files contained in the document
+        update_uncontained: Whether to update uncontained children (deprecated)
+
+    Returns:
+        A dict that contains the ID of the added document.
+    """
+    validate_entity_against_self(document, document_service.get_blueprint)
+
+    if not address.path:
+        return _add_document_to_data_source(address.data_source, document, update_uncontained, document_service)
+
+    return _add_document_to_entity_or_list(
+        address=address,
         document=document,
         files={f.filename: f.file for f in files} if files else None,
         update_uncontained=update_uncontained,
+        document_service=document_service,
     )
-
-    return document

--- a/src/tests/unit/test_reference.py
+++ b/src/tests/unit/test_reference.py
@@ -5,6 +5,7 @@ from unittest import mock
 from common.address import Address
 from common.exceptions import ValidationException
 from enums import REFERENCE_TYPES, SIMOS
+from features.document.use_cases.add_document_use_case import add_document_use_case
 from tests.unit.mock_utils import get_mock_document_service
 
 
@@ -294,6 +295,11 @@ class ReferenceTestCase(unittest.TestCase):
             "type": SIMOS.REFERENCE.value,
             "referenceType": REFERENCE_TYPES.LINK.value,
         }
-        document_service.add(Address("$1.uncontained_in_every_way", "testing"), reference, update_uncontained=True)
+        add_document_use_case(
+            address=Address("$1.uncontained_in_every_way", "testing"),
+            document=reference,
+            update_uncontained=True,
+            document_service=document_service,
+        )
         assert len(doc_storage["1"]["uncontained_in_every_way"]) == 2
         assert doc_storage["1"]["uncontained_in_every_way"][1] == reference

--- a/src/tests/unit/test_tree_functionality/test_tree_node_update.py
+++ b/src/tests/unit/test_tree_functionality/test_tree_node_update.py
@@ -9,6 +9,7 @@ from common.utils.data_structure.compare import get_and_print_diff
 from domain_classes.blueprint import Blueprint
 from domain_classes.tree_node import Node
 from enums import REFERENCE_TYPES, SIMOS
+from features.document.use_cases.add_document_use_case import add_document_use_case
 from storage.repositories.file import LocalFileRepository
 from tests.unit.mock_utils import get_mock_document_service
 from tests.unit.test_tree_functionality.get_node_for_tree_tests import (
@@ -232,12 +233,12 @@ class DocumentServiceTestCase(unittest.TestCase):
         repository.get = mock_get
         repository.update = mock_update
         document_service = get_mock_document_service(repository_provider)
-        document_service.add(
-            Address("$1.im_optional", "testing"),
+        add_document_use_case(
+            address=Address("$1.im_optional", "testing"),
             document={"type": "basic_blueprint", "name": "new_entity", "description": "This is my new entity"},
-            files=[],
+            update_uncontained=True,
+            document_service=document_service,
         )
-
         assert get_and_print_diff(doc_storage["1"], doc_1_after) == []
 
     def test_add_invalid_child_type(self):
@@ -325,10 +326,11 @@ class DocumentServiceTestCase(unittest.TestCase):
         repository.get = mock_get
         repository.update = mock_update
         document_service = get_mock_document_service(repository_provider)
-        document_service.add(
-            Address("$1.nested_with_optional.im_optional", "testing"),
+        add_document_use_case(
+            address=Address("$1.nested_with_optional.im_optional", "testing"),
             document={"name": "new_entity", "description": "This is my new entity", "type": "basic_blueprint"},
-            files=[],
+            update_uncontained=True,
+            document_service=document_service,
         )
 
         assert get_and_print_diff(doc_storage["1"], doc_1_after) == []
@@ -362,10 +364,11 @@ class DocumentServiceTestCase(unittest.TestCase):
         document_service = get_mock_document_service(lambda x, y: repository)
 
         with self.assertRaises(BadRequestException):
-            document_service.add(
-                Address("$1.im_optional", "testing"),
+            add_document_use_case(
+                address=Address("$1.im_optional", "testing"),
                 document={"type": "basic_blueprint", "name": "duplicate", "description": "This is my new entity"},
-                files=[],
+                update_uncontained=True,
+                document_service=document_service,
             )
 
     def test_add_valid_specialized_child_type(self):


### PR DESCRIPTION
## What does this pull request change?

* Moves the add document from the document service to the `add_document_use case`.

## Why is this pull request needed?

* Document service is too big, and getting an overview of the code is therefore more complicated than it should. Isolate all document add functionality to the add document feature (use case). 

> NOTE: this is the first PR of several that will refactor the document service. 

## Issues related to this change:
