### PR TITLE
feat: extend testing coverage of scrypt method to be complete

### DIFF
--- a/src/tests/unit/test_hashing.py
+++ b/src/tests/unit/test_hashing.py
@@ -6,8 +6,21 @@ from common.utils.encryption import scrypt
 class HasingTestCase(unittest.TestCase):
     salt = "arandomgeneratedstring"
 
-    def test_scrypt(self):
+    def test_hasing_returns_same_with_same_value_and_same_salt(self):
         value = "My string to hash"
         digest = scrypt(value, self.salt)
         digest2 = scrypt(value, self.salt)
         assert digest == digest2
+
+    def test_hashing_returns_different_with_different_salt_and_same_value(self):
+        value = "My string to hash"
+        digest = scrypt(value, self.salt)
+        digest2 = scrypt(value, "another salt")
+        assert digest != digest2
+
+    def test_hashing_returns_different_with_different_value_and_same_salt(self):
+        value1 = "My string to hash."
+        value2 = "Another string."
+        digest = scrypt(value1, self.salt)
+        digest2 = scrypt(value2, self.salt)
+        assert digest != digest2

--- a/src/tests/unit/test_hashing.py
+++ b/src/tests/unit/test_hashing.py
@@ -5,22 +5,30 @@ from common.utils.encryption import scrypt
 
 class HasingTestCase(unittest.TestCase):
     salt = "arandomgeneratedstring"
+    value1 = "My string to hash."
+    value2 = "Another string."
 
-    def test_hasing_returns_same_with_same_value_and_same_salt(self):
-        value = "My string to hash"
-        digest = scrypt(value, self.salt)
-        digest2 = scrypt(value, self.salt)
-        assert digest == digest2
+    def test_hashing_returns_same_with_same_value_and_same_salt(self):
+        digest1 = scrypt(self.value1, self.salt)
+        digest2 = scrypt(self.value1, self.salt)
+        assert digest1 == digest2
 
     def test_hashing_returns_different_with_different_salt_and_same_value(self):
-        value = "My string to hash"
-        digest = scrypt(value, self.salt)
-        digest2 = scrypt(value, "another salt")
-        assert digest != digest2
+        digest1 = scrypt(self.value1, self.salt)
+        digest2 = scrypt(self.value1, "another salt")
+        assert digest1 != digest2
 
     def test_hashing_returns_different_with_different_value_and_same_salt(self):
-        value1 = "My string to hash."
-        value2 = "Another string."
-        digest = scrypt(value1, self.salt)
-        digest2 = scrypt(value2, self.salt)
-        assert digest != digest2
+        digest1 = scrypt(self.value1, self.salt)
+        digest2 = scrypt(self.value2, self.salt)
+        assert digest1 != digest2
+
+    def test_hashing_output_has_equal_length_for_different_input(self):
+        digest1 = scrypt(self.value1, self.salt)
+        digest2 = scrypt(self.value2, self.salt)
+        assert len(digest1) == len(digest2)
+
+    def test_hashing_output_not_contain_the_values_or_salt(self):
+        digest = scrypt(self.value1, self.salt)
+        assert self.value1 not in digest
+        assert self.salt not in digest


### PR DESCRIPTION
## What does this pull request change?

Was digging through unit tests, and found hasing testing to be incomplete. 
- It did only test that equal values with the same salt returned the same hash. 


1. I added the negative test, that for different salts and values, the hash should _not_ be equal. 
3. Test that the output of the salting has the same length, for different input
4. Test that the output does not contain the values or the salt, so that it _actually_ is hashed. 

## Why is this pull request needed?

## Issues related to this change:
