### PR TITLE
refactor: move set acl logic to use case instead of document service

### DIFF
--- a/src/features/access_control/access_control_feature.py
+++ b/src/features/access_control/access_control_feature.py
@@ -4,7 +4,13 @@ from fastapi.responses import JSONResponse, PlainTextResponse
 from authentication.authentication import auth_w_jwt_or_pat
 from authentication.models import AccessControlList, User
 from common.responses import create_response, responses
-from storage.internal.data_source_repository import DataSourceRepository
+from common.utils.get_blueprint import get_blueprint_provider
+from common.utils.get_storage_recipe import storage_recipe_provider
+from services.document_service import DocumentService
+from storage.internal.data_source_repository import (
+    DataSourceRepository,
+    get_data_source,
+)
 
 from .use_cases.get_acl_use_case import get_acl_use_case
 from .use_cases.set_acl_use_case import set_acl_use_case
@@ -32,8 +38,20 @@ def set_acl(
     Returns:
     - str: "OK" (200)
     """
+    document_service = DocumentService(
+        repository_provider=get_data_source,
+        user=user,
+        blueprint_provider=get_blueprint_provider(user),
+        recipe_provider=storage_recipe_provider,
+    )
+
     return set_acl_use_case(
-        user=user, data_source_id=data_source_id, document_id=document_id, acl=acl, recursively=recursively
+        data_source_id=data_source_id,
+        document_id=document_id,
+        acl=acl,
+        recursively=recursively,
+        data_source_repository=DataSourceRepository(user),
+        document_service=document_service,
     )
 
 

--- a/src/features/access_control/use_cases/set_acl_use_case.py
+++ b/src/features/access_control/use_cases/set_acl_use_case.py
@@ -1,8 +1,40 @@
-from authentication.models import AccessControlList, User
+from authentication.models import AccessControlList
+from common.address import Address
+from common.exceptions import MissingPrivilegeException
+from common.utils.logging import logger
 from services.document_service import DocumentService
+from storage.data_source_class import DataSource
+from storage.internal.data_source_repository import DataSourceRepository
 
 
-def set_acl_use_case(user: User, data_source_id: str, document_id: str, acl: AccessControlList, recursively: bool):
-    document_service = DocumentService(user=user)
-    document_service.set_acl(data_source_id=data_source_id, document_id=document_id, acl=acl, recursively=recursively)
+def set_acl_use_case(
+    data_source_id: str,
+    document_id: str,
+    acl: AccessControlList,
+    recursively: bool,
+    data_source_repository: DataSourceRepository,
+    document_service: DocumentService,
+):
+    if "." in document_id:
+        raise Exception(
+            f"set_acl() function got document_id: {document_id}. "
+            f"The set_acl() function can only be used on root documents. You cannot use a dotted document id."
+        )
+    data_source: DataSource = data_source_repository.get(data_source_id)
+
+    if not recursively:  # Only update acl on the one document
+        data_source.update_access_control(document_id, acl)
+        return
+
+    # TODO: Updating ACL for Links should only be additive
+    # TODO: ACL for StorageReferences should always be identical to parent document
+    root_node = document_service.get_document(Address(document_id, data_source_id), 99)
+    data_source.update_access_control(root_node.node_id, acl)
+    for child in root_node.children:
+        for node in child.traverse():
+            if not node.storage_contained and not node.is_array():
+                try:
+                    data_source.update_access_control(node.entity["_id"], acl)
+                except MissingPrivilegeException:  # The user might not have permission on a referenced document
+                    logger.warning(f"Failed to update ACL on {node.node_id}. Permission denied.")
     return "OK"


### PR DESCRIPTION
## What does this pull request change?

* Moves the get acl from the document service to the `get_acl_use_case`.

## Why is this pull request needed?

* Document service is too big, and getting an overview of the code is therefore more complicated than it should be. Isolate all document update functionality to the update document feature (use case). 

Other related PRs:
- https://github.com/equinor/data-modelling-storage-service/pull/510
- https://github.com/equinor/data-modelling-storage-service/pull/513
- https://github.com/equinor/data-modelling-storage-service/pull/533

## Issues related to this change:

