### PR TITLE
fix: content in File blueprint should not be model uncontained

### DIFF
--- a/src/home/system/SIMOS/File.json
+++ b/src/home/system/SIMOS/File.json
@@ -37,8 +37,7 @@
       "name": "content",
       "type": "dmss://system/SIMOS/BlueprintAttribute",
       "attributeType": "binary",
-      "optional": true,
-      "contained": false
+      "optional": true
     }
   ]
 }


### PR DESCRIPTION
## What does this pull request change?

## Why is this pull request needed?

## Issues related to this change:
closes https://github.com/equinor/dm-core-packages/issues/403