### PR TITLE
refactor: add oauth scope to swagger

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -19,6 +19,7 @@ services:
       OAUTH_AUDIENCE: 97a6b5bd-63fb-42c6-bb75-7e5de2394ba0 #if using azure ad, audience is the azure client id
       OAUTH_CLIENT_ID: 97a6b5bd-63fb-42c6-bb75-7e5de2394ba0
       OAUTH_CLIENT_SECRET: ${OAUTH_CLIENT_SECRET}
+      OAUTH_AUTH_SCOPE: api://97a6b5bd-63fb-42c6-bb75-7e5de2394ba0/dmss
       AAD_ENTERPRISE_APP_OID: b9041025-05f0-44d4-89a7-3b5f955c0de5
       AUTH_PROVIDER_FOR_ROLE_CHECK:
     ports:

--- a/src/app.py
+++ b/src/app.py
@@ -73,7 +73,13 @@ def create_app() -> FastAPI:
         title="Data Modelling Storage Service",
         version="1.3.1",  # x-release-please-version
         description="API for basic data modelling interaction",
-        swagger_ui_init_oauth={"usePkceWithAuthorizationCodeGrant": True, "clientId": config.OAUTH_CLIENT_ID},
+        swagger_ui_init_oauth={
+            "clientId": config.OAUTH_CLIENT_ID,
+            "appName": "DMSS",
+            "usePkceWithAuthorizationCodeGrant": True,
+            "scopes": config.OAUTH_AUTH_SCOPE,
+            "useBasicAuthenticationWithAccessCodeGrant": True,
+        },
     )
     app.include_router(authenticated_routes, prefix=server_root, dependencies=[Security(auth_w_jwt_or_pat)])
     app.include_router(jwt_only_routes, prefix=server_root, dependencies=[Security(auth_with_jwt)])

--- a/src/config.py
+++ b/src/config.py
@@ -29,6 +29,7 @@ class Config(BaseSettings):
     OAUTH_CLIENT_ID: str = Field("dmss", env="OAUTH_CLIENT_ID")
     OAUTH_CLIENT_SECRET: str = Field("", env="OAUTH_CLIENT_SECRET")
     AUTH_AUDIENCE: str = Field("dmss", env="OAUTH_AUDIENCE")
+    OAUTH_AUTH_SCOPE: str = Field("", env="OAUTH_AUTH_SCOPE")
     MICROSOFT_AUTH_PROVIDER: str = "login.microsoftonline.com"
     AUTH_PROVIDER_FOR_ROLE_CHECK: AuthProviderForRoleCheck = Field(None, env="AUTH_PROVIDER_FOR_ROLE_CHECK")
     AAD_ENTERPRISE_APP_OID: str = Field(


### PR DESCRIPTION
## What does this pull request change?

* Be able to add OAUTH_SCOPES defined here: https://portal.azure.com/#view/Microsoft_AAD_RegisteredApps/ApplicationMenuBlade/~/ProtectAnAPI/appId/97a6b5bd-63fb-42c6-bb75-7e5de2394ba0/isMSAApp~/false

## Why is this pull request needed?

## Issues related to this change:
