### PR TITLE
refactor: use method to find attribute

### DIFF
--- a/src/features/document/use_cases/add_document_use_case.py
+++ b/src/features/document/use_cases/add_document_use_case.py
@@ -103,26 +103,14 @@ def _add_document_to_entity_or_list(
             protocol=address.protocol, path=parent_address_as_string, data_source=address.data_source
         )
         parent_node: Node = document_service.get_document(parent_address, depth=1)
-        parent_blueprint = parent_node.blueprint
-        if (
-            len(
-                [
-                    blueprint_attribute
-                    for blueprint_attribute in parent_blueprint.attributes
-                    if blueprint_attribute.name == last_attribute_in_address
-                ]
-            )
-            == 0
-        ):
-            raise NotFoundException(
-                f"Could not find attribute {last_attribute_in_address} in blueprint for {parent_blueprint.name}"
-            )
 
-        attribute_to_update = [
-            blueprint_attribute
-            for blueprint_attribute in parent_blueprint.attributes
-            if blueprint_attribute.name == last_attribute_in_address
-        ][0]
+        attribute_to_update: BlueprintAttribute = parent_node.blueprint.get_attribute_by_name(
+            last_attribute_in_address
+        )
+        if not attribute_to_update:
+            raise NotFoundException(
+                f"Could not find attribute {last_attribute_in_address} in blueprint for {parent_node.blueprint.name}"
+            )
 
         new_node = tree_node_from_dict(
             {**document},


### PR DESCRIPTION
## What does this pull request change?

* Use the `get_attribute_by_name` method on the Blueprint class instead of finding the attribute manually. 

## Why is this pull request needed?

* More readable code

## Issues related to this change:
