### PR TITLE
fix: documentUpdate failing for references

### DIFF
--- a/src/common/tree_node_serializer.py
+++ b/src/common/tree_node_serializer.py
@@ -100,7 +100,7 @@ def tree_node_to_ref_dict(node: Node | ListNode) -> dict:
     for child in node.children:
         if child.is_array():
             # If the content of the list is not contained, i.e. references.
-            if not child.storage_contained:
+            if not child.storage_contained or not child.contained:
                 data[child.key] = [
                     child.entity
                     if child.type == SIMOS.REFERENCE.value
@@ -217,18 +217,12 @@ def tree_node_from_dict(
                     content_attribute.attribute_type = child["type"]
                     list_child_attribute = content_attribute
 
-                if child["type"] == SIMOS.REFERENCE.value:
-                    # TODO: Resolve to get uid?
-                    child_uid = child["address"].replace("$", "")
-                else:
-                    child_uid = child.get("_id", "")
-
                 # The child inside a list is identical to the attribute in the parent,
                 # except it does not have dimensions *
                 list_child_attribute.dimensions.dimensions = ""
 
                 list_child_node = tree_node_from_dict(
-                    uid=child_uid,
+                    uid=None if child["type"] == SIMOS.REFERENCE.value else child.get("_id", ""),
                     entity=child,
                     key=str(i),
                     blueprint_provider=blueprint_provider,
@@ -245,14 +239,9 @@ def tree_node_from_dict(
                     f"The attribute '{child_attribute.name}' on blueprint '{node.type}' "
                     + f"should be a dict, but was '{str(type(attribute_data))}'"
                 )
-            # If the child is not contained, get or create it's _id
-            if attribute_data.get("type", "") == SIMOS.REFERENCE.value:
-                child_uid = attribute_data["address"].replace("$", "")
-            else:
-                child_uid = attribute_data.get("_id", "")
 
             child_node = tree_node_from_dict(
-                uid=child_uid,
+                uid=None if attribute_data.get("type", "") == SIMOS.REFERENCE.value else attribute_data.get("_id", ""),
                 entity=attribute_data,
                 key=child_attribute.name,
                 blueprint_provider=blueprint_provider,

--- a/src/common/utils/get_storage_recipe.py
+++ b/src/common/utils/get_storage_recipe.py
@@ -2,7 +2,7 @@ from common.exceptions import NotFoundException
 from domain_classes.lookup import Lookup
 from domain_classes.storage_recipe import StorageRecipe
 from domain_classes.ui_recipe import Recipe
-from enums import SIMOS
+from enums import SIMOS, StorageDataTypes
 from storage.internal.lookup_tables import get_lookup
 
 default_yaml_view = Recipe(
@@ -90,3 +90,13 @@ def storage_recipe_provider(type: str, context: str | None = None) -> list[Stora
         storage_recipes = lookup.storage_recipes.get("_default_", [])
 
     return storage_recipes
+
+
+def create_default_storage_recipe() -> list[StorageRecipe]:
+    return [
+        StorageRecipe(
+            name="Default",
+            storage_affinity=StorageDataTypes.DEFAULT,
+            attributes={},
+        )
+    ]

--- a/src/domain_classes/tree_node.py
+++ b/src/domain_classes/tree_node.py
@@ -2,6 +2,7 @@ from typing import Callable, List, Union
 from uuid import uuid4
 
 from common.exceptions import ValidationException
+from common.utils.get_storage_recipe import create_default_storage_recipe
 from domain_classes.blueprint import Blueprint
 from domain_classes.blueprint_attribute import BlueprintAttribute
 from domain_classes.storage_recipe import StorageAttribute, StorageRecipe
@@ -55,21 +56,9 @@ class NodeBase:
     @property
     def storage_recipes(self, context: str | None = "DMSS") -> list[StorageRecipe]:
         # TODO: support other contexts than "DMSS"
-        if not self.recipe_provider:
-            return []
-
-        if context_recipes := self.recipe_provider(self.type, context):
-            return context_recipes
-        # No storage recipes found, creating a default
-        return [
-            StorageRecipe(
-                name="Default",
-                storage_affinity=StorageDataTypes.DEFAULT.value,
-                attributes={
-                    a.name: StorageAttribute(name=a.name, contained=a.contained) for a in self.blueprint.attributes
-                },
-            )
-        ]
+        if not self.recipe_provider or not (context_recipes := self.recipe_provider(self.type, context)):
+            return create_default_storage_recipe()
+        return context_recipes
 
     def is_empty(self):
         return not self.entity

--- a/src/features/document/use_cases/add_document_use_case.py
+++ b/src/features/document/use_cases/add_document_use_case.py
@@ -51,7 +51,7 @@ def _add_document_to_data_source(
     except NotFoundException:
         pass
 
-    new_node.set_uid()
+    new_node.set_uid(new_node.generate_id())
 
     document_service.save(new_node, data_source_id, update_uncontained=update_uncontained)
 
@@ -172,9 +172,10 @@ def _add_document_to_entity_or_list(
         target = target.children[0]  # Set target to be the packages content
 
     if isinstance(target, ListNode) or target.parent.type == SIMOS.PACKAGE.value:
-        new_node.set_uid()
         new_node.parent = target
         new_node.key = str(len(target.children))
+        if new_node.should_have_id():
+            new_node.set_uid(new_node.generate_id())
         target.add_child(new_node)
         document_service.save(target.find_parent(), address.data_source, update_uncontained=False)
     else:

--- a/src/services/document_service.py
+++ b/src/services/document_service.py
@@ -172,7 +172,8 @@ class DocumentService:
         if node.type == SIMOS.BLOB.value:
             node.entity = self.save_blob_data(node, repository)
 
-        node.set_uid()  # Ensure the node has a _id
+        if isinstance(node, Node) and node.should_have_id():
+            node.set_uid(node.generate_id())  # Ensure the node has a _id
         ref_dict = tree_node_to_ref_dict(node)
 
         # If the node is not contained, and has data, save it!

--- a/src/tests/bdd/document/reference.feature
+++ b/src/tests/bdd/document/reference.feature
@@ -18,7 +18,7 @@ Feature: Add and remove references
     }
     """
 
-    Given there exist document with id "3f9ff99f-9cb5-4afc-947b-a3224eee341f" in data source "test-DS"
+    Given there exist document with id "5" in data source "test-DS"
     """
     {
       "type": "dmss://system/SIMOS/Blueprint",
@@ -28,22 +28,45 @@ Feature: Add and remove references
       "attributes": []
     }
     """
+
     Given i access the resource url "/api/documents/test-DS/$1.content"
     When i make a form-data "POST" request
     """
     {
       "document":
         {
-          "address": "$3f9ff99f-9cb5-4afc-947b-a3224eee341f",
+          "address": "$5",
           "type": "dmss://system/SIMOS/Reference",
           "referenceType": "link"
         }
     }
     """
     Then the response status should be "OK"
+
+    Given i access the resource url "/api/documents/test-DS/$1"
+    When i make a "GET" request
+    Then the response status should be "OK"
+    And the response should contain
+    """
+    {
+      "name": "TestData",
+      "description": "",
+      "type": "dmss://system/SIMOS/Package",
+      "content": [
+        {
+          "address": "$5",
+          "type": "dmss://system/SIMOS/Reference",
+          "referenceType": "link"
+        }
+      ],
+      "isRoot": true
+    }
+    """
+
     Given i access the resource url "/api/documents/test-DS/$1.content[0]"
     When i make a "DELETE" request
     Then the response status should be "OK"
+
     Given i access the resource url "/api/documents/test-DS/$1"
     When i make a "GET" request
     Then the response status should be "OK"
@@ -67,22 +90,27 @@ Feature: Add and remove references
       "type": "dmss://system/SIMOS/Package",
       "content": [
         {
-          "address": "$2",
+          "address": "$turbineBlueprint",
           "type": "dmss://system/SIMOS/Reference",
           "referenceType": "link"
         },
         {
-          "address": "$3",
+          "address": "$mooringBlueprint",
           "type": "dmss://system/SIMOS/Reference",
           "referenceType": "link"
         },
         {
-          "address": "$4",
+          "address": "$turbineEntity",
           "type": "dmss://system/SIMOS/Reference",
           "referenceType": "link"
         },
         {
-          "address": "$3f9ff99f-9cb5-4afc-947b-a3224eee341f",
+          "address": "$mooringEntity1",
+          "type": "dmss://system/SIMOS/Reference",
+          "referenceType": "link"
+        },
+        {
+          "address": "$mooringEntity2",
           "type": "dmss://system/SIMOS/Reference",
           "referenceType": "link"
         }
@@ -91,7 +119,7 @@ Feature: Add and remove references
     }
     """
 
-    Given there exist document with id "2" in data source "test-DS"
+    Given there exist document with id "turbineBlueprint" in data source "test-DS"
     """
     {
       "name": "Turbine",
@@ -109,7 +137,8 @@ Feature: Add and remove references
       ]
     }
     """
-    Given there exist document with id "3" in data source "test-DS"
+
+    Given there exist document with id "mooringBlueprint" in data source "test-DS"
     """
     {
       "name": "Mooring",
@@ -127,7 +156,8 @@ Feature: Add and remove references
       ]
     }
     """
-    Given there exist document with id "4" in data source "test-DS"
+
+    Given there exist document with id "turbineEntity" in data source "test-DS"
     """
     {
       "name": "myTurbine",
@@ -135,31 +165,92 @@ Feature: Add and remove references
       "description": "This is a wind turbine demoing uncontained relationships"
     }
     """
-    Given there exist document with id "3f9ff99f-9cb5-4afc-947b-a3224eee341f" in data source "test-DS"
+
+    Given there exist document with id "mooringEntity1" in data source "test-DS"
     """
     {
-    "name": "myMooring",
+    "name": "mooring1",
     "type": "dmss://test-DS/TestData/Mooring",
     "description": "",
     "Bigness": 10
     }
     """
-    Given i access the resource url "/api/documents/test-DS/$4.Mooring"
+
+    Given there exist document with id "mooringEntity2" in data source "test-DS"
+    """
+    {
+    "name": "mooring2",
+    "type": "dmss://test-DS/TestData/Mooring",
+    "description": "",
+    "Bigness": 100
+    }
+    """
+
+    Given i access the resource url "/api/documents/test-DS/$turbineEntity.Mooring"
     When i make a form-data "POST" request
     """
     {
       "document": {
-        "address": "$3f9ff99f-9cb5-4afc-947b-a3224eee341f",
+        "address": "$mooringEntity1",
         "type": "dmss://system/SIMOS/Reference",
         "referenceType": "link"
       }
     }
     """
     Then the response status should be "OK"
-    Given i access the resource url "/api/documents/test-DS/$4.Mooring"
+
+    Given i access the resource url "/api/documents/test-DS/$turbineEntity"
+    When i make a "GET" request
+    Then the response status should be "OK"
+    And the response should contain
+    """
+    {
+      "name": "myTurbine",
+      "type": "dmss://test-DS/TestData/Turbine",
+      "description": "This is a wind turbine demoing uncontained relationships",
+      "Mooring": {
+        "address": "$mooringEntity1",
+        "type": "dmss://system/SIMOS/Reference",
+        "referenceType": "link"
+      }
+    }
+    """
+
+    Given i access the resource url "/api/documents/test-DS/$turbineEntity.Mooring"
+    When i make a form-data "PUT" request
+    """
+    {
+      "data": {
+        "address": "$mooringEntity2",
+        "type": "dmss://system/SIMOS/Reference",
+        "referenceType": "link"
+      }
+    }
+    """
+    Then the response status should be "OK"
+
+    Given i access the resource url "/api/documents/test-DS/$turbineEntity"
+    When i make a "GET" request
+    Then the response status should be "OK"
+    And the response should contain
+    """
+    {
+      "name": "myTurbine",
+      "type": "dmss://test-DS/TestData/Turbine",
+      "description": "This is a wind turbine demoing uncontained relationships",
+      "Mooring": {
+        "address": "$mooringEntity2",
+        "type": "dmss://system/SIMOS/Reference",
+        "referenceType": "link"
+      }
+    }
+    """
+
+    Given i access the resource url "/api/documents/test-DS/$turbineEntity.Mooring"
     When i make a "DELETE" request
     Then the response status should be "OK"
-    Given i access the resource url "/api/documents/test-DS/$4"
+
+    Given i access the resource url "/api/documents/test-DS/$turbineEntity"
     When i make a "GET" request
     Then the response status should be "OK"
     And the response should contain

--- a/src/tests/unit/test_tree_functionality/blueprints_for_tree_tests.py
+++ b/src/tests/unit/test_tree_functionality/blueprints_for_tree_tests.py
@@ -256,4 +256,4 @@ def get_blueprint(type: str):
         return Blueprint(reference_blueprint)
     if type == "uncontained_list_blueprint":
         return Blueprint(uncontained_list_blueprint, type)
-    return None
+    raise Exception(f"Invalid type {type}")


### PR DESCRIPTION
## What does this pull request change?

Update bdd test to ensure this issue doesn't arise anew. Then fix issue

## Why is this pull request needed?

Started working on this due to documentUpdate not saving to db when input is a reference. Bug seemed caused by the entity getting `storage_contained = False`, which isn't correct. Fixing it caused a new issue with node uids.

## Issues related to this change:
