### PR TITLE
test: split up two tests into two classes

### DIFF
--- a/src/tests/unit/test_tree_functionality/test_tree_node_from_dict.py
+++ b/src/tests/unit/test_tree_functionality/test_tree_node_from_dict.py
@@ -1,20 +1,11 @@
 import json
 import unittest
 
-from common.tree_node_serializer import (
-    tree_node_from_dict,
-    tree_node_to_dict,
-    tree_node_to_ref_dict,
-)
+from common.tree_node_serializer import tree_node_from_dict, tree_node_to_dict
 from common.utils.data_structure.compare import get_and_print_diff
-from domain_classes.blueprint_attribute import BlueprintAttribute
-from domain_classes.tree_node import ListNode, Node
 from enums import REFERENCE_TYPES, SIMOS
 from tests.unit.test_tree_functionality.mock_data_for_tree_tests.mock_blueprint_provider_for_tree_tests import (
     BlueprintProvider,
-)
-from tests.unit.test_tree_functionality.mock_data_for_tree_tests.mock_document_service_for_tree_tests import (
-    mock_document_service,
 )
 from tests.unit.test_tree_functionality.mock_data_for_tree_tests.mock_storage_recipe_provider import (
     mock_storage_recipe_provider,
@@ -219,75 +210,6 @@ class TreeNodeFromDictTestCase(unittest.TestCase):
         assert "aOptionalNestedObject" not in doc and "aOptionalNestedObject" not in tree_node_to_dict(root)
         assert "optionalNumberList" not in doc and "optionalNumberList" not in tree_node_to_dict(root)
         assert "optionalObjectList" not in doc and "optionalObjectList" not in tree_node_to_dict(root)
-
-    def test_tree_node_to_ref_dict(self):
-        # Arrange
-        engine_package_content_bp_attribute = BlueprintAttribute(
-            name="content", attribute_type="object", type="dmss://system/SIMOS/BlueprintAttribute"
-        )
-        engine_entity_ref = {
-            "address": "$123",
-            "type": SIMOS.REFERENCE.value,
-            "referenceType": REFERENCE_TYPES.LINK.value,
-        }
-
-        engine_package_entity = {
-            "_id": "26d94353-3ff0-4b7d-bf06-86f006dd6f7b",
-            "type": "dmss://system/SIMOS/Package",
-            "name": "EnginePackage",
-            "isRoot": False,
-            "content": [engine_entity_ref],
-        }
-        engine_package_blueprint_attribute = BlueprintAttribute(
-            name="Package",
-            attribute_type="dmss://system/SIMOS/Package",
-            type="dmss://system/SIMOS/BlueprintAttribute",
-        )
-        engine_package_node = Node(
-            key="Package",
-            entity=engine_package_entity,
-            attribute=engine_package_blueprint_attribute,
-            blueprint_provider=mock_document_service.get_blueprint,
-            recipe_provider=None,
-        )
-
-        engine_blueprint_attribute = BlueprintAttribute(
-            name="content",
-            attribute_type=SIMOS.REFERENCE.value,
-            type="dmss://system/SIMOS/BlueprintAttribute",
-            contained=False,
-        )
-        engine_ref_node = Node(
-            key="0",
-            entity=engine_entity_ref,
-            attribute=engine_blueprint_attribute,
-            blueprint_provider=mock_document_service.get_blueprint,
-            recipe_provider=None,
-            uid=engine_entity_ref["address"],
-        )
-
-        content = ListNode(
-            key="content",
-            attribute=engine_package_content_bp_attribute,
-            entity=[engine_entity_ref],
-            blueprint_provider=None,
-            recipe_provider=None,
-        )
-        content.children = [engine_ref_node]
-        engine_package_node.children = [content]
-
-        content.parent = engine_package_node
-        engine_ref_node.parent = content.children[0]
-
-        # Act
-        engine_package_dict = tree_node_to_ref_dict(engine_package_node)
-
-        # Assert
-        assert engine_package_dict["content"][0] == {
-            "address": "$123",
-            "type": SIMOS.REFERENCE.value,
-            "referenceType": REFERENCE_TYPES.LINK.value,
-        }
 
     def test_recursive_from_dict(self):
         document_1 = {"_id": "1", "name": "Parent", "description": "", "type": "Recursive", "im_me!": {}}

--- a/src/tests/unit/test_tree_functionality/test_tree_node_to_dict.py
+++ b/src/tests/unit/test_tree_functionality/test_tree_node_to_dict.py
@@ -1,12 +1,8 @@
 import unittest
 
-from common.tree_node_serializer import tree_node_to_dict, tree_node_to_ref_dict
+from common.tree_node_serializer import tree_node_to_dict
 from domain_classes.blueprint_attribute import BlueprintAttribute
 from domain_classes.tree_node import ListNode, Node
-from enums import REFERENCE_TYPES, SIMOS
-from tests.unit.test_tree_functionality.mock_data_for_tree_tests.get_node_for_tree_tests import (
-    get_form_example_node,
-)
 from tests.unit.test_tree_functionality.mock_data_for_tree_tests.mock_blueprint_provider_for_tree_tests import (
     BlueprintProvider,
 )
@@ -117,7 +113,6 @@ class TreeNodeToDictTestCase(unittest.TestCase):
             },
             "list": [{"name": "Item1", "description": "", "type": "Garden"}],
         }
-
         self.assertEqual(actual_root, tree_node_to_dict(root))
 
         actual_nested = {
@@ -137,76 +132,6 @@ class TreeNodeToDictTestCase(unittest.TestCase):
         item_1_actual = {"name": "Item1", "description": "", "type": "Garden"}
 
         self.assertEqual(item_1_actual, tree_node_to_dict(item_1))
-
-    def test_tree_node_to_ref_dict_2(self):
-        form_node = get_form_example_node()
-        form_dict = tree_node_to_ref_dict(form_node)
-        assert form_dict["inputEntity"] == {
-            "type": SIMOS.REFERENCE.value,
-            "referenceType": REFERENCE_TYPES.LINK.value,
-            "address": "dmss://DemoDataSource/$product1",
-        }
-        # Check that optional attributes that don't exist on the node entity are not added by tree_node_to_ref_dict()
-        assert "aOptionalNestedObject" not in form_node.entity and "aOptionalNestedObject" not in form_dict
-
-    def test_tree_node_to_ref_dict_for_references(self):
-        reference_1 = {
-            "address": "$22",
-            "type": SIMOS.REFERENCE.value,
-            "referenceType": REFERENCE_TYPES.LINK.value,
-        }
-        reference_2 = {
-            "address": "$33",
-            "type": SIMOS.REFERENCE.value,
-            "referenceType": REFERENCE_TYPES.LINK.value,
-        }
-        uncontained_in_every_way = [reference_1, reference_2]
-        document = {
-            "_id": "1",
-            "name": "Parent",
-            "description": "",
-            "type": "uncontained_list_blueprint",
-            "uncontained_in_every_way": [reference_1, reference_2],
-        }
-
-        parent_node: Node = Node(
-            recipe_provider=mock_storage_recipe_provider,
-            key="",
-            uid="1",
-            entity=document,
-            blueprint_provider=BlueprintProvider.get_blueprint,
-            attribute=BlueprintAttribute(name="", attribute_type="uncontained_list_blueprint"),
-        )
-        uncontained_in_every_way_node = ListNode(
-            recipe_provider=mock_storage_recipe_provider,
-            key="uncontained_in_every_way",
-            uid="1.uncontained_in_every_way",
-            entity=uncontained_in_every_way,
-            blueprint_provider=BlueprintProvider.get_blueprint,
-            attribute=BlueprintAttribute(name="", attribute_type="Garden"),
-        )
-        reference_1_node = Node(
-            recipe_provider=mock_storage_recipe_provider,
-            key="0",
-            uid="1.uncontained_in_every_way.0",
-            entity=reference_1,
-            blueprint_provider=BlueprintProvider.get_blueprint,
-            attribute=BlueprintAttribute(name="", attribute_type="dmss://system/SIMOS/Reference"),
-        )
-        reference_2_node = Node(
-            recipe_provider=mock_storage_recipe_provider,
-            key="1",
-            uid="1.uncontained_in_every_way.1",
-            entity=reference_2,
-            blueprint_provider=BlueprintProvider.get_blueprint,
-            attribute=BlueprintAttribute(name="", attribute_type="dmss://system/SIMOS/Reference"),
-        )
-        uncontained_in_every_way_node.children.append(reference_1_node)
-        uncontained_in_every_way_node.children.append(reference_2_node)
-        parent_node.children.append(uncontained_in_every_way_node)
-        parent_document = tree_node_to_ref_dict(parent_node)
-        assert parent_document["uncontained_in_every_way"][0] == reference_1
-        assert parent_document["uncontained_in_every_way"][1] == reference_2
 
 
 if __name__ == "__main__":

--- a/src/tests/unit/test_tree_functionality/test_tree_node_to_ref_dict.py
+++ b/src/tests/unit/test_tree_functionality/test_tree_node_to_ref_dict.py
@@ -10,12 +10,84 @@ from tests.unit.test_tree_functionality.mock_data_for_tree_tests.get_node_for_tr
 from tests.unit.test_tree_functionality.mock_data_for_tree_tests.mock_blueprint_provider_for_tree_tests import (
     BlueprintProvider,
 )
+from tests.unit.test_tree_functionality.mock_data_for_tree_tests.mock_document_service_for_tree_tests import (
+    mock_document_service,
+)
 from tests.unit.test_tree_functionality.mock_data_for_tree_tests.mock_storage_recipe_provider import (
     mock_storage_recipe_provider,
 )
 
 
 class TreeNodeToRefDictTestCase(unittest.TestCase):
+    def test_tree_node_to_ref_dict(self):
+        # Arrange
+        engine_package_content_bp_attribute = BlueprintAttribute(
+            name="content", attribute_type="object", type="dmss://system/SIMOS/BlueprintAttribute"
+        )
+        engine_entity_ref = {
+            "address": "$123",
+            "type": SIMOS.REFERENCE.value,
+            "referenceType": REFERENCE_TYPES.LINK.value,
+        }
+
+        engine_package_entity = {
+            "_id": "26d94353-3ff0-4b7d-bf06-86f006dd6f7b",
+            "type": "dmss://system/SIMOS/Package",
+            "name": "EnginePackage",
+            "isRoot": False,
+            "content": [engine_entity_ref],
+        }
+        engine_package_blueprint_attribute = BlueprintAttribute(
+            name="Package",
+            attribute_type="dmss://system/SIMOS/Package",
+            type="dmss://system/SIMOS/BlueprintAttribute",
+        )
+        engine_package_node = Node(
+            key="Package",
+            entity=engine_package_entity,
+            attribute=engine_package_blueprint_attribute,
+            blueprint_provider=mock_document_service.get_blueprint,
+            recipe_provider=None,
+        )
+
+        engine_blueprint_attribute = BlueprintAttribute(
+            name="content",
+            attribute_type=SIMOS.REFERENCE.value,
+            type="dmss://system/SIMOS/BlueprintAttribute",
+            contained=False,
+        )
+        engine_ref_node = Node(
+            key="0",
+            entity=engine_entity_ref,
+            attribute=engine_blueprint_attribute,
+            blueprint_provider=mock_document_service.get_blueprint,
+            recipe_provider=None,
+            uid=engine_entity_ref["address"],
+        )
+
+        content = ListNode(
+            key="content",
+            attribute=engine_package_content_bp_attribute,
+            entity=[engine_entity_ref],
+            blueprint_provider=None,
+            recipe_provider=None,
+        )
+        content.children = [engine_ref_node]
+        engine_package_node.children = [content]
+
+        content.parent = engine_package_node
+        engine_ref_node.parent = content.children[0]
+
+        # Act
+        engine_package_dict = tree_node_to_ref_dict(engine_package_node)
+
+        # Assert
+        assert engine_package_dict["content"][0] == {
+            "address": "$123",
+            "type": SIMOS.REFERENCE.value,
+            "referenceType": REFERENCE_TYPES.LINK.value,
+        }
+
     def test_tree_node_to_ref_dict_2(self):
         form_node = get_form_example_node()
         form_dict = tree_node_to_ref_dict(form_node)

--- a/src/tests/unit/test_tree_functionality/test_tree_node_to_ref_dict.py
+++ b/src/tests/unit/test_tree_functionality/test_tree_node_to_ref_dict.py
@@ -1,0 +1,91 @@
+import unittest
+
+from common.tree_node_serializer import tree_node_to_ref_dict
+from domain_classes.blueprint_attribute import BlueprintAttribute
+from domain_classes.tree_node import ListNode, Node
+from enums import REFERENCE_TYPES, SIMOS
+from tests.unit.test_tree_functionality.mock_data_for_tree_tests.get_node_for_tree_tests import (
+    get_form_example_node,
+)
+from tests.unit.test_tree_functionality.mock_data_for_tree_tests.mock_blueprint_provider_for_tree_tests import (
+    BlueprintProvider,
+)
+from tests.unit.test_tree_functionality.mock_data_for_tree_tests.mock_storage_recipe_provider import (
+    mock_storage_recipe_provider,
+)
+
+
+class TreeNodeToRefDictTestCase(unittest.TestCase):
+    def test_tree_node_to_ref_dict_2(self):
+        form_node = get_form_example_node()
+        form_dict = tree_node_to_ref_dict(form_node)
+        assert form_dict["inputEntity"] == {
+            "type": SIMOS.REFERENCE.value,
+            "referenceType": REFERENCE_TYPES.LINK.value,
+            "address": "dmss://DemoDataSource/$product1",
+        }
+        # Check that optional attributes that don't exist on the node entity are not added by tree_node_to_ref_dict()
+        assert "aOptionalNestedObject" not in form_node.entity and "aOptionalNestedObject" not in form_dict
+
+    def test_tree_node_to_ref_dict_for_references(self):
+        reference_1 = {
+            "address": "$22",
+            "type": SIMOS.REFERENCE.value,
+            "referenceType": REFERENCE_TYPES.LINK.value,
+        }
+        reference_2 = {
+            "address": "$33",
+            "type": SIMOS.REFERENCE.value,
+            "referenceType": REFERENCE_TYPES.LINK.value,
+        }
+        uncontained_in_every_way = [reference_1, reference_2]
+        document = {
+            "_id": "1",
+            "name": "Parent",
+            "description": "",
+            "type": "uncontained_list_blueprint",
+            "uncontained_in_every_way": [reference_1, reference_2],
+        }
+
+        parent_node: Node = Node(
+            recipe_provider=mock_storage_recipe_provider,
+            key="",
+            uid="1",
+            entity=document,
+            blueprint_provider=BlueprintProvider.get_blueprint,
+            attribute=BlueprintAttribute(name="", attribute_type="uncontained_list_blueprint"),
+        )
+        uncontained_in_every_way_node = ListNode(
+            recipe_provider=mock_storage_recipe_provider,
+            key="uncontained_in_every_way",
+            uid="1.uncontained_in_every_way",
+            entity=uncontained_in_every_way,
+            blueprint_provider=BlueprintProvider.get_blueprint,
+            attribute=BlueprintAttribute(name="", attribute_type="Garden"),
+        )
+        reference_1_node = Node(
+            recipe_provider=mock_storage_recipe_provider,
+            key="0",
+            uid="1.uncontained_in_every_way.0",
+            entity=reference_1,
+            blueprint_provider=BlueprintProvider.get_blueprint,
+            attribute=BlueprintAttribute(name="", attribute_type="dmss://system/SIMOS/Reference"),
+        )
+        reference_2_node = Node(
+            recipe_provider=mock_storage_recipe_provider,
+            key="1",
+            uid="1.uncontained_in_every_way.1",
+            entity=reference_2,
+            blueprint_provider=BlueprintProvider.get_blueprint,
+            attribute=BlueprintAttribute(name="", attribute_type="dmss://system/SIMOS/Reference"),
+        )
+        uncontained_in_every_way_node.children.append(reference_1_node)
+        uncontained_in_every_way_node.children.append(reference_2_node)
+        parent_node.children.append(uncontained_in_every_way_node)
+        parent_document = tree_node_to_ref_dict(parent_node)
+        assert parent_document["uncontained_in_every_way"][0] == reference_1
+        assert parent_document["uncontained_in_every_way"][1] == reference_2
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What does this pull request change?

❗️No code changes. 

🖖 Split a testing class into two testing classes, as they were testing two different methods, and shared no data
- `tree_node_to_dict`
- `tree_node_to_ref_dict`

➡️ Moved a method `test_tree_node_to_ref_dict()`, which was in `test_from_dict.py` into the correct file

## Why is this pull request needed?

🧘‍♀️ Calm and tranquility, readability, sensibility, and .. affordability(?)

## Issues related to this change:

#495 
