### PR TITLE
test: be explicit about which SIMOS blueprints are allowed in test-data

### DIFF
--- a/src/tests/unit/mock_data/mock_blueprint_provider.py
+++ b/src/tests/unit/mock_data/mock_blueprint_provider.py
@@ -39,8 +39,19 @@ class BlueprintProvider:
         ]:
             with open(_FILE_PATH + type + ".blueprint.json") as f:
                 return Blueprint(json.load(f), type)
-        else:
+        if type in [
+            "dmss://system/SIMOS/AttributeTypes",
+            "dmss://system/SIMOS/Blob",
+            "dmss://system/SIMOS/Blueprint",
+            "dmss://system/SIMOS/BlueprintAttribute",
+            "dmss://system/SIMOS/NamedEntity",
+            "dmss://system/SIMOS/Package",
+            "dmss://system/SIMOS/Reference",
+        ]:
             return Blueprint(file_repository_test.get(type), type)
+        raise FileNotFoundError(
+            f"Invalid type {type} provided to the MockBlueprintProvider. No such blueprint found in the test data."
+        )
 
 
 blueprint_provider = BlueprintProvider()

--- a/src/tests/unit/test_tree_functionality/mock_data_for_tree_tests/mock_blueprint_provider_for_tree_tests.py
+++ b/src/tests/unit/test_tree_functionality/mock_data_for_tree_tests/mock_blueprint_provider_for_tree_tests.py
@@ -39,8 +39,9 @@ class BlueprintProvider:
                 return Blueprint(json.load(f), type)
         if type in ["dmss://system/SIMOS/Reference", "dmss://system/SIMOS/Package", "dmss://system/SIMOS/NamedEntity"]:
             return Blueprint(file_repository_test.get(type), type)
-
-        raise Exception(f"Invalid type {type}")
+        raise FileNotFoundError(
+            f"Invalid type {type} provided to the MockBlueprintProvider. No such blueprint found in the test data."
+        )
 
 
 blueprint_provider = BlueprintProvider()


### PR DESCRIPTION
## What does this pull request change?

The unit tests refer sometimes to the CORE SIMOS blueprints.
This is now required to be set explicit in order to make it more readable what blueprints are accessed in the tests. 

It it is not found, then it retuns a `FileNotFoundError`, which is the same as is returned from the real BlueprintProvider. 

## Why is this pull request needed?

## Issues related to this change:

#495
