### PR TITLE
refactor: move update document logic to use case instead of document service

### DIFF
--- a/src/features/document/document_feature.py
+++ b/src/features/document/document_feature.py
@@ -56,12 +56,20 @@ def update(
     """Update document
     - **id_address**: <protocol>://<data_source>/$<document_uuid> (can also include an optional .<attribute> after <document_uuid>)
     """
-    return update_document_use_case(
+
+    document_service = DocumentService(
+        repository_provider=get_data_source,
         user=user,
-        address=id_address,
+        blueprint_provider=get_blueprint_provider(user),
+        recipe_provider=storage_recipe_provider,
+    )
+
+    return update_document_use_case(
+        address=Address.from_absolute(id_address),
         data=data,
         files=files,
         update_uncontained=update_uncontained,
+        document_service=document_service,
     )
 
 

--- a/src/features/document/use_cases/update_document_use_case.py
+++ b/src/features/document/use_cases/update_document_use_case.py
@@ -1,26 +1,83 @@
-from typing import List, Optional, Union
+from typing import BinaryIO, List, Optional, Union
 
-from fastapi import File, UploadFile
+from fastapi import UploadFile
 
-from authentication.models import User
 from common.address import Address
-from enums import SIMOS
+from common.exceptions import NotFoundException, ValidationException
+from common.tree_node_serializer import tree_node_to_dict
+from common.utils.logging import logger
+from common.utils.merge_entity_and_files import merge_entity_and_files
+from common.utils.validators import validate_entity, validate_entity_against_self
+from domain_classes.tree_node import Node
+from enums import SIMOS, BuiltinDataTypes
 from services.document_service import DocumentService
-from storage.internal.data_source_repository import get_data_source
+
+
+def _update_document(
+    address: Address,
+    data: Union[dict, list],
+    document_service: DocumentService,
+    files: dict[str, BinaryIO] | None,
+    update_uncontained: Optional[bool],
+):
+    """
+    Update a document.
+
+    What to update is referred to with an address.
+    It can either be an entire document or just an attribute inside a document.
+    """
+    validate_entity_against_self(data, document_service.get_blueprint)
+    if not address.path:
+        raise Exception(f"Could not find the node on '{address}'")
+
+    try:
+        node: Node = document_service.get_document(address)  # type: ignore
+    except NotFoundException:
+        raise ValidationException(
+            f"Can not update document with address {address}, since that document does not exist. If the goal is to add a document, use the document add use instead"
+        )
+
+    if node.attribute.attribute_type != BuiltinDataTypes.OBJECT.value:
+        validate_entity(
+            data,
+            document_service.get_blueprint,
+            document_service.get_blueprint(node.attribute.attribute_type),
+            "extend",
+        )
+        # TODO consider validating link reference objects if the data parameter is of type system/SIMOS/Reference.
+
+    node.update(data)
+    if files:
+        merge_entity_and_files(node, files)
+
+    document_service.save(node, address.data_source, update_uncontained=update_uncontained, initial=True)
+    logger.info(f"Updated entity '{address}'")
+    return {"data": tree_node_to_dict(node)}
 
 
 def update_document_use_case(
-    user: User,
-    address: str,
+    address: Address,
     data: Union[dict, list],
-    files: Optional[List[UploadFile]] = File(None),
+    document_service: DocumentService,
+    files: Optional[List[UploadFile]] = None,
     update_uncontained: Optional[bool] = True,
-    repository_provider=get_data_source,
 ):
-    document_service = DocumentService(repository_provider=repository_provider, user=user)
-    document = document_service.update_document(
-        Address.from_absolute(address),
-        data,
+    """Update document.
+
+    Args:
+        address: Reference to an existing entity
+        data: The data to be updated
+        document_service: The document service
+        files: Dict with names and files of the files contained in the document
+        update_uncontained: Whether to update uncontained children (deprecated)
+    Returns:
+        A dict that contains the updated document.
+    """
+
+    document = _update_document(
+        address=address,
+        data=data,
+        document_service=document_service,
         files={f.filename: f.file for f in files} if files else None,
         update_uncontained=update_uncontained,
     )

--- a/src/tests/unit/test_complex_arrays.py
+++ b/src/tests/unit/test_complex_arrays.py
@@ -7,6 +7,9 @@ from common.address import Address
 from common.utils.data_structure.compare import get_and_print_diff
 from domain_classes.blueprint import Blueprint
 from enums import SIMOS
+from features.document.use_cases.update_document_use_case import (
+    update_document_use_case,
+)
 from storage.repositories.file import LocalFileRepository
 from tests.unit.mock_utils import get_mock_document_service
 
@@ -265,77 +268,79 @@ class ArraysDocumentServiceTestCase(unittest.TestCase):
 
         document_service = get_mock_document_service(repository_provider, blueprint_provider=blueprint_provider)
         # fmt: off
-        document_service.update_document(
+        data = {
+            "_id": "1",
+            "name": "complexArraysEntity",
+            "type": "higher_rank_array",
+            "1_dim-unfixed": [45, 65, 999999999999999999, 0, -12],
+            "1_dim-fixed_complex_type": [
+                {
+                    "name": "0",
+                    "type": "basic_blueprint",
+                    "description": "",
+                    "length": 1
+                },
+                {
+                    "name": "1",
+                    "type": "basic_blueprint",
+                    "description": "",
+                    "length": 23
+                },
+                {
+                    "name": "2",
+                    "type": "basic_blueprint",
+                    "description": "",
+                    "length": 200
+                },
+                {
+                    "name": "3",
+                    "type": "basic_blueprint",
+                    "description": "",
+                    "length": 345
+                },
+                {
+                    "name": "4",
+                    "type": "basic_blueprint",
+                    "description": "some other description",
+                    "length": 1
+                },
+            ],
+            "2_dim-unfixed": [[23, 234, 123], [1, 1, 1, 1, 1, 1]],
+            "3_dim-mix": [
+                [
+                    [
+                        11, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                        0, 0, 0, 0, 0, 0, 0, 0, 0, 22
+                    ]
+                ],
+                [
+                    [
+                        33, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                        0, 0, 0, 0, 0, 0, 0, 0, 0, 44
+                    ]
+                ],
+            ],
+        }
+        update_document_use_case(
+            data=data,
             address=Address.from_absolute("dmss://testing/$1"),
-            data={
-                "_id": "1",
-                "name": "complexArraysEntity",
-                "type": "higher_rank_array",
-                "1_dim-unfixed": [45, 65, 999999999999999999, 0, -12],
-                "1_dim-fixed_complex_type": [
-                    {
-                        "name": "0",
-                        "type": "basic_blueprint",
-                        "description": "",
-                        "length": 1
-                    },
-                    {
-                        "name": "1",
-                        "type": "basic_blueprint",
-                        "description": "",
-                        "length": 23
-                    },
-                    {
-                        "name": "2",
-                        "type": "basic_blueprint",
-                        "description": "",
-                        "length": 200
-                    },
-                    {
-                        "name": "3",
-                        "type": "basic_blueprint",
-                        "description": "",
-                        "length": 345
-                    },
-                    {
-                        "name": "4",
-                        "type": "basic_blueprint",
-                        "description": "some other description",
-                        "length": 1
-                    },
-                ],
-                "2_dim-unfixed": [[23, 234, 123], [1, 1, 1, 1, 1, 1]],
-                "3_dim-mix": [
-                    [
-                        [
-                            11, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                            0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                            0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                            0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                            0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                            0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                            0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                            0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                            0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                            0, 0, 0, 0, 0, 0, 0, 0, 0, 22
-                        ]
-                    ],
-                    [
-                        [
-                            33, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                            0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                            0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                            0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                            0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                            0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                            0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                            0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                            0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                            0, 0, 0, 0, 0, 0, 0, 0, 0, 44
-                        ]
-                    ],
-                ],
-            },
+            document_service=document_service
         )
 
         expected_1 = {

--- a/src/tests/unit/test_reference.py
+++ b/src/tests/unit/test_reference.py
@@ -6,6 +6,9 @@ from common.address import Address
 from common.exceptions import ValidationException
 from enums import REFERENCE_TYPES, SIMOS
 from features.document.use_cases.add_document_use_case import add_document_use_case
+from features.document.use_cases.update_document_use_case import (
+    update_document_use_case,
+)
 from tests.unit.mock_utils import get_mock_document_service
 
 
@@ -45,8 +48,10 @@ class ReferenceTestCase(unittest.TestCase):
             "type": SIMOS.REFERENCE.value,
             "referenceType": REFERENCE_TYPES.LINK.value,
         }
-        document_service.update_document(
-            Address("$1.uncontained_in_every_way", "testing"), reference, update_uncontained=False
+        update_document_use_case(
+            data=reference,
+            address=Address("$1.uncontained_in_every_way", "testing"),
+            document_service=document_service,
         )
         assert doc_storage["1"]["uncontained_in_every_way"] == reference
 
@@ -93,7 +98,11 @@ class ReferenceTestCase(unittest.TestCase):
         }
 
         with self.assertRaises(ValidationException):
-            document_service.update_document(Address("$1.uncontained_in_every_way", "testing"), reference_entity)
+            update_document_use_case(
+                data=reference_entity,
+                address=Address("$1.uncontained_in_every_way", "testing"),
+                document_service=document_service,
+            )
 
     def test_insert_reference_missing_required_attribute(self):
         repository = mock.Mock()
@@ -125,8 +134,10 @@ class ReferenceTestCase(unittest.TestCase):
 
         reference_entity_with_missing_attribute = {"address": "$123", "type": SIMOS.REFERENCE.value}
         with self.assertRaises(ValidationException):
-            document_service.update_document(
-                Address("$1.uncontained_in_every_way", "testing"), reference_entity_with_missing_attribute
+            update_document_use_case(
+                data=reference_entity_with_missing_attribute,
+                address=Address("$1.uncontained_in_every_way", "testing"),
+                document_service=document_service,
             )
 
     def test_remove_reference(self):

--- a/src/tests/unit/test_save.py
+++ b/src/tests/unit/test_save.py
@@ -9,6 +9,9 @@ from common.utils.data_structure.compare import get_and_print_diff
 from domain_classes.blueprint_attribute import BlueprintAttribute
 from domain_classes.tree_node import Node
 from enums import REFERENCE_TYPES, SIMOS
+from features.document.use_cases.update_document_use_case import (
+    update_document_use_case,
+)
 from tests.unit.mock_utils import (
     get_mock_document_service,
     mock_storage_recipe_provider,
@@ -300,26 +303,24 @@ class DocumentServiceTestCase(unittest.TestCase):
 
         document_service = get_mock_document_service(lambda x, y: repository)
 
-        document_service.update_document(
-            Address("$1", "test"),
-            data={
-                "_id": "1",
-                "name": "Root",
-                "description": "I'm the root document",
-                "type": "blueprint_with_second_level_nested_uncontained_attribute",
-                "i_have_a_uncontained_attribute": {
-                    "type": "uncontained_blueprint",
-                    "name": "first",
-                    "description": "This has changed!",
-                    "uncontained_in_every_way": {
-                        "type": SIMOS.REFERENCE.value,
-                        "referenceType": REFERENCE_TYPES.LINK.value,
-                        "address": "$2",
-                    },
+        data = {
+            "_id": "1",
+            "name": "Root",
+            "description": "I'm the root document",
+            "type": "blueprint_with_second_level_nested_uncontained_attribute",
+            "i_have_a_uncontained_attribute": {
+                "type": "uncontained_blueprint",
+                "name": "first",
+                "description": "This has changed!",
+                "uncontained_in_every_way": {
+                    "type": SIMOS.REFERENCE.value,
+                    "referenceType": REFERENCE_TYPES.LINK.value,
+                    "address": "$2",
                 },
             },
-            update_uncontained=False,
-        )
+        }
+
+        update_document_use_case(data=data, address=Address("$1", "test"), document_service=document_service)
         # Test that the "2" document has not been overwritten
         assert doc_storage["2"].get("description") == "I'm the second nested document, uncontained"
         assert doc_storage["1"]["i_have_a_uncontained_attribute"]["description"] == "This has changed!"
@@ -370,7 +371,7 @@ class DocumentServiceTestCase(unittest.TestCase):
             "nested": {},
             "references": [],
         }
-        document_service.update_document(Address("$1.a", "testing"), new_data, update_uncontained=True)
+        update_document_use_case(data=new_data, address=Address("$1.a", "testing"), document_service=document_service)
 
         assert doc_storage["1"]["a"]["description"] == "SOME DESCRIPTION"
         assert doc_storage["1"]["a"]["reference"]["description"] == "A NEW DESCRIPTION HERE"


### PR DESCRIPTION
## What does this pull request change?

* Moves the update document from the document service to the `update_document_use case`.

## Why is this pull request needed?

* Document service is too big, and getting an overview of the code is therefore more complicated than it should be. Isolate all document update functionality to the update document feature (use case). 

> NOTE: this is the first PR of several that will refactor the document service. 

Other PRs:
- https://github.com/equinor/data-modelling-storage-service/pull/510

## Issues related to this change:

