### PR TITLE
feat: endpoint for checking if document exist

### DIFF
--- a/src/features/document/document_feature.py
+++ b/src/features/document/document_feature.py
@@ -15,6 +15,7 @@ from storage.internal.data_source_repository import get_data_source
 
 from .use_cases.add_document_use_case import add_document_use_case
 from .use_cases.add_raw_use_case import add_raw_use_case
+from .use_cases.check_exsistence_use_case import check_existence_use_case
 from .use_cases.get_document_use_case import get_document_use_case
 from .use_cases.remove_use_case import remove_use_case
 from .use_cases.update_document_use_case import update_document_use_case
@@ -174,3 +175,18 @@ def remove(address: str, user: User = Depends(auth_w_jwt_or_pat)):
     - str: "OK" (200)
     """
     return remove_use_case(user=user, address=address)
+
+
+@router.get("-existence/{address:path}", operation_id="document_check", response_model=bool, responses=responses)
+@create_response(JSONResponse)
+def check_existence(address: str, user: User = Depends(auth_w_jwt_or_pat)):
+    """Checks if an entity exists, given an address.
+
+    Args:
+    - Address
+
+    Returns:
+    - bool: 'true' if the address points to an existing document, else 'false'.
+    """
+    document_service = DocumentService(repository_provider=get_data_source, user=user)
+    return check_existence_use_case(address=Address.from_absolute(address), document_service=document_service)

--- a/src/features/document/use_cases/check_exsistence_use_case.py
+++ b/src/features/document/use_cases/check_exsistence_use_case.py
@@ -1,0 +1,11 @@
+from common.address import Address
+from common.exceptions import NotFoundException
+from services.document_service import DocumentService
+
+
+def check_existence_use_case(address: Address, document_service: DocumentService) -> bool:
+    try:
+        document_service.get_document(address)
+        return True
+    except NotFoundException:
+        return False

--- a/src/tests/bdd/document/check_existence.feature
+++ b/src/tests/bdd/document/check_existence.feature
@@ -1,0 +1,34 @@
+# Created by christopher.lokken at 24/08/2023
+Feature: Check the existence of documents
+
+  Background: There are data sources in the system
+    Given the system data source and SIMOS core package are available
+    Given there are basic data sources with repositories
+      |   name  |
+      | test-DS |
+    Given there exist document with id "1" in data source "test-DS"
+    """
+    {
+      "name": "TestData",
+      "description": "",
+      "type": "dmss://system/SIMOS/Package",
+      "content": [],
+      "isRoot": true
+    }
+    """
+
+  Scenario: Check the existence of non-existing document
+    Given I access the resource url "/api/documents-existence/test-DS/$1"
+    When I make a "GET" request
+    Then the response status should be "OK"
+    And the response should be
+    """
+    true
+    """
+    Given I access the resource url "/api/documents-existence/test-DS/$2"
+    When I make a "GET" request
+    Then the response status should be "OK"
+    And the response should be
+    """
+    false
+    """

--- a/src/tests/bdd/steps/handle_response.py
+++ b/src/tests/bdd/steps/handle_response.py
@@ -114,8 +114,8 @@ def step_impl_should_be(context):
         assert actual == data
     else:
         actual = context.response.json()
-        data = json.loads(context.text) or json.loads(context.data)
-        assert get_and_print_diff(actual, data) == []
+        data = context.text or context.data
+        assert get_and_print_diff(actual, json.loads(data)) == []
 
 
 @then("the length of the response should not be zero")

--- a/src/tests/unit/test_check_existence.py
+++ b/src/tests/unit/test_check_existence.py
@@ -1,0 +1,40 @@
+import unittest
+from copy import deepcopy
+from unittest import mock
+
+from common.address import Address
+from features.document.use_cases.check_exsistence_use_case import (
+    check_existence_use_case,
+)
+from tests.unit.mock_utils import get_mock_document_service
+
+
+class CheckExistenceTestCase(unittest.TestCase):
+    def setUp(self) -> None:
+        self.storage = {
+            "1": {
+                "name": "Test_document",
+                "type": "basic_blueprint",
+                "_id": "1",
+            }
+        }
+        self.repository = mock.Mock()
+        self.repository.get = self.mock_get
+        self.repository.delete = self.mock_delete
+        self.document_service = get_mock_document_service(lambda x, y: self.repository)
+
+    def mock_get(self, document_id: str):
+        return deepcopy(self.storage.get(document_id))
+
+    def mock_delete(self, document_id: str):
+        del self.storage[document_id]
+
+    def test_check_existence_of_existing_document(self):
+        assert (
+            check_existence_use_case(address=Address("$1", "testing"), document_service=self.document_service) is True
+        )
+
+    def test_check_existence_of_non_existing_document(self):
+        assert (
+            check_existence_use_case(address=Address("$2", "testing"), document_service=self.document_service) is False
+        )

--- a/src/tests/unit/test_remove.py
+++ b/src/tests/unit/test_remove.py
@@ -1,5 +1,4 @@
 import unittest
-from copy import deepcopy
 from unittest import mock
 
 from common.address import Address
@@ -20,7 +19,7 @@ class DocumentServiceTestCase(unittest.TestCase):
         self.document_service = get_mock_document_service(lambda x, y: self.repository)
 
     def mock_get(self, document_id: str):
-        return deepcopy(self.storage[document_id])
+        return self.storage[document_id]
 
     def mock_update(self, entity: dict, *args, **kwargs):
         self.storage[entity["_id"]] = entity


### PR DESCRIPTION
## What does this pull request change?
Introduces an endpoint for checking if a document exists. The endpoint returns a boolean based on a document address, and a 200 OK for both cases. 

## Why is this pull request needed?
Gives the ability to check if a document exists without creating error logs.

## Issues related to this change:
Closes #529
