### PR TITLE
refactor: move get acl logic to use case instead of document service

### DIFF
--- a/src/features/access_control/access_control_feature.py
+++ b/src/features/access_control/access_control_feature.py
@@ -4,6 +4,7 @@ from fastapi.responses import JSONResponse, PlainTextResponse
 from authentication.authentication import auth_w_jwt_or_pat
 from authentication.models import AccessControlList, User
 from common.responses import create_response, responses
+from storage.internal.data_source_repository import DataSourceRepository
 
 from .use_cases.get_acl_use_case import get_acl_use_case
 from .use_cases.set_acl_use_case import set_acl_use_case
@@ -53,4 +54,6 @@ def get_acl(data_source_id: str, document_id: str, user: User = Depends(auth_w_j
     Returns:
     - ACL: The access control list requested.
     """
-    return get_acl_use_case(user=user, data_source_id=data_source_id, document_id=document_id).dict()
+    return get_acl_use_case(
+        data_source_id=data_source_id, document_id=document_id, data_source_repository=DataSourceRepository(user)
+    ).dict()

--- a/src/features/access_control/use_cases/get_acl_use_case.py
+++ b/src/features/access_control/use_cases/get_acl_use_case.py
@@ -1,10 +1,14 @@
-from authentication.models import AccessControlList, User
-from services.document_service import DocumentService
+from authentication.models import AccessControlList
+from domain_classes.document_look_up import DocumentLookUp
+from storage.data_source_class import DataSource
+from storage.internal.data_source_repository import DataSourceRepository
 
 
-def get_acl_use_case(user: User, document_id: str, data_source_id: str):
-    document_service = DocumentService(user=user)
-    acl: AccessControlList = document_service.get_access_control_list(
-        data_source_id=data_source_id, document_id=document_id
-    )
-    return acl
+def get_acl_use_case(
+    document_id: str, data_source_id: str, data_source_repository: DataSourceRepository
+) -> AccessControlList:
+    data_source: DataSource = data_source_repository.get(data_source_id)
+    if document_id.startswith("$"):
+        document_id = document_id[1:]
+    lookup: DocumentLookUp = data_source.get_lookup(document_id)
+    return lookup.acl

--- a/src/services/document_service.py
+++ b/src/services/document_service.py
@@ -309,10 +309,3 @@ class DocumentService:
                         data_source.update_access_control(node.entity["_id"], acl)
                     except MissingPrivilegeException:  # The user might not have permission on a referenced document
                         logger.warning(f"Failed to update ACL on {node.node_id}. Permission denied.")
-
-    def get_access_control_list(self, data_source_id, document_id) -> AccessControlList:
-        data_source: DataSource = self.repository_provider(data_source_id, self.user)
-        if document_id.startswith("$"):
-            document_id = document_id[1:]
-        lookup = data_source.get_lookup(document_id)
-        return lookup.acl


### PR DESCRIPTION
## What does this pull request change?

* Moves the get acl from the document service to the `get_acl_use_case`.

## Why is this pull request needed?

* Document service is too big, and getting an overview of the code is therefore more complicated than it should be. Isolate all document update functionality to the update document feature (use case). 

Other related PRs:
- https://github.com/equinor/data-modelling-storage-service/pull/510
- https://github.com/equinor/data-modelling-storage-service/pull/513

## Issues related to this change:

