### PR TITLE
refactor: renaming to be more clear

### DIFF
--- a/src/authentication/access_control.py
+++ b/src/authentication/access_control.py
@@ -1,9 +1,9 @@
-from authentication.models import ACL, AccessLevel, User
+from authentication.models import AccessControlList, AccessLevel, User
 from common.exceptions import MissingPrivilegeException
 from config import config
 
 
-def access_control(acl: ACL, access_level_required: AccessLevel, user: User):
+def assert_user_has_access(acl: AccessControlList, access_level_required: AccessLevel, user: User):
     """
     This is the main access control function.
     It will either return True or an MissingPrivilegeException.
@@ -36,9 +36,13 @@ def access_control(acl: ACL, access_level_required: AccessLevel, user: User):
     raise MissingPrivilegeException(f"The requested operation requires '{access_level_required.name}' privileges")
 
 
-def create_acl(user: User) -> ACL:
+def create_access_control_list(user: User) -> AccessControlList:
     """Used when there is no ACL to inherit. Sets the current user as owner, and rest copies DEFAULT_ACL"""
-    return ACL(owner=user.user_id, roles=DEFAULT_ACL.roles, others=DEFAULT_ACL.others)
+    return AccessControlList(
+        owner=user.user_id, roles=DEFAULT_ACCESS_CONTROL_LIST.roles, others=DEFAULT_ACCESS_CONTROL_LIST.others
+    )
 
 
-DEFAULT_ACL = ACL(owner=config.DMSS_ADMIN, roles={config.DMSS_ADMIN_ROLE: AccessLevel.WRITE}, others=AccessLevel.READ)
+DEFAULT_ACCESS_CONTROL_LIST = AccessControlList(
+    owner=config.DMSS_ADMIN, roles={config.DMSS_ADMIN_ROLE: AccessLevel.WRITE}, others=AccessLevel.READ
+)

--- a/src/authentication/models.py
+++ b/src/authentication/models.py
@@ -54,7 +54,7 @@ class User(BaseModel):
         return hash(self.user_id)
 
 
-class ACL(BaseModel):
+class AccessControlList(BaseModel):
     """
     acl:
       owner: 'user_id'

--- a/src/domain_classes/document_look_up.py
+++ b/src/domain_classes/document_look_up.py
@@ -1,12 +1,12 @@
 from pydantic import BaseModel
 
-from authentication.models import ACL
+from authentication.models import AccessControlList
 
 
 class DocumentLookUp(BaseModel):
     lookup_id: str
     repository: str
     database_id: str
-    acl: ACL
+    acl: AccessControlList
     storage_affinity: str
     meta: dict | None = None

--- a/src/features/access_control/access_control_feature.py
+++ b/src/features/access_control/access_control_feature.py
@@ -2,7 +2,7 @@ from fastapi import APIRouter, Depends
 from fastapi.responses import JSONResponse, PlainTextResponse
 
 from authentication.authentication import auth_w_jwt_or_pat
-from authentication.models import ACL, User
+from authentication.models import AccessControlList, User
 from common.responses import create_response, responses
 
 from .use_cases.get_acl_use_case import get_acl_use_case
@@ -14,7 +14,11 @@ router = APIRouter(tags=["default", "access_control"], prefix="/acl")
 @router.put("/{data_source_id}/{document_id}", operation_id="set_acl", response_model=str, responses=responses)
 @create_response(PlainTextResponse)
 def set_acl(
-    data_source_id: str, document_id: str, acl: ACL, recursively: bool = True, user: User = Depends(auth_w_jwt_or_pat)
+    data_source_id: str,
+    document_id: str,
+    acl: AccessControlList,
+    recursively: bool = True,
+    user: User = Depends(auth_w_jwt_or_pat),
 ):
     """Update access control list (ACL) for a document.
 
@@ -32,7 +36,9 @@ def set_acl(
     )
 
 
-@router.get("/{data_source_id}/{document_id}", operation_id="get_acl", response_model=ACL, responses=responses)
+@router.get(
+    "/{data_source_id}/{document_id}", operation_id="get_acl", response_model=AccessControlList, responses=responses
+)
 @create_response(JSONResponse)
 def get_acl(data_source_id: str, document_id: str, user: User = Depends(auth_w_jwt_or_pat)):
     """GET the access control list (ACL) for a document.

--- a/src/features/access_control/use_cases/get_acl_use_case.py
+++ b/src/features/access_control/use_cases/get_acl_use_case.py
@@ -1,8 +1,10 @@
-from authentication.models import ACL, User
+from authentication.models import AccessControlList, User
 from services.document_service import DocumentService
 
 
 def get_acl_use_case(user: User, document_id: str, data_source_id: str):
     document_service = DocumentService(user=user)
-    acl: ACL = document_service.get_acl(data_source_id=data_source_id, document_id=document_id)
+    acl: AccessControlList = document_service.get_access_control_list(
+        data_source_id=data_source_id, document_id=document_id
+    )
     return acl

--- a/src/features/access_control/use_cases/set_acl_use_case.py
+++ b/src/features/access_control/use_cases/set_acl_use_case.py
@@ -1,8 +1,8 @@
-from authentication.models import ACL, User
+from authentication.models import AccessControlList, User
 from services.document_service import DocumentService
 
 
-def set_acl_use_case(user: User, data_source_id: str, document_id: str, acl: ACL, recursively: bool):
+def set_acl_use_case(user: User, data_source_id: str, document_id: str, acl: AccessControlList, recursively: bool):
     document_service = DocumentService(user=user)
     document_service.set_acl(data_source_id=data_source_id, document_id=document_id, acl=acl, recursively=recursively)
     return "OK"

--- a/src/features/lookup_table/use_cases/create_lookup_table.py
+++ b/src/features/lookup_table/use_cases/create_lookup_table.py
@@ -1,4 +1,7 @@
-from authentication.access_control import DEFAULT_ACL, access_control
+from authentication.access_control import (
+    DEFAULT_ACCESS_CONTROL_LIST,
+    assert_user_has_access,
+)
 from authentication.models import AccessLevel, User
 from common.address import Address
 from domain_classes.lookup import Lookup
@@ -16,7 +19,7 @@ def create_lookup_table_use_case(
     """
     Create lookup table. If the lookup table already exist, the lookup table will be updated.
     """
-    access_control(DEFAULT_ACL, AccessLevel.WRITE, user)
+    assert_user_has_access(DEFAULT_ACCESS_CONTROL_LIST, AccessLevel.WRITE, user)
 
     document_service = DocumentService(repository_provider=repository_provider, user=user)
     lookup_class_attributes = list(Lookup.__annotations__.keys())

--- a/src/features/lookup_table/use_cases/get_lookup_table.py
+++ b/src/features/lookup_table/use_cases/get_lookup_table.py
@@ -1,8 +1,11 @@
-from authentication.access_control import DEFAULT_ACL, access_control
+from authentication.access_control import (
+    DEFAULT_ACCESS_CONTROL_LIST,
+    assert_user_has_access,
+)
 from authentication.models import AccessLevel, User
 from storage.internal.lookup_tables import get_lookup
 
 
 def get_lookup_table_use_case(lookup_id: str, user: User) -> dict:
-    access_control(DEFAULT_ACL, AccessLevel.READ, user)
+    assert_user_has_access(DEFAULT_ACCESS_CONTROL_LIST, AccessLevel.READ, user)
     return get_lookup(lookup_id).dict()

--- a/src/services/document_service.py
+++ b/src/services/document_service.py
@@ -4,7 +4,7 @@ from functools import lru_cache
 from typing import Callable, Dict, List, Union
 from uuid import uuid4
 
-from authentication.models import ACL
+from authentication.models import AccessControlList
 from common.address import Address
 from common.exceptions import (
     ApplicationException,
@@ -370,7 +370,7 @@ class DocumentService:
 
         return result_list
 
-    def set_acl(self, data_source_id: str, document_id: str, acl: ACL, recursively: bool = True):
+    def set_acl(self, data_source_id: str, document_id: str, acl: AccessControlList, recursively: bool = True):
         if "." in document_id:
             raise Exception(
                 f"set_acl() function got document_id: {document_id}. "
@@ -394,7 +394,7 @@ class DocumentService:
                     except MissingPrivilegeException:  # The user might not have permission on a referenced document
                         logger.warning(f"Failed to update ACL on {node.node_id}. Permission denied.")
 
-    def get_acl(self, data_source_id, document_id) -> ACL:
+    def get_access_control_list(self, data_source_id, document_id) -> AccessControlList:
         data_source: DataSource = self.repository_provider(data_source_id, self.user)
         if document_id.startswith("$"):
             document_id = document_id[1:]

--- a/src/storage/data_source_class.py
+++ b/src/storage/data_source_class.py
@@ -4,8 +4,12 @@ from uuid import uuid4
 
 from pydantic import UUID4
 
-from authentication.access_control import DEFAULT_ACL, access_control, create_acl
-from authentication.models import ACL, AccessLevel, User
+from authentication.access_control import (
+    DEFAULT_ACCESS_CONTROL_LIST,
+    assert_user_has_access,
+    create_access_control_list,
+)
+from authentication.models import AccessControlList, AccessLevel, User
 from common.exceptions import (
     BadRequestException,
     MissingPrivilegeException,
@@ -30,13 +34,13 @@ class DataSource:
         self,
         name: str,
         user: User,
-        acl: ACL = DEFAULT_ACL,
+        acl: AccessControlList = DEFAULT_ACCESS_CONTROL_LIST,
         repositories=None,
         data_source_collection=data_source_collection,
     ):
         self.name = name
         self.user = user
-        # This ACL is used when there is no parent to inherit ACL from. Controls who can create root-packages.
+        # This Access Control List (ACL) is used when there is no parent to inherit ACL from. Controls who can create root-packages.
         self.acl = acl
         self.repositories: Dict[str, Repository] = repositories
         self.data_source_collection = data_source_collection
@@ -46,7 +50,7 @@ class DataSource:
         return cls(
             a_dict["name"],
             user,
-            ACL(**a_dict.get("acl", DEFAULT_ACL.dict())),
+            AccessControlList(**a_dict.get("acl", DEFAULT_ACCESS_CONTROL_LIST.dict())),
             {key: Repository(name=key, **value) for key, value in a_dict["repositories"].items()},
         )
 
@@ -86,15 +90,15 @@ class DataSource:
             filter={"_id": self.name}, update={"$set": {f"documentLookUp.{lookup.lookup_id}": lookup.dict()}}
         )
 
-    def update_access_control(self, document_id: str, acl: ACL) -> None:
+    def update_access_control(self, document_id: str, acl: AccessControlList) -> None:
         old_lookup = self._lookup(document_id)
-        access_control(old_lookup.acl, AccessLevel.WRITE, self.user)
+        assert_user_has_access(old_lookup.acl, AccessLevel.WRITE, self.user)
         old_lookup.acl = acl
         self._update_lookup(old_lookup)
 
     def get_access_control(self, document_id: str) -> DocumentLookUp:
         lookup = self._lookup(document_id)
-        access_control(lookup.acl, AccessLevel.READ, self.user)
+        assert_user_has_access(lookup.acl, AccessLevel.READ, self.user)
         return lookup
 
     def _remove_lookup(self, lookup_id):
@@ -105,7 +109,7 @@ class DataSource:
     def get(self, uid: Union[str, UUID4]) -> dict:
         uid = str(uid)
         lookup = self._lookup(uid)
-        access_control(lookup.acl, AccessLevel.READ, self.user)
+        assert_user_has_access(lookup.acl, AccessLevel.READ, self.user)
         repo = self.repositories[lookup.repository]
         return repo.get(uid)
 
@@ -117,7 +121,7 @@ class DataSource:
         for entity in repo.find(filter):
             if lookup := self._lookup(entity.get("_id")):
                 try:
-                    access_control(lookup.acl, AccessLevel.READ, self.user)
+                    assert_user_has_access(lookup.acl, AccessLevel.READ, self.user)
                     documents_with_access.append(entity)
                 except MissingPrivilegeException:
                     pass
@@ -153,10 +157,10 @@ class DataSource:
 
             parent_acl = parent_lookup.acl if parent_lookup else self.acl  # If no parentLookup, use DataSource default
             # Before inserting a new lookUp, check permissions on parent resource
-            access_control(parent_acl, AccessLevel.WRITE, self.user)
+            assert_user_has_access(parent_acl, AccessLevel.WRITE, self.user)
             repo = self._get_repo_from_storage_attribute(storage_attribute)
             document_owner = self.user
-            acl: ACL = ACL(
+            acl: AccessControlList = AccessControlList(
                 owner=document_owner.user_id,
                 roles=parent_acl.roles,
                 users=parent_acl.users,
@@ -176,7 +180,7 @@ class DataSource:
             self._update_lookup(lookup)
 
         repo = self.repositories[lookup.repository]
-        access_control(lookup.acl, AccessLevel.WRITE, self.user)
+        assert_user_has_access(lookup.acl, AccessLevel.WRITE, self.user)
         repo.update(document["_id"], document)
 
     def update_blob(self, uid: str, filename: str, content_type: str, file) -> None:
@@ -193,24 +197,24 @@ class DataSource:
             lookup_id=uid,
             repository=repo.name,
             database_id=uid,
-            acl=create_acl(self.user),
+            acl=create_access_control_list(self.user),
             storage_affinity=StorageDataTypes.BLOB.value,
             meta=meta,
         )
-        access_control(lookup.acl, AccessLevel.WRITE, self.user)
+        assert_user_has_access(lookup.acl, AccessLevel.WRITE, self.user)
         self._update_lookup(lookup)
         repo.update_blob(uid, file.read())
 
     def get_blob(self, uid: str) -> bytes:
         lookup = self._lookup(uid)
-        access_control(lookup.acl, AccessLevel.READ, self.user)
+        assert_user_has_access(lookup.acl, AccessLevel.READ, self.user)
         return self.repositories[lookup.repository].get_blob(lookup.database_id)
 
     def delete_blob(self, uid: str) -> None:
         # If lookup not found, assume it's deleted
         try:
             lookup = self._lookup(uid)
-            access_control(lookup.acl, AccessLevel.WRITE, self.user)
+            assert_user_has_access(lookup.acl, AccessLevel.WRITE, self.user)
             self._remove_lookup(uid)
             self.repositories[lookup.repository].delete_blob(uid)
         except NotFoundException:
@@ -220,7 +224,7 @@ class DataSource:
         # If lookup not found, assume it's deleted
         try:
             lookup = self._lookup(uid)
-            access_control(lookup.acl, AccessLevel.WRITE, self.user)
+            assert_user_has_access(lookup.acl, AccessLevel.WRITE, self.user)
             self._remove_lookup(uid)
             self.repositories[lookup.repository].delete(uid)
         except NotFoundException:

--- a/src/tests/bdd/steps/domain.py
+++ b/src/tests/bdd/steps/domain.py
@@ -2,7 +2,7 @@ import json
 
 from behave import given, then
 
-from authentication.models import ACL
+from authentication.models import AccessControlList
 from common.utils.create_entity import CreateEntity
 from common.utils.get_storage_recipe import storage_recipe_provider
 from domain_classes.blueprint_attribute import BlueprintAttribute
@@ -99,13 +99,13 @@ def step_impl_documents(context, data_source_id: str, collection: str):
 @given('AccessControlList for document "{document_id}" in data-source "{data_source}" is')
 def step_impl(context, document_id, data_source):
     document_service = DocumentService(get_data_source, user=context.user)
-    acl = ACL(**json.loads(context.text))
+    acl = AccessControlList(**json.loads(context.text))
     document_service.repository_provider(data_source, context.user).update_access_control(document_id, acl)
 
 
 @then('AccessControlList for document "{document_id}" in data-source "{data_source}" should be')
 def step_impl(context, document_id, data_source):
-    acl = ACL(**json.loads(context.text))
+    acl = AccessControlList(**json.loads(context.text))
     lookup_for_data_source: dict = {}
 
     mongodb_cursor = data_source_collection.find({"_id": data_source})
@@ -121,5 +121,5 @@ def step_impl(context, document_id, data_source):
 
 @given('AccessControlList for data-source "{data_source}" is')
 def step_impl(context, data_source):
-    acl = ACL(**json.loads(context.text))
+    acl = AccessControlList(**json.loads(context.text))
     DataSourceRepository(context.user).update_access_control(data_source, acl)


### PR DESCRIPTION
## What does this pull request change?

Renames some things to be more clear
1.  ACL -> AccessControlList
2.  access_control( ) -> assert_user_has_access( )
3. DEFAULT_ACT -> DEFAULT_ACCESS_CONTROL_LIST

## Why is this pull request needed?

Understanding this as a new guy is really hard, so therefore it is better to write out the names of code. 
Code should be more readable as natural language, and not filled with abbreviations and vague method names.

## Issues related to this change:
