### PR TITLE
refactor: Rename of a method to fix private method import issue

### DIFF
--- a/src/features/meta/use_cases/get_meta_use_case.py
+++ b/src/features/meta/use_cases/get_meta_use_case.py
@@ -6,5 +6,5 @@ def get_meta_use_case(user: User, data_source_id: str, document_id: str):
     data_source = get_data_source(data_source_id, user)
     if document_id.startswith("$"):
         document_id = document_id[1:]
-    lookup = data_source._lookup(document_id)
+    lookup = data_source.get_lookup(document_id)
     return lookup.meta

--- a/src/services/document_service.py
+++ b/src/services/document_service.py
@@ -398,7 +398,7 @@ class DocumentService:
         data_source: DataSource = self.repository_provider(data_source_id, self.user)
         if document_id.startswith("$"):
             document_id = document_id[1:]
-        lookup = data_source.get_access_control(document_id)
+        lookup = data_source.get_lookup(document_id)
         return lookup.acl
 
     def remove_reference(self, address: Address) -> dict:

--- a/src/storage/data_source_class.py
+++ b/src/storage/data_source_class.py
@@ -92,7 +92,7 @@ class DataSource:
         old_lookup.acl = acl
         self._update_lookup(old_lookup)
 
-    def get_access_control(self, document_id: str) -> DocumentLookUp:
+    def get_lookup(self, document_id: str) -> DocumentLookUp:
         lookup = self._lookup(document_id)
         access_control(lookup.acl, AccessLevel.READ, self.user)
         return lookup


### PR DESCRIPTION
## What does this pull request change?

1. Renamed get_access_control to get_lookup because that is what is really is returning.  
2. Changed reference to use get_lookup instead of using the private method _lookup ( ) 

## Why is this pull request needed?

Convention and clear naming is key

## Issues related to this change:
