### PR TITLE
fix(documentAdd): lower depth

### DIFF
--- a/src/features/document/use_cases/add_document_use_case.py
+++ b/src/features/document/use_cases/add_document_use_case.py
@@ -102,7 +102,7 @@ def _add_document_to_entity_or_list(
         parent_address: Address = Address(
             protocol=address.protocol, path=parent_address_as_string, data_source=address.data_source
         )
-        parent_node: Node = document_service.get_document(parent_address, depth=99)
+        parent_node: Node = document_service.get_document(parent_address, depth=1)
         parent_blueprint = parent_node.blueprint
         if (
             len(


### PR DESCRIPTION
## What does this pull request change?

Lower depth used when getting parent. Does not add tests to reproduce the bug, since fixing this bug fast has high priority.

## Why is this pull request needed?

If documentAdd is used to add an optional attribute, we use documentGet to get the parent. The depth was too high, causing non-relevant references to be resolved. When saving later on, the document would be invalid.

## Issues related to this change:
