### PR TITLE
fix: bug with updating a list from update document endpoint

### DIFF
--- a/src/domain_classes/tree_node.py
+++ b/src/domain_classes/tree_node.py
@@ -1,6 +1,7 @@
 from typing import Callable, List, Union
 from uuid import uuid4
 
+from common.exceptions import ValidationException
 from domain_classes.blueprint import Blueprint
 from domain_classes.blueprint_attribute import BlueprintAttribute
 from domain_classes.storage_recipe import StorageAttribute, StorageRecipe
@@ -422,6 +423,8 @@ class ListNode(NodeBase):
 
     def update(self, data: list):
         # Replaces the whole list with the new one
+        if not isinstance(data, list):
+            raise ValidationException(f"Cannot replace a list with a dictionary. Got data: {data}")
         self.children = []
         for i, item in enumerate(data):
             # Set self.type from posted type, and validate against parent blueprint

--- a/src/features/document/document_feature.py
+++ b/src/features/document/document_feature.py
@@ -92,7 +92,7 @@ def add_document(
     - update_uncontained (bool): Optional flag specifying whether
     - user (User): The authenticated user accessing the endpoint.
 
-
+    TODO decide if we should support adding an empty list. That is currently not supported.
     """
 
     document_service = DocumentService(

--- a/src/tests/bdd/document/update.feature
+++ b/src/tests/bdd/document/update.feature
@@ -155,172 +155,44 @@ Feature: Document 2
     }
     """
 
-  Scenario: Update document (only contained)
-    Given i access the resource url "/api/documents/data-source-name/$1"
-    When i make a form-data "PUT" request
-    """
-    { "data":{
-      "name": "package_1",
-      "type": "dmss://system/SIMOS/Package",
-      "description": "new description",
-      "isRoot": true
-    }}
-    """
-    Then the response status should be "OK"
-    And the response should contain
-    """
-    {
-      "data": {
-        "name": "package_1",
-        "type": "dmss://system/SIMOS/Package",
-        "description": "new description",
-        "isRoot": true
-      }
-    }
-    """
 
-  Scenario: Update document (both contained and not contained)
-    Given i access the resource url "/api/documents/data-source-name/$6"
-    When i make a form-data "PUT" request
-    """
-    { "data":{
-      "name": "new_name",
-      "type": "dmss://test-source-name/TestData/TestContainer",
-      "description": "some description",
-      "itemContained": {
-          "name": "item_contained",
-          "type": "dmss://test-source-name/TestData/ItemType",
-           "extra": "extra_1"
-      },
-      "itemsContained": [
-        {
-          "name": "item_1_contained",
-          "type": "dmss://test-source-name/TestData/ItemType",
-          "list": ["a", "b", "c"],
-          "complexList": [
-              {
-                "name": "item_1_contained",
-                "type": "dmss://test-source-name/TestData/ItemTypeTwo",
-                "extra": "extra_1"
-              }
-            ]
-        }
-      ],
-      "itemNotContained": {
-          "name": "item_single",
-          "type": "dmss://test-source-name/TestData/ItemType",
-           "extra": "extra_1"
-      },
-      "itemsNotContained": [
-        {
-          "name": "item_1",
-          "type": "dmss://test-source-name/TestData/ItemType",
-          "list": ["a", "b"],
-          "complexList": [
-              {
-                "name": "item_1",
-                "type": "dmss://test-source-name/TestData/ItemTypeTwo",
-                "extra": "extra_1"
-              }
-            ]
-        }
-      ]
-    }}
-    """
-    Then the response status should be "OK"
-    And the response should contain
-    """
-    {
-      "data": {
-        "name": "new_name",
-        "type": "dmss://test-source-name/TestData/TestContainer",
-        "description": "some description",
-        "itemContained": {
-          "name": "item_contained",
-          "type": "dmss://test-source-name/TestData/ItemType",
-           "extra": "extra_1"
-        },
-        "itemsContained": [
-        {
-            "name": "item_1_contained",
-            "type": "dmss://test-source-name/TestData/ItemType",
-            "list": ["a", "b", "c"],
-            "complexList": [
-                {
-                  "name": "item_1_contained",
-                  "type": "dmss://test-source-name/TestData/ItemTypeTwo",
-                  "extra": "extra_1"
-                }
-              ]
-          }
-        ],
-        "itemNotContained": {
-            "name": "item_single",
-            "type": "dmss://test-source-name/TestData/ItemType",
-            "extra": "extra_1"
-        },
-        "itemsNotContained": [
-          {
-            "name": "item_1",
-            "type": "dmss://test-source-name/TestData/ItemType",
-            "list": ["a", "b"],
-            "complexList": [
-              {
-                "name": "item_1",
-                "type": "dmss://test-source-name/TestData/ItemTypeTwo",
-                "extra": "extra_1"
-              }
-            ]
-          }
-        ]
-      }
-    }
-    """
-
-  Scenario: Update document (attribute and not contained)
-    Given i access the resource url "/api/documents/data-source-name/$6.itemNotContained"
-    When i make a form-data "PUT" request
-    """
-    { "data": {
-        "name": "item_single",
-        "type": "dmss://test-source-name/TestData/ItemType"
-      }
-    }
-    """
-    Then the response status should be "OK"
-    And the response should contain
-    """
-    {
-      "data": {
-        "name": "item_single",
-        "type": "dmss://test-source-name/TestData/ItemType"
-      }
-    }
-    """
 
   Scenario: Update complex list attribute
+    Given i access the resource url "/api/documents/data-source-name/$7.complexList"
+    When I make a "POST" request with "1" files
+      """
+      {
+        "document":
+       {
+          "name": "item_1_contained",
+          "type": "dmss://test-source-name/TestData/ItemTypeTwo",
+          "extra": "extra_1"
+        }
+      }
+      """
+    Then the response status should be "OK"
     Given i access the resource url "/api/documents/data-source-name/$7.complexList"
     When i make a form-data "PUT" request
     """
     { "data":
     [
         {
-          "name": "item_1_contained",
+          "name": "item_1_contained_modified",
           "type": "dmss://test-source-name/TestData/ItemTypeTwo",
-          "extra": "extra_1"
+          "extra": "extra_1_modified"
         }
     ]
     }
     """
     Then the response status should be "OK"
-    And the response should contain
+    And the response should be
     """
     {
       "data": [
           {
-            "name": "item_1_contained",
+            "name": "item_1_contained_modified",
             "type": "dmss://test-source-name/TestData/ItemTypeTwo",
-            "extra": "extra_1"
+            "extra": "extra_1_modified"
           }
         ]
     }
@@ -336,9 +208,9 @@ Feature: Document 2
       "type": "dmss://test-source-name/TestData/ItemType",
       "complexList": [
           {
-            "name": "item_1_contained",
+            "name": "item_1_contained_modified",
             "type": "dmss://test-source-name/TestData/ItemTypeTwo",
-            "extra": "extra_1"
+            "extra": "extra_1_modified"
           }
       ]
     }
@@ -350,51 +222,55 @@ Feature: Document 2
     """
     [
           {
-            "name": "item_1_contained",
+            "name": "item_1_contained_modified",
             "type": "dmss://test-source-name/TestData/ItemTypeTwo",
-            "extra": "extra_1"
+            "extra": "extra_1_modified"
           }
       ]
     """
     Given i access the resource url "/api/documents/data-source-name/$7.complexList[0]"
     When I make a "GET" request
     Then the response status should be "OK"
-        And the response should be
+    And the response should be
     """
     {
-      "name": "item_1_contained",
+      "name": "item_1_contained_modified",
       "type": "dmss://test-source-name/TestData/ItemTypeTwo",
-      "extra": "extra_1"
+      "extra": "extra_1_modified"
     }
     """
 
 
   Scenario: Update complex attribute
     Given i access the resource url "/api/documents/data-source-name/$7.complexList"
-    When i make a form-data "PUT" request
-    """
-    { "data":
-      [
-          {
-            "name": "item_1_contained",
+    When I make a "POST" request with "1" files
+      """
+      {
+        "document":
+       {
+          "name": "item_1_contained",
+          "type": "dmss://test-source-name/TestData/ItemTypeTwo",
+          "extra": "extra_1",
+          "complexAttribute": {
+            "name": "itemForComplexAttribute",
             "type": "dmss://test-source-name/TestData/ItemTypeTwo",
-            "extra": "extra_1"
+            "extra": "extra_2"
           }
-      ]
-    }
-    """
-    Then the response status should be "OK"
+        }
+      }
+      """
     Given i access the resource url "/api/documents/data-source-name/$7.complexList[0].complexAttribute"
     When i make a form-data "PUT" request
     """
     { "data":
-        {
-          "name": "itemForComplexAttribute",
-          "type": "dmss://test-source-name/TestData/ItemTypeTwo",
-          "extra": "extra_2"
-        }
+      {
+        "name": "itemForComplexAttributeModified",
+        "type": "dmss://test-source-name/TestData/ItemTypeTwo",
+        "extra": "extra_2_modified"
+      }
     }
     """
+
     Then the response status should be "OK"
     Given i access the resource url "/api/documents/data-source-name/$7.complexList[0]"
     When I make a "GET" request
@@ -406,9 +282,9 @@ Feature: Document 2
       "type": "dmss://test-source-name/TestData/ItemTypeTwo",
       "extra": "extra_1",
       "complexAttribute": {
-        "name": "itemForComplexAttribute",
+        "name": "itemForComplexAttributeModified",
         "type": "dmss://test-source-name/TestData/ItemTypeTwo",
-        "extra": "extra_2"
+        "extra": "extra_2_modified"
       }
     }
     """
@@ -418,8 +294,8 @@ Feature: Document 2
     And the response should contain
     """
     {
-      "name": "itemForComplexAttribute",
+      "name": "itemForComplexAttributeModified",
       "type": "dmss://test-source-name/TestData/ItemTypeTwo",
-      "extra": "extra_2"
+      "extra": "extra_2_modified"
     }
     """

--- a/src/tests/bdd/document/update_list.feature
+++ b/src/tests/bdd/document/update_list.feature
@@ -1,0 +1,243 @@
+Feature: Add document with optional attributes
+
+  Background: There are data sources in the system
+    Given the system data source and SIMOS core package are available
+
+    Given there are data sources
+      |       name         |
+      | data-source-name   |
+
+    Given there are repositories in the data sources
+      | data-source      | host | port  | username | password | tls   | name       | database  | collection | type     | dataTypes    |
+      | data-source-name | db   | 27017 | maf      | maf      | false | repo1      |  bdd-test | documents  | mongo-db | default      |
+
+    Given there exist document with id "100" in data source "data-source-name"
+      """
+      {
+          "name": "root_package",
+          "description": "",
+          "type": "dmss://system/SIMOS/Package",
+          "isRoot": true,
+          "content": [
+              {
+                  "address": "$101",
+                  "type": "dmss://system/SIMOS/Reference",
+                  "referenceType": "link"
+              },
+              {
+                  "address": "$102",
+                  "type": "dmss://system/SIMOS/Reference",
+                  "referenceType": "link"
+              },
+              {
+                  "address": "$103",
+                  "type": "dmss://system/SIMOS/Reference",
+                  "referenceType": "link"
+              },
+              {
+                  "address": "$workComputerId",
+                  "type": "dmss://system/SIMOS/Reference",
+                  "referenceType": "link"
+              }
+          ]
+      }
+      """
+
+    Given there exist document with id "103" in data source "data-source-name"
+    """
+    {
+      "name": "KeyboardKey",
+      "type": "dmss://system/SIMOS/Blueprint",
+      "extends": [
+        "dmss://system/SIMOS/NamedEntity"
+      ],
+      "description": "",
+      "attributes": []
+    }
+    """
+
+    Given there exist document with id "101" in data source "data-source-name"
+      """
+      {
+      "name": "Computer",
+      "type": "dmss://system/SIMOS/Blueprint",
+      "extends": [
+        "dmss://system/SIMOS/NamedEntity"
+      ],
+      "description": "",
+      "attributes": [
+          {
+            "name": "model",
+            "type": "dmss://system/SIMOS/BlueprintAttribute",
+            "attributeType": "string"
+          },
+          {
+            "name": "keyboard",
+            "type": "dmss://system/SIMOS/BlueprintAttribute",
+            "attributeType": "data-source-name/root_package/Keyboard",
+            "optional": true
+          },
+          {
+            "name": "letterKeys",
+            "type": "dmss://system/SIMOS/BlueprintAttribute",
+            "attributeType": "data-source-name/root_package/KeyboardKey",
+            "optional": true,
+            "dimensions": "*"
+          },
+          {
+            "name": "numberKeys",
+            "type": "dmss://system/SIMOS/BlueprintAttribute",
+            "attributeType": "data-source-name/root_package/KeyboardKey",
+            "optional": true,
+            "dimensions": "*"
+          }
+        ]
+      }
+     """
+
+    Given there exist document with id "102" in data source "data-source-name"
+      """
+      {
+        "name": "Keyboard",
+        "type": "dmss://system/SIMOS/Blueprint",
+        "extends": [
+          "dmss://system/SIMOS/NamedEntity"
+        ],
+        "attributes": [
+          {
+            "name": "language",
+            "type": "dmss://system/SIMOS/BlueprintAttribute",
+            "attributeType": "string"
+          }
+        ]
+      }
+      """
+
+    Given there exist document with id "workComputerId" in data source "data-source-name"
+      """
+      {
+        "type": "data-source-name/root_package/Computer",
+        "name": "workComputer",
+        "model": "Dell",
+        "letterKeys": []
+      }
+      """
+
+  Scenario: add to list that exist
+    Given i access the resource url "/api/documents/data-source-name/$workComputerId.letterKeys"
+    When I make a "POST" request with "1" files
+    """
+    {
+      "document":
+       {
+        "name": "T",
+        "type": "data-source-name/root_package/KeyboardKey"
+      }
+    }
+    """
+    Then the response status should be "OK"
+    And the response should contain
+    """
+      {
+        "uid": "workComputerId.letterKeys.0"
+      }
+    """
+    Given i access the resource url "/api/documents/data-source-name/$workComputerId.letterKeys"
+    When I make a "GET" request
+    Then the response status should be "OK"
+    And the response should contain
+    """
+    [
+     {
+       "name": "T",
+       "type": "data-source-name/root_package/KeyboardKey"
+     }
+    ]
+    """
+    Given i access the resource url "/api/documents/data-source-name/$workComputerId.letterKeys"
+    When I make a "POST" request with "1" files
+    """
+    {
+      "document":
+       {
+        "name": "X",
+        "type": "data-source-name/root_package/KeyboardKey"
+      }
+    }
+    """
+    Then the response status should be "OK"
+    Given i access the resource url "/api/documents/data-source-name/$workComputerId.letterKeys"
+    When I make a "GET" request
+    Then the response status should be "OK"
+    And the response should contain
+    """
+    [
+     {
+       "name": "T",
+       "type": "data-source-name/root_package/KeyboardKey"
+     },
+     {
+       "name": "X",
+       "type": "data-source-name/root_package/KeyboardKey"
+     }
+    ]
+    """
+
+
+  Scenario: change list that exist
+    Given i access the resource url "/api/documents/data-source-name/$workComputerId.letterKeys"
+    When I make a "POST" request with "1" files
+    """
+    {
+      "document":
+       {
+        "name": "T",
+        "type": "data-source-name/root_package/KeyboardKey"
+      }
+    }
+    """
+    Then the response status should be "OK"
+    Given i access the resource url "/api/documents/data-source-name/$workComputerId"
+    When i make a "GET" request
+    Then the response status should be "OK"
+    And the response should contain
+    """
+    {
+      "_id": "workComputerId",
+      "type": "data-source-name/root_package/Computer",
+      "name": "workComputer",
+      "model": "Dell",
+      "letterKeys": [
+       {
+        "name": "T",
+        "type": "data-source-name/root_package/KeyboardKey"
+      }
+      ]
+    }
+    """
+    Given i access the resource url "/api/documents/data-source-name/$workComputerId.letterKeys[0]"
+    When i make a form-data "PUT" request
+    """
+    {
+      "data":
+       {
+        "name": "XXX",
+        "type": "data-source-name/root_package/KeyboardKey"
+      }
+    }
+    """
+    Then the response status should be "OK"
+    Given i access the resource url "/api/documents/data-source-name/$workComputerId.letterKeys"
+    When i make a "GET" request
+    Then the response status should be "OK"
+    And the response should be
+    """
+       [{
+        "name": "XXX",
+        "type": "data-source-name/root_package/KeyboardKey"
+      }]
+    """
+
+
+
+


### PR DESCRIPTION
## What does this pull request change?
fix bug with update document: when updating an element in a list, a new element was added. Wanted behavior is to have same number of list elements before and after update.

## Issues related to this change:
https://github.com/orgs/equinor/projects/189/views/3?pane=issue&itemId=31259287