### PR TITLE
test: made simos blueprints explicit

### DIFF
--- a/src/tests/unit/common/utils/resolve_address/test_resolve_address.py
+++ b/src/tests/unit/common/utils/resolve_address/test_resolve_address.py
@@ -8,6 +8,7 @@ from common.address import Address
 from common.exceptions import ApplicationException, NotFoundException
 from common.utils.resolve_address import resolve_address
 from enums import REFERENCE_TYPES, SIMOS
+from tests.unit.mock_data.mock_blueprint_provider import MockBlueprintProvider
 from tests.unit.mock_data.mock_document_service import get_mock_document_service
 
 
@@ -78,7 +79,11 @@ class ResolveReferenceTestCase(unittest.TestCase):
         self.document_repository.name = "datasource"
         self.document_repository.get = self.mock_get
         self.document_repository.find = self.mock_find
-        self.document_service = get_mock_document_service(lambda x, y: self.document_repository)
+        simos_blueprints = []
+        mock_blueprint_provider = MockBlueprintProvider(simos_blueprints_available_for_test=simos_blueprints)
+        self.document_service = get_mock_document_service(
+            repository_provider=lambda x, y: self.document_repository, blueprint_provider=mock_blueprint_provider
+        )
 
     def mock_get(self, document_id: str):
         if document_id == "car_rental_company_id":

--- a/src/tests/unit/common/utils/test_create_entity.py
+++ b/src/tests/unit/common/utils/test_create_entity.py
@@ -2,17 +2,19 @@ import unittest
 
 from common.utils.create_entity import CreateEntity
 from domain_classes.blueprint_attribute import BlueprintAttribute
-from storage.repositories.file import LocalFileRepository
+from tests.unit.mock_data.mock_blueprint_provider import MockBlueprintProvider
 from tests.unit.mock_data.mock_document_service import get_mock_document_service
-
-file_repository_test = LocalFileRepository()
-
-document_service = get_mock_document_service()
-blueprint_provider = document_service.get_blueprint
 
 
 class CreateEntityTestCase(unittest.TestCase):
     def setUp(self):
+        simos_blueprints = [
+            "dmss://system/SIMOS/AttributeTypes",
+            "dmss://system/SIMOS/BlueprintAttribute",
+            "dmss://system/SIMOS/NamedEntity",
+        ]
+        self.mock_blueprint_provider = MockBlueprintProvider(simos_blueprints_available_for_test=simos_blueprints)
+        self.mock_document_service = get_mock_document_service(blueprint_provider=self.mock_blueprint_provider)
         self.maxDiff = None
 
     def test_blueprint_entity(self):
@@ -41,7 +43,7 @@ class CreateEntityTestCase(unittest.TestCase):
             "stringValues": ["one", "two", "three"],
         }
 
-        entity = CreateEntity(blueprint_provider=blueprint_provider, type="CarTest").entity
+        entity = CreateEntity(blueprint_provider=self.mock_document_service.get_blueprint, type="CarTest").entity
 
         self.assertEqual(expected_entity, entity)
 

--- a/src/tests/unit/common/utils/validators/test_validate_entity.py
+++ b/src/tests/unit/common/utils/validators/test_validate_entity.py
@@ -3,12 +3,20 @@ import unittest
 from common.exceptions import ValidationException
 from common.tree_node_serializer import tree_node_from_dict, tree_node_to_dict
 from common.utils.validators import validate_entity, validate_entity_against_self
+from tests.unit.mock_data.mock_blueprint_provider import MockBlueprintProvider
 from tests.unit.mock_data.mock_document_service import get_mock_document_service
 from tests.unit.mock_data.mock_recipe_provider import mock_storage_recipe_provider
 
 
 class ValidateEntityTestCase(unittest.TestCase):
-    get_blueprint = get_mock_document_service().get_blueprint
+    simos_blueprints = [
+        "dmss://system/SIMOS/Blueprint",
+        "dmss://system/SIMOS/NamedEntity",
+        "dmss://system/SIMOS/BlueprintAttribute",
+    ]
+    mock_blueprint_provider = MockBlueprintProvider(simos_blueprints_available_for_test=simos_blueprints)
+    mock_document_service = get_mock_document_service(blueprint_provider=mock_blueprint_provider)
+    get_blueprint = mock_document_service.get_blueprint
 
     def test_a_simple_valid_entity(self):
         test_entity = {

--- a/src/tests/unit/mock_data/mock_blueprint_provider.py
+++ b/src/tests/unit/mock_data/mock_blueprint_provider.py
@@ -1,16 +1,26 @@
 import json
+from typing import List
 
 from domain_classes.blueprint import Blueprint
 from storage.repositories.file import LocalFileRepository
 
 file_repository_test = LocalFileRepository()
 
-_FILE_PATH = "src/tests/unit/mock_data/mock_blueprints/"
 
+class MockBlueprintProvider:
+    def __init__(
+        self,
+        test_blueprint_data_path: str = "src/tests/unit/mock_data/mock_blueprints",
+        simos_blueprints_available_for_test: List[str] = None,
+    ):
+        if simos_blueprints_available_for_test is None:
+            simos_blueprints_available_for_test = []
+        if test_blueprint_data_path.endswith("/"):
+            test_blueprint_data_path = test_blueprint_data_path[:-1]
+        self.test_blueprint_data_path = test_blueprint_data_path
+        self.simos_blueprints_available_for_test = simos_blueprints_available_for_test
 
-class BlueprintProvider:
-    @staticmethod
-    def get_blueprint(type: str):
+    def get_blueprint(self, type: str):
         if type in [
             "BaseChild",
             "ExtendedBlueprint",
@@ -37,21 +47,10 @@ class BlueprintProvider:
             "Customer",
             "RentalCar",
         ]:
-            with open(_FILE_PATH + type + ".blueprint.json") as f:
+            with open(f"{self.test_blueprint_data_path}/{type}.blueprint.json") as f:
                 return Blueprint(json.load(f), type)
-        if type in [
-            "dmss://system/SIMOS/AttributeTypes",
-            "dmss://system/SIMOS/Blob",
-            "dmss://system/SIMOS/Blueprint",
-            "dmss://system/SIMOS/BlueprintAttribute",
-            "dmss://system/SIMOS/NamedEntity",
-            "dmss://system/SIMOS/Package",
-            "dmss://system/SIMOS/Reference",
-        ]:
+        if type in self.simos_blueprints_available_for_test:
             return Blueprint(file_repository_test.get(type), type)
         raise FileNotFoundError(
             f"Invalid type {type} provided to the MockBlueprintProvider. No such blueprint found in the test data."
         )
-
-
-blueprint_provider = BlueprintProvider()

--- a/src/tests/unit/mock_data/mock_document_service.py
+++ b/src/tests/unit/mock_data/mock_document_service.py
@@ -1,11 +1,10 @@
 from services.document_service import DocumentService
-from tests.unit.mock_data.mock_blueprint_provider import blueprint_provider
 from tests.unit.mock_data.mock_recipe_provider import mock_storage_recipe_provider
 
 
 def get_mock_document_service(
+    blueprint_provider,
     repository_provider=None,
-    blueprint_provider=blueprint_provider,
     recipe_provider=mock_storage_recipe_provider,
     user=None,
     context=None,

--- a/src/tests/unit/services/document_service/test_data_source_and_repositories.py
+++ b/src/tests/unit/services/document_service/test_data_source_and_repositories.py
@@ -7,6 +7,7 @@ from config import config
 from domain_classes.tree_node import Node
 from enums import StorageDataTypes
 from storage.data_source_class import DataSource
+from tests.unit.mock_data.mock_blueprint_provider import MockBlueprintProvider
 from tests.unit.mock_data.mock_document_service import get_mock_document_service
 from tests.unit.mock_data.mock_recipe_provider import mock_storage_recipe_provider
 
@@ -15,6 +16,11 @@ test_user = User(**{"user_id": "unit-test", "full_name": "Unit Test", "email": "
 
 
 class DataSourceTestCase(unittest.TestCase):
+    def setUp(self) -> None:
+        simos_blueprints = ["dmss://system/SIMOS/NamedEntity"]
+        self.mock_blueprint_provider = MockBlueprintProvider(simos_blueprints_available_for_test=simos_blueprints)
+        pass
+
     def test_save_into_multiple_repositories(self):
         uncontained_doc = {
             "name": "Parent",
@@ -67,7 +73,11 @@ class DataSourceTestCase(unittest.TestCase):
             data_source_collection=data_source_collection,
         )
 
-        document_service = get_mock_document_service(lambda x, y: data_source, user=test_user)
+        document_service = get_mock_document_service(
+            repository_provider=lambda x, y: data_source,
+            blueprint_provider=self.mock_blueprint_provider,
+            user=test_user,
+        )
 
         node: Node = tree_node_from_dict(
             uncontained_doc,
@@ -128,7 +138,11 @@ class DataSourceTestCase(unittest.TestCase):
             data_source_collection=data_source_collection,
         )
 
-        document_service = get_mock_document_service(lambda x, y: data_source, user=test_user)
+        document_service = get_mock_document_service(
+            repository_provider=lambda x, y: data_source,
+            blueprint_provider=self.mock_blueprint_provider,
+            user=test_user,
+        )
 
         node: Node = tree_node_from_dict(
             blob_doc,
@@ -194,7 +208,11 @@ class DataSourceTestCase(unittest.TestCase):
             data_source_collection=data_source_collection,
         )
 
-        document_service = get_mock_document_service(lambda x, y: data_source, user=test_user)
+        document_service = get_mock_document_service(
+            repository_provider=lambda x, y: data_source,
+            blueprint_provider=self.mock_blueprint_provider,
+            user=test_user,
+        )
 
         node: Node = tree_node_from_dict(
             blob_doc, document_service.get_blueprint, uid="1", recipe_provider=mock_storage_recipe_provider

--- a/src/tests/unit/services/document_service/test_document_service_get_document.py
+++ b/src/tests/unit/services/document_service/test_document_service_get_document.py
@@ -5,6 +5,7 @@ from common.address import Address
 from common.tree_node_serializer import tree_node_to_dict
 from common.utils.data_structure.compare import get_and_print_diff
 from enums import REFERENCE_TYPES, SIMOS
+from tests.unit.mock_data.mock_blueprint_provider import MockBlueprintProvider
 from tests.unit.mock_data.mock_document_service import get_mock_document_service
 
 
@@ -66,7 +67,12 @@ class GetDocumentInputTestCase(unittest.TestCase):
         self.document_repository.name = "datasource"
         self.document_repository.get = self.mock_get
         self.document_repository.find = self.mock_find
-        self.document_service = get_mock_document_service(lambda x, y: self.document_repository)
+
+        simos_blueprints = ["dmss://system/SIMOS/NamedEntity", "dmss://system/SIMOS/Reference"]
+        mock_blueprint_provider = MockBlueprintProvider(simos_blueprints_available_for_test=simos_blueprints)
+        self.document_service = get_mock_document_service(
+            repository_provider=lambda x, y: self.document_repository, blueprint_provider=mock_blueprint_provider
+        )
 
     def mock_get(self, document_id: str):
         if document_id == "1":

--- a/src/tests/unit/services/document_service/test_get_extended_blueprint.py
+++ b/src/tests/unit/services/document_service/test_get_extended_blueprint.py
@@ -5,19 +5,23 @@ from common.address import Address
 from common.utils.data_structure.compare import get_and_print_diff
 from domain_classes.blueprint import Blueprint
 from domain_classes.tree_node import Node
+from tests.unit.mock_data.mock_blueprint_provider import MockBlueprintProvider
 from tests.unit.mock_data.mock_document_service import get_mock_document_service
 
 
 class GetExtendedBlueprintTestCase(unittest.TestCase):
+    def setUp(self):
+        simos_blueprints = ["dmss://system/SIMOS/NamedEntity"]
+        self.mock_blueprint_provider = MockBlueprintProvider(simos_blueprints_available_for_test=simos_blueprints)
+        self.document_service = get_mock_document_service(blueprint_provider=self.mock_blueprint_provider)
+
     def test_get_simple_extended(self):
-        document_service = get_mock_document_service()
-        full_blueprint: Blueprint = document_service.get_blueprint("ExtendedBlueprint")
+        full_blueprint: Blueprint = self.document_service.get_blueprint("ExtendedBlueprint")
 
         assert next((attr for attr in full_blueprint.attributes if attr.name == "description"), None) is not None
 
     def test_get_second_level_extended(self):
-        document_service = get_mock_document_service()
-        full_blueprint: Blueprint = document_service.get_blueprint("SecondLevelExtendedBlueprint")
+        full_blueprint: Blueprint = self.document_service.get_blueprint("SecondLevelExtendedBlueprint")
 
         assert next((attr for attr in full_blueprint.attributes if attr.name == "description"), None) is not None
         assert next((attr for attr in full_blueprint.attributes if attr.name == "another_value"), None) is not None
@@ -51,7 +55,9 @@ class GetExtendedBlueprintTestCase(unittest.TestCase):
 
         repository.get = lambda doc_id: doc_storage[doc_id]
         repository.update = mock_update
-        document_service = get_mock_document_service(lambda x, y: repository)
+        document_service = get_mock_document_service(
+            repository_provider=lambda x, y: repository, blueprint_provider=self.mock_blueprint_provider
+        )
 
         node: Node = document_service.get_document(Address.from_absolute("testing/$1"))
         node.update(doc_1_after)

--- a/src/tests/unit/services/document_service/test_save.py
+++ b/src/tests/unit/services/document_service/test_save.py
@@ -11,10 +11,16 @@ from enums import REFERENCE_TYPES, SIMOS
 from features.document.use_cases.update_document_use_case import (
     update_document_use_case,
 )
+from tests.unit.mock_data.mock_blueprint_provider import MockBlueprintProvider
 from tests.unit.mock_data.mock_document_service import get_mock_document_service
 
 
 class DocumentServiceTestCase(unittest.TestCase):
+    def setUp(self) -> None:
+        simos_blueprints = ["dmss://system/SIMOS/NamedEntity", "dmss://system/SIMOS/Reference"]
+        self.mock_blueprint_provider = MockBlueprintProvider(simos_blueprints_available_for_test=simos_blueprints)
+        self.document_service = get_mock_document_service(blueprint_provider=self.mock_blueprint_provider)
+
     def test_save_update(self):
         repository = mock.Mock()
 
@@ -45,8 +51,10 @@ class DocumentServiceTestCase(unittest.TestCase):
 
         repository.get = mock_get
         repository.update = mock_update
-        document_service = get_mock_document_service(lambda x, y: repository)
 
+        document_service = get_mock_document_service(
+            repository_provider=lambda x, y: repository, blueprint_provider=self.mock_blueprint_provider
+        )
         node: Node = document_service.get_document(Address("$1", "testing"))
         contained_node: Node = node.get_by_path("references.1".split("."))
         contained_node.update({"_id": "4", "name": "ref2", "description": "TEST_MODIFY", "type": "basic_blueprint"})
@@ -81,7 +89,9 @@ class DocumentServiceTestCase(unittest.TestCase):
 
         repository.get = mock_get
         repository.update = mock_update
-        document_service = get_mock_document_service(lambda x, y: repository)
+        document_service = get_mock_document_service(
+            repository_provider=lambda x, y: repository, blueprint_provider=self.mock_blueprint_provider
+        )
 
         contained_node: Node = document_service.get_document(Address("$1.nested", "testing"))
         contained_node.update({"name": "RENAMED", "description": "TEST_MODIFY", "type": "basic_blueprint"})
@@ -115,7 +125,9 @@ class DocumentServiceTestCase(unittest.TestCase):
         repository.get = mock_get
         repository.update = mock_update
 
-        document_service = get_mock_document_service(lambda x, y: repository)
+        document_service = get_mock_document_service(
+            repository_provider=lambda x, y: repository, blueprint_provider=self.mock_blueprint_provider
+        )
 
         node: Node = document_service.get_document(Address("$1", "testing"))
         contained_node: Node = node.search("1.references")
@@ -195,7 +207,9 @@ class DocumentServiceTestCase(unittest.TestCase):
             if data_source_id == "testing":
                 return repository
 
-        document_service = get_mock_document_service(repository_provider)
+        document_service = get_mock_document_service(
+            repository_provider=repository_provider, blueprint_provider=self.mock_blueprint_provider
+        )
 
         node: Node = document_service.get_document(Address("$1", "testing"))
         contained_node: Node = node.search("1.references")
@@ -245,7 +259,9 @@ class DocumentServiceTestCase(unittest.TestCase):
         repository.get = lambda id: doc_storage[id]
         repository.update = mock_update
 
-        document_service = get_mock_document_service(lambda x, y: repository)
+        document_service = get_mock_document_service(
+            repository_provider=lambda x, y: repository, blueprint_provider=self.mock_blueprint_provider
+        )
 
         # Testing updating the reference
         node: Node = document_service.get_document(Address("$1", "testing"))
@@ -292,7 +308,9 @@ class DocumentServiceTestCase(unittest.TestCase):
         repository.get = lambda id: deepcopy(doc_storage[id])
         repository.update = mock_update
 
-        document_service = get_mock_document_service(lambda x, y: repository)
+        document_service = get_mock_document_service(
+            repository_provider=lambda x, y: repository, blueprint_provider=self.mock_blueprint_provider
+        )
 
         data = {
             "_id": "1",
@@ -348,7 +366,9 @@ class DocumentServiceTestCase(unittest.TestCase):
 
         repository.get = mock_get
         repository.update = mock_update
-        document_service = get_mock_document_service(lambda x, y: repository)
+        document_service = get_mock_document_service(
+            repository_provider=lambda x, y: repository, blueprint_provider=self.mock_blueprint_provider
+        )
         new_data = {
             "name": "A-contained_attribute",
             "type": "all_contained_cases_blueprint",

--- a/src/tests/unit/services/document_service/test_update_document_complex_arrays.py
+++ b/src/tests/unit/services/document_service/test_update_document_complex_arrays.py
@@ -120,7 +120,9 @@ class ArraysDocumentServiceTestCase(unittest.TestCase):
             if data_source_id == "testing":
                 return document_repository
 
-        document_service = get_mock_document_service(repository_provider, blueprint_provider=blueprint_provider)
+        document_service = get_mock_document_service(
+            repository_provider=repository_provider, blueprint_provider=blueprint_provider
+        )
         document_service.add_document(
             data_source_id="testing",
             parent_id="1",
@@ -266,7 +268,9 @@ class ArraysDocumentServiceTestCase(unittest.TestCase):
             if data_source_id == "testing":
                 return document_repository
 
-        document_service = get_mock_document_service(repository_provider, blueprint_provider=blueprint_provider)
+        document_service = get_mock_document_service(
+            repository_provider=repository_provider, blueprint_provider=blueprint_provider
+        )
         # fmt: off
         data = {
             "_id": "1",

--- a/src/tests/unit/use_cases/test_check_existence.py
+++ b/src/tests/unit/use_cases/test_check_existence.py
@@ -6,6 +6,7 @@ from common.address import Address
 from features.document.use_cases.check_exsistence_use_case import (
     check_existence_use_case,
 )
+from tests.unit.mock_data.mock_blueprint_provider import MockBlueprintProvider
 from tests.unit.mock_data.mock_document_service import get_mock_document_service
 
 
@@ -21,7 +22,12 @@ class CheckExistenceTestCase(unittest.TestCase):
         self.repository = mock.Mock()
         self.repository.get = self.mock_get
         self.repository.delete = self.mock_delete
-        self.document_service = get_mock_document_service(lambda x, y: self.repository)
+
+        simos_blueprints = ["dmss://system/SIMOS/NamedEntity"]
+        mock_blueprint_provider = MockBlueprintProvider(simos_blueprints_available_for_test=simos_blueprints)
+        self.document_service = get_mock_document_service(
+            repository_provider=lambda x, y: self.repository, blueprint_provider=mock_blueprint_provider
+        )
 
     def mock_get(self, document_id: str):
         return deepcopy(self.storage.get(document_id))

--- a/src/tests/unit/use_cases/test_reference.py
+++ b/src/tests/unit/use_cases/test_reference.py
@@ -9,10 +9,15 @@ from features.document.use_cases.add_document_use_case import add_document_use_c
 from features.document.use_cases.update_document_use_case import (
     update_document_use_case,
 )
+from tests.unit.mock_data.mock_blueprint_provider import MockBlueprintProvider
 from tests.unit.mock_data.mock_document_service import get_mock_document_service
 
 
 class ReferenceTestCase(unittest.TestCase):
+    def setUp(self) -> None:
+        simos_blueprints = ["dmss://system/SIMOS/NamedEntity", "dmss://system/SIMOS/Reference"]
+        self.mock_blueprint_provider = MockBlueprintProvider(simos_blueprints_available_for_test=simos_blueprints)
+
     def test_insert_reference(self):
         repository = mock.Mock()
 
@@ -42,7 +47,9 @@ class ReferenceTestCase(unittest.TestCase):
 
         repository.get = lambda x: doc_storage[str(x)]
         repository.update = mock_update
-        document_service = get_mock_document_service(lambda x, y: repository)
+        document_service = get_mock_document_service(
+            repository_provider=lambda x, y: repository, blueprint_provider=self.mock_blueprint_provider
+        )
         reference = {
             "address": "$2d7c3249-985d-43d2-83cf-a887e440825a",
             "type": SIMOS.REFERENCE.value,
@@ -87,7 +94,9 @@ class ReferenceTestCase(unittest.TestCase):
 
         repository.get = mock_get
         repository.update = mock_update
-        document_service = get_mock_document_service(lambda x, y: repository)
+        document_service = get_mock_document_service(
+            repository_provider=lambda x, y: repository, blueprint_provider=self.mock_blueprint_provider
+        )
 
         reference_entity = {
             "address": "$2d7c3249-985d-43d2-83cf-a887e440825a",
@@ -130,7 +139,9 @@ class ReferenceTestCase(unittest.TestCase):
 
         repository.get = mock_get
         repository.update = mock_update
-        document_service = get_mock_document_service(lambda x, y: repository)
+        document_service = get_mock_document_service(
+            repository_provider=lambda x, y: repository, blueprint_provider=self.mock_blueprint_provider
+        )
 
         reference_entity_with_missing_attribute = {"address": "$123", "type": SIMOS.REFERENCE.value}
         with self.assertRaises(ValidationException):
@@ -170,7 +181,9 @@ class ReferenceTestCase(unittest.TestCase):
 
         repository.get = lambda id: doc_storage[id]
         repository.update = mock_update
-        document_service = get_mock_document_service(lambda x, y: repository)
+        document_service = get_mock_document_service(
+            repository_provider=lambda x, y: repository, blueprint_provider=self.mock_blueprint_provider
+        )
 
         self.assertRaises(
             ValidationException, document_service.remove, Address("$1.uncontained_in_every_way", "testing")
@@ -211,7 +224,9 @@ class ReferenceTestCase(unittest.TestCase):
 
         repository.get = lambda id: doc_storage[id]
         repository.update = mock_update
-        document_service = get_mock_document_service(lambda x, y: repository)
+        document_service = get_mock_document_service(
+            repository_provider=lambda x, y: repository, blueprint_provider=self.mock_blueprint_provider
+        )
 
         self.assertRaises(
             ValidationException,
@@ -258,7 +273,9 @@ class ReferenceTestCase(unittest.TestCase):
 
         repository.get = lambda x: doc_storage[str(x)]
         repository.update = mock_update
-        document_service = get_mock_document_service(lambda x, y: repository)
+        document_service = get_mock_document_service(
+            repository_provider=lambda x, y: repository, blueprint_provider=self.mock_blueprint_provider
+        )
 
         self.assertRaises(
             ValidationException, document_service.remove, Address("$1.uncontained_in_every_way[0]", "testing")
@@ -298,7 +315,9 @@ class ReferenceTestCase(unittest.TestCase):
 
         repository.get = lambda x: doc_storage[str(x)]
         repository.update = mock_update
-        document_service = get_mock_document_service(lambda x, y: repository)
+        document_service = get_mock_document_service(
+            repository_provider=lambda x, y: repository, blueprint_provider=self.mock_blueprint_provider
+        )
         reference = {
             "address": "$42dbe4a5-0eb0-4ee2-826c-695172c3c35a",
             "type": SIMOS.REFERENCE.value,


### PR DESCRIPTION
## What does this pull request change?

In order to make it very clear what CORE: blueprints are accessed in the tests, the `MockBlueprintProvider( )` class is modified to take a list of available simos blueprints as a parameter. 

This is one step on the way to making the mocker be data-less, taking all data as parameters. 
The end goal is that the mocker does not know any data, only gets data as parameters, so the tests themselves provide the data explicitly. 

Many tests are now modified to facilitate this change

## Why is this pull request needed?

## Issues related to this change:

#495 
