### PR TITLE
Feat: error handling in 'has_key_value_pair' method

### DIFF
--- a/src/common/utils/data_structure/has_key_value_pairs.py
+++ b/src/common/utils/data_structure/has_key_value_pairs.py
@@ -1,9 +1,3 @@
 def has_key_value_pairs(target: dict, content: dict):
     """Util method for checking that target entity contains the key-value pairs defined in content"""
-    is_identical = True
-    for key in content:
-        if key not in target:
-            raise KeyError(f"They key '{key}' does not exist in target {str(target)}")
-        if target[key] != content[key]:
-            is_identical = False
-    return is_identical
+    return all(key in target and target[key] == value for key, value in content.items())

--- a/src/tests/unit/test_common/test_utils/test_data_structure/test_has_key_value_pairs.py
+++ b/src/tests/unit/test_common/test_utils/test_data_structure/test_has_key_value_pairs.py
@@ -10,7 +10,14 @@ class HasKeyValuePairsTestCase(unittest.TestCase):
     def test_target_contains_key_value_pair_returns_true(self):
         assert has_key_value_pairs(self.target, {"a": "1"})
         assert has_key_value_pairs(self.target, {"b": "2"})
+        assert has_key_value_pairs(self.target, {"b": "2", "a": "1"})
 
     def test_target_not_contains_key_value_pair_returns_false(self):
         assert has_key_value_pairs(self.target, {"a": "2"}) is False
         assert has_key_value_pairs(self.target, {"b": "1"}) is False
+        assert has_key_value_pairs(self.target, {"a": "1", "b": "1000"}) is False
+
+    def test_target_not_contains_key_returns_false(self):
+        assert has_key_value_pairs(self.target, {"x": "y"}) is False
+        assert has_key_value_pairs(self.target, {1: {"x": "y"}}) is False
+        assert has_key_value_pairs(self.target, {1: {"a": "1"}}) is False


### PR DESCRIPTION
## What does this pull request change?

Merge #552 first

Example 
`
input: 
    target {"a": "b"}
    content {"x": "y"}
` -> throws
changed to -> `returns false`

The way it was implemented was that 
- if the key in `content` did not exist, the method throws! 

From the naming of the method, and the use, I propose that it should return `false` when the key in `content` does not exist in `target`. 


should return false instead of throw. 

The method `has_key_value_pair()` is a method that is used only once, in `get_child()`, se below, and this implementation should not break the usage of the method

<img width="1031" alt="image" src="https://github.com/equinor/data-modelling-storage-service/assets/37016135/b32a7663-aa37-49e3-b696-03d36df5accf">




## Why is this pull request needed?

## Issues related to this change:
