### PR TITLE
test: made simos blueprints explicit

### DIFF
--- a/src/tests/unit/services/document_service/test_data_source_and_repositories.py
+++ b/src/tests/unit/services/document_service/test_data_source_and_repositories.py
@@ -18,8 +18,8 @@ test_user = User(**{"user_id": "unit-test", "full_name": "Unit Test", "email": "
 class DataSourceTestCase(unittest.TestCase):
     def setUp(self) -> None:
         simos_blueprints = ["dmss://system/SIMOS/NamedEntity"]
-        self.mock_blueprint_provider = MockBlueprintProvider(simos_blueprints_available_for_test=simos_blueprints)
-        pass
+        mock_blueprint_provider = MockBlueprintProvider(simos_blueprints_available_for_test=simos_blueprints)
+        self.mock_document_service = get_mock_document_service(blueprint_provider=mock_blueprint_provider)
 
     def test_save_into_multiple_repositories(self):
         uncontained_doc = {
@@ -73,20 +73,17 @@ class DataSourceTestCase(unittest.TestCase):
             data_source_collection=data_source_collection,
         )
 
-        document_service = get_mock_document_service(
-            repository_provider=lambda x, y: data_source,
-            blueprint_provider=self.mock_blueprint_provider,
-            user=test_user,
-        )
+        self.mock_document_service.repository_provider = lambda x, y: data_source
+        self.mock_document_service.user = test_user
 
         node: Node = tree_node_from_dict(
             uncontained_doc,
             uid="1",
-            blueprint_provider=document_service.get_blueprint,
+            blueprint_provider=self.mock_document_service.get_blueprint,
             recipe_provider=mock_storage_recipe_provider,
         )
 
-        document_service.save(node, "testing", update_uncontained=True)
+        self.mock_document_service.save(node, "testing", update_uncontained=True)
 
         # Test that both repos gets written into
         assert blob_doc_storage and default_doc_storage
@@ -138,20 +135,17 @@ class DataSourceTestCase(unittest.TestCase):
             data_source_collection=data_source_collection,
         )
 
-        document_service = get_mock_document_service(
-            repository_provider=lambda x, y: data_source,
-            blueprint_provider=self.mock_blueprint_provider,
-            user=test_user,
-        )
+        self.mock_document_service.repository_provider = lambda x, y: data_source
+        self.mock_document_service.user = test_user
 
         node: Node = tree_node_from_dict(
             blob_doc,
             uid="1",
-            blueprint_provider=document_service.get_blueprint,
+            blueprint_provider=self.mock_document_service.get_blueprint,
             recipe_provider=mock_storage_recipe_provider,
         )
 
-        document_service.save(node, "testing")
+        self.mock_document_service.save(node, "testing")
 
         # Test that only the blob storage is written into
         assert blob_doc_storage and not default_doc_storage
@@ -207,18 +201,14 @@ class DataSourceTestCase(unittest.TestCase):
             repositories={"default": default_repo, "blob": blob_repo},
             data_source_collection=data_source_collection,
         )
-
-        document_service = get_mock_document_service(
-            repository_provider=lambda x, y: data_source,
-            blueprint_provider=self.mock_blueprint_provider,
-            user=test_user,
-        )
+        self.mock_document_service.repository_provider = lambda x, y: data_source
+        self.mock_document_service.user = test_user
 
         node: Node = tree_node_from_dict(
-            blob_doc, document_service.get_blueprint, uid="1", recipe_provider=mock_storage_recipe_provider
+            blob_doc, self.mock_document_service.get_blueprint, uid="1", recipe_provider=mock_storage_recipe_provider
         )
 
-        document_service.save(node, "testing", update_uncontained=True)
+        self.mock_document_service.save(node, "testing", update_uncontained=True)
 
         # Test that both repos gets written into
         assert blob_doc_storage and default_doc_storage

--- a/src/tests/unit/services/document_service/test_get_extended_blueprint.py
+++ b/src/tests/unit/services/document_service/test_get_extended_blueprint.py
@@ -55,12 +55,11 @@ class GetExtendedBlueprintTestCase(unittest.TestCase):
 
         repository.get = lambda doc_id: doc_storage[doc_id]
         repository.update = mock_update
-        document_service = get_mock_document_service(
-            repository_provider=lambda x, y: repository, blueprint_provider=self.mock_blueprint_provider
-        )
 
-        node: Node = document_service.get_document(Address.from_absolute("testing/$1"))
+        self.document_service.repository_provider = lambda x, y: repository
+
+        node: Node = self.document_service.get_document(Address.from_absolute("testing/$1"))
         node.update(doc_1_after)
-        document_service.save(node, "testing")
+        self.document_service.save(node, "testing")
 
         assert get_and_print_diff(doc_storage["1"], doc_1_after) == []

--- a/src/tests/unit/services/document_service/test_update_document_complex_arrays.py
+++ b/src/tests/unit/services/document_service/test_update_document_complex_arrays.py
@@ -76,7 +76,7 @@ higher_rank_array_blueprint = {
 file_repository_test = LocalFileRepository()
 
 
-class BlueprintProvider:
+class _BlueprintProvider:
     def get_blueprint(self, template_type: str):
         if template_type == "higher_rank_array":
             blueprint = Blueprint(higher_rank_array_blueprint)
@@ -90,10 +90,11 @@ class BlueprintProvider:
         return blueprint
 
 
-blueprint_provider = BlueprintProvider()
-
-
 class ArraysDocumentServiceTestCase(unittest.TestCase):
+    def setUp(self) -> None:
+        blueprint_provider = _BlueprintProvider()
+        self.mock_document_service = get_mock_document_service(blueprint_provider=blueprint_provider)
+
     @skip
     def test_create_complex_array(self):
         doc_storage = {
@@ -120,10 +121,8 @@ class ArraysDocumentServiceTestCase(unittest.TestCase):
             if data_source_id == "testing":
                 return document_repository
 
-        document_service = get_mock_document_service(
-            repository_provider=repository_provider, blueprint_provider=blueprint_provider
-        )
-        document_service.add_document(
+        self.mock_document_service.repository_provider = repository_provider
+        self.mock_document_service.add_document(
             data_source_id="testing",
             parent_id="1",
             data={"type": "higher_rank_array", "name": "complexArraysEntity"},
@@ -268,9 +267,8 @@ class ArraysDocumentServiceTestCase(unittest.TestCase):
             if data_source_id == "testing":
                 return document_repository
 
-        document_service = get_mock_document_service(
-            repository_provider=repository_provider, blueprint_provider=blueprint_provider
-        )
+        self.mock_document_service.repository_provider = repository_provider
+
         # fmt: off
         data = {
             "_id": "1",
@@ -344,7 +342,7 @@ class ArraysDocumentServiceTestCase(unittest.TestCase):
         update_document_use_case(
             data=data,
             address=Address.from_absolute("dmss://testing/$1"),
-            document_service=document_service
+            document_service=self.mock_document_service
         )
 
         expected_1 = {

--- a/src/tests/unit/use_cases/test_reference.py
+++ b/src/tests/unit/use_cases/test_reference.py
@@ -16,7 +16,8 @@ from tests.unit.mock_data.mock_document_service import get_mock_document_service
 class ReferenceTestCase(unittest.TestCase):
     def setUp(self) -> None:
         simos_blueprints = ["dmss://system/SIMOS/NamedEntity", "dmss://system/SIMOS/Reference"]
-        self.mock_blueprint_provider = MockBlueprintProvider(simos_blueprints_available_for_test=simos_blueprints)
+        mock_blueprint_provider = MockBlueprintProvider(simos_blueprints_available_for_test=simos_blueprints)
+        self.document_service = get_mock_document_service(blueprint_provider=mock_blueprint_provider)
 
     def test_insert_reference(self):
         repository = mock.Mock()
@@ -47,9 +48,7 @@ class ReferenceTestCase(unittest.TestCase):
 
         repository.get = lambda x: doc_storage[str(x)]
         repository.update = mock_update
-        document_service = get_mock_document_service(
-            repository_provider=lambda x, y: repository, blueprint_provider=self.mock_blueprint_provider
-        )
+        self.document_service.repository_provider = lambda x, y: repository
         reference = {
             "address": "$2d7c3249-985d-43d2-83cf-a887e440825a",
             "type": SIMOS.REFERENCE.value,
@@ -58,7 +57,7 @@ class ReferenceTestCase(unittest.TestCase):
         update_document_use_case(
             data=reference,
             address=Address("$1.uncontained_in_every_way", "testing"),
-            document_service=document_service,
+            document_service=self.document_service,
         )
         assert doc_storage["1"]["uncontained_in_every_way"] == reference
 
@@ -94,9 +93,7 @@ class ReferenceTestCase(unittest.TestCase):
 
         repository.get = mock_get
         repository.update = mock_update
-        document_service = get_mock_document_service(
-            repository_provider=lambda x, y: repository, blueprint_provider=self.mock_blueprint_provider
-        )
+        self.document_service.repository_provider = lambda x, y: repository
 
         reference_entity = {
             "address": "$2d7c3249-985d-43d2-83cf-a887e440825a",
@@ -110,7 +107,7 @@ class ReferenceTestCase(unittest.TestCase):
             update_document_use_case(
                 data=reference_entity,
                 address=Address("$1.uncontained_in_every_way", "testing"),
-                document_service=document_service,
+                document_service=self.document_service,
             )
 
     def test_insert_reference_missing_required_attribute(self):
@@ -139,16 +136,14 @@ class ReferenceTestCase(unittest.TestCase):
 
         repository.get = mock_get
         repository.update = mock_update
-        document_service = get_mock_document_service(
-            repository_provider=lambda x, y: repository, blueprint_provider=self.mock_blueprint_provider
-        )
+        self.document_service.repository_provider = lambda x, y: repository
 
         reference_entity_with_missing_attribute = {"address": "$123", "type": SIMOS.REFERENCE.value}
         with self.assertRaises(ValidationException):
             update_document_use_case(
                 data=reference_entity_with_missing_attribute,
                 address=Address("$1.uncontained_in_every_way", "testing"),
-                document_service=document_service,
+                document_service=self.document_service,
             )
 
     def test_remove_reference(self):
@@ -181,12 +176,10 @@ class ReferenceTestCase(unittest.TestCase):
 
         repository.get = lambda id: doc_storage[id]
         repository.update = mock_update
-        document_service = get_mock_document_service(
-            repository_provider=lambda x, y: repository, blueprint_provider=self.mock_blueprint_provider
-        )
+        self.document_service.repository_provider = lambda x, y: repository
 
         self.assertRaises(
-            ValidationException, document_service.remove, Address("$1.uncontained_in_every_way", "testing")
+            ValidationException, self.document_service.remove, Address("$1.uncontained_in_every_way", "testing")
         )
 
     def test_remove_nested_reference(self):
@@ -224,13 +217,11 @@ class ReferenceTestCase(unittest.TestCase):
 
         repository.get = lambda id: doc_storage[id]
         repository.update = mock_update
-        document_service = get_mock_document_service(
-            repository_provider=lambda x, y: repository, blueprint_provider=self.mock_blueprint_provider
-        )
+        self.document_service.repository_provider = lambda x, y: repository
 
         self.assertRaises(
             ValidationException,
-            document_service.remove,
+            self.document_service.remove,
             Address("$1.i_have_a_uncontained_attribute.uncontained_in_every_way", "testing"),
         )
 
@@ -273,12 +264,9 @@ class ReferenceTestCase(unittest.TestCase):
 
         repository.get = lambda x: doc_storage[str(x)]
         repository.update = mock_update
-        document_service = get_mock_document_service(
-            repository_provider=lambda x, y: repository, blueprint_provider=self.mock_blueprint_provider
-        )
-
+        self.document_service.repository_provider = lambda x, y: repository
         self.assertRaises(
-            ValidationException, document_service.remove, Address("$1.uncontained_in_every_way[0]", "testing")
+            ValidationException, self.document_service.remove, Address("$1.uncontained_in_every_way[0]", "testing")
         )
 
     def test_add_reference_in_list(self):
@@ -315,9 +303,7 @@ class ReferenceTestCase(unittest.TestCase):
 
         repository.get = lambda x: doc_storage[str(x)]
         repository.update = mock_update
-        document_service = get_mock_document_service(
-            repository_provider=lambda x, y: repository, blueprint_provider=self.mock_blueprint_provider
-        )
+        self.document_service.repository_provider = lambda x, y: repository
         reference = {
             "address": "$42dbe4a5-0eb0-4ee2-826c-695172c3c35a",
             "type": SIMOS.REFERENCE.value,
@@ -327,7 +313,7 @@ class ReferenceTestCase(unittest.TestCase):
             address=Address("$1.uncontained_in_every_way", "testing"),
             document=reference,
             update_uncontained=True,
-            document_service=document_service,
+            document_service=self.document_service,
         )
         assert len(doc_storage["1"]["uncontained_in_every_way"]) == 2
         assert doc_storage["1"]["uncontained_in_every_way"][1] == reference


### PR DESCRIPTION
## What does this pull request change?

The mocking objects should only be created in the setUp methods. 
Then in the tests, they are modified instead of created. 


## Why is this pull request needed?

Concistency between tests. 
Makes the tests more clean, ie. readable


## Issues related to this change:

#495 
