### PR TITLE
Test: Require list of blueprints as input to the MockBlueprintProvider

### DIFF
--- a/src/tests/unit/common/utils/resolve_address/test_resolve_address.py
+++ b/src/tests/unit/common/utils/resolve_address/test_resolve_address.py
@@ -80,7 +80,10 @@ class ResolveReferenceTestCase(unittest.TestCase):
         self.document_repository.get = self.mock_get
         self.document_repository.find = self.mock_find
         simos_blueprints = []
-        mock_blueprint_provider = MockBlueprintProvider(simos_blueprints_available_for_test=simos_blueprints)
+        mock_blueprint_folder = "src/tests/unit/mock_data/mock_blueprints"
+        mock_blueprint_provider = MockBlueprintProvider(
+            mock_blueprint_folder=mock_blueprint_folder, simos_blueprints_available_for_test=simos_blueprints
+        )
         self.document_service = get_mock_document_service(
             repository_provider=lambda x, y: self.document_repository, blueprint_provider=mock_blueprint_provider
         )

--- a/src/tests/unit/common/utils/resolve_address/test_resolve_address.py
+++ b/src/tests/unit/common/utils/resolve_address/test_resolve_address.py
@@ -8,7 +8,6 @@ from common.address import Address
 from common.exceptions import ApplicationException, NotFoundException
 from common.utils.resolve_address import resolve_address
 from enums import REFERENCE_TYPES, SIMOS
-from tests.unit.mock_data.mock_blueprint_provider import MockBlueprintProvider
 from tests.unit.mock_data.mock_document_service import get_mock_document_service
 
 
@@ -79,13 +78,8 @@ class ResolveReferenceTestCase(unittest.TestCase):
         self.document_repository.name = "datasource"
         self.document_repository.get = self.mock_get
         self.document_repository.find = self.mock_find
-        simos_blueprints = []
-        mock_blueprint_folder = "src/tests/unit/mock_data/mock_blueprints"
-        mock_blueprint_provider = MockBlueprintProvider(
-            mock_blueprint_folder=mock_blueprint_folder, simos_blueprints_available_for_test=simos_blueprints
-        )
         self.document_service = get_mock_document_service(
-            repository_provider=lambda x, y: self.document_repository, blueprint_provider=mock_blueprint_provider
+            repository_provider=lambda x, y: self.document_repository, blueprint_provider=None
         )
 
     def mock_get(self, document_id: str):

--- a/src/tests/unit/common/utils/test_create_entity.py
+++ b/src/tests/unit/common/utils/test_create_entity.py
@@ -13,7 +13,10 @@ class CreateEntityTestCase(unittest.TestCase):
             "dmss://system/SIMOS/BlueprintAttribute",
             "dmss://system/SIMOS/NamedEntity",
         ]
-        self.mock_blueprint_provider = MockBlueprintProvider(simos_blueprints_available_for_test=simos_blueprints)
+        mock_blueprint_folder = "src/tests/unit/mock_data/mock_blueprints"
+        self.mock_blueprint_provider = MockBlueprintProvider(
+            mock_blueprint_folder=mock_blueprint_folder, simos_blueprints_available_for_test=simos_blueprints
+        )
         self.mock_document_service = get_mock_document_service(blueprint_provider=self.mock_blueprint_provider)
         self.maxDiff = None
 

--- a/src/tests/unit/common/utils/test_create_entity.py
+++ b/src/tests/unit/common/utils/test_create_entity.py
@@ -14,8 +14,16 @@ class CreateEntityTestCase(unittest.TestCase):
             "dmss://system/SIMOS/NamedEntity",
         ]
         mock_blueprint_folder = "src/tests/unit/mock_data/mock_blueprints"
+        mock_blueprints_and_file_names = {
+            "CarTest": "CarTest.blueprint.json",
+            "WheelTest": "WheelTest.blueprint.json",
+            "EngineTest": "EngineTest.blueprint.json",
+            "FuelPumpTest": "FuelPumpTest.blueprint.json",
+        }
         self.mock_blueprint_provider = MockBlueprintProvider(
-            mock_blueprint_folder=mock_blueprint_folder, simos_blueprints_available_for_test=simos_blueprints
+            mock_blueprints_and_file_names=mock_blueprints_and_file_names,
+            mock_blueprint_folder=mock_blueprint_folder,
+            simos_blueprints_available_for_test=simos_blueprints,
         )
         self.mock_document_service = get_mock_document_service(blueprint_provider=self.mock_blueprint_provider)
         self.maxDiff = None

--- a/src/tests/unit/common/utils/validators/test_validate_entity.py
+++ b/src/tests/unit/common/utils/validators/test_validate_entity.py
@@ -16,10 +16,23 @@ class ValidateEntityTestCase(unittest.TestCase):
             "dmss://system/SIMOS/BlueprintAttribute",
         ]
         mock_blueprint_folder = "src/tests/unit/mock_data/mock_blueprints"
-        self.mock_blueprint_provider = MockBlueprintProvider(
-            mock_blueprint_folder=mock_blueprint_folder, simos_blueprints_available_for_test=simos_blueprints
+        mock_blueprints_and_file_names = {
+            "CarRental": "CarRental.blueprint.json",
+            "RentalCar": "RentalCar.blueprint.json",
+            "CarTest": "CarTest.blueprint.json",
+            "BaseChild": "BaseChild.blueprint.json",
+            "WheelTest": "WheelTest.blueprint.json",
+            "SpecialChild": "SpecialChild.blueprint.json",
+            "Parent": "Parent.blueprint.json",
+            "FuelPumpTest": "FuelPumpTest.blueprint.json",
+            "EngineTest": "EngineTest.blueprint.json",
+        }
+        mock_blueprint_provider = MockBlueprintProvider(
+            mock_blueprints_and_file_names=mock_blueprints_and_file_names,
+            mock_blueprint_folder=mock_blueprint_folder,
+            simos_blueprints_available_for_test=simos_blueprints,
         )
-        self.mock_document_service = get_mock_document_service(blueprint_provider=self.mock_blueprint_provider)
+        self.mock_document_service = get_mock_document_service(blueprint_provider=mock_blueprint_provider)
 
     def test_a_simple_valid_entity(self):
         test_entity = {

--- a/src/tests/unit/common/utils/validators/test_validate_entity.py
+++ b/src/tests/unit/common/utils/validators/test_validate_entity.py
@@ -15,7 +15,10 @@ class ValidateEntityTestCase(unittest.TestCase):
             "dmss://system/SIMOS/NamedEntity",
             "dmss://system/SIMOS/BlueprintAttribute",
         ]
-        self.mock_blueprint_provider = MockBlueprintProvider(simos_blueprints_available_for_test=simos_blueprints)
+        mock_blueprint_folder = "src/tests/unit/mock_data/mock_blueprints"
+        self.mock_blueprint_provider = MockBlueprintProvider(
+            mock_blueprint_folder=mock_blueprint_folder, simos_blueprints_available_for_test=simos_blueprints
+        )
         self.mock_document_service = get_mock_document_service(blueprint_provider=self.mock_blueprint_provider)
 
     def test_a_simple_valid_entity(self):

--- a/src/tests/unit/mock_data/mock_blueprint_provider.py
+++ b/src/tests/unit/mock_data/mock_blueprint_provider.py
@@ -10,14 +10,14 @@ file_repository_test = LocalFileRepository()
 class MockBlueprintProvider:
     def __init__(
         self,
-        test_blueprint_data_path: str = "src/tests/unit/mock_data/mock_blueprints",
+        mock_blueprint_folder: str,
         simos_blueprints_available_for_test: List[str] = None,
     ):
         if simos_blueprints_available_for_test is None:
             simos_blueprints_available_for_test = []
-        if test_blueprint_data_path.endswith("/"):
-            test_blueprint_data_path = test_blueprint_data_path[:-1]
-        self.test_blueprint_data_path = test_blueprint_data_path
+        if mock_blueprint_folder.endswith("/"):
+            mock_blueprint_folder = mock_blueprint_folder[:-1]
+        self.mock_blueprint_folder = mock_blueprint_folder
         self.simos_blueprints_available_for_test = simos_blueprints_available_for_test
 
     def get_blueprint(self, type: str):
@@ -47,7 +47,7 @@ class MockBlueprintProvider:
             "Customer",
             "RentalCar",
         ]:
-            with open(f"{self.test_blueprint_data_path}/{type}.blueprint.json") as f:
+            with open(f"{self.mock_blueprint_folder}/{type}.blueprint.json") as f:
                 return Blueprint(json.load(f), type)
         if type in self.simos_blueprints_available_for_test:
             return Blueprint(file_repository_test.get(type), type)

--- a/src/tests/unit/mock_data/mock_blueprint_provider.py
+++ b/src/tests/unit/mock_data/mock_blueprint_provider.py
@@ -1,5 +1,5 @@
 import json
-from typing import List
+from typing import Dict, List
 
 from domain_classes.blueprint import Blueprint
 from storage.repositories.file import LocalFileRepository
@@ -11,6 +11,7 @@ class MockBlueprintProvider:
     def __init__(
         self,
         mock_blueprint_folder: str,
+        mock_blueprints_and_file_names: Dict[str, str],
         simos_blueprints_available_for_test: List[str] = None,
     ):
         if simos_blueprints_available_for_test is None:
@@ -18,39 +19,15 @@ class MockBlueprintProvider:
         if mock_blueprint_folder.endswith("/"):
             mock_blueprint_folder = mock_blueprint_folder[:-1]
         self.mock_blueprint_folder = mock_blueprint_folder
+        self.mock_blueprints_and_file_names = mock_blueprints_and_file_names
         self.simos_blueprints_available_for_test = simos_blueprints_available_for_test
 
     def get_blueprint(self, type: str):
-        if type in [
-            "BaseChild",
-            "ExtendedBlueprint",
-            "Parent",
-            "SecondLevelExtendedBlueprint",
-            "SpecialChild",
-            "all_contained_cases_blueprint",
-            "basic_blueprint",
-            "blob",
-            "blobContainer",
-            "blueprint_with_blob",
-            "blueprint_with_nested_optional_attr",
-            "blueprint_with_optional_attr",
-            "blueprint_with_second_level_nested_uncontained_attribute",
-            "blueprint_with_second_level_reference",
-            "two_contained_deep_attributes",
-            "uncontained_blueprint",
-            "uncontained_list_blueprint",
-            "FuelPumpTest",
-            "CarTest",
-            "WheelTest",
-            "EngineTest",
-            "CarRental",
-            "Customer",
-            "RentalCar",
-        ]:
-            with open(f"{self.mock_blueprint_folder}/{type}.blueprint.json") as f:
+        if file_name := self.mock_blueprints_and_file_names.get(type):
+            with open(f"{self.mock_blueprint_folder}/{file_name}") as f:
                 return Blueprint(json.load(f), type)
         if type in self.simos_blueprints_available_for_test:
             return Blueprint(file_repository_test.get(type), type)
         raise FileNotFoundError(
-            f"Invalid type {type} provided to the MockBlueprintProvider. No such blueprint found in the test data."
+            f"Invalid type {type} asked for from the MockBlueprintProvider. No such blueprint were provided as available blueprints as parameters in the initialisation of the MockBlueprintProvider."
         )

--- a/src/tests/unit/services/document_service/test_data_source_and_repositories.py
+++ b/src/tests/unit/services/document_service/test_data_source_and_repositories.py
@@ -18,8 +18,8 @@ test_user = User(**{"user_id": "unit-test", "full_name": "Unit Test", "email": "
 class DataSourceTestCase(unittest.TestCase):
     def setUp(self) -> None:
         simos_blueprints = ["dmss://system/SIMOS/NamedEntity"]
-        self.mock_blueprint_provider = MockBlueprintProvider(simos_blueprints_available_for_test=simos_blueprints)
-        pass
+        mock_blueprint_provider = MockBlueprintProvider(simos_blueprints_available_for_test=simos_blueprints)
+        self.mock_document_service = get_mock_document_service(blueprint_provider=mock_blueprint_provider)
 
     def test_save_into_multiple_repositories(self):
         uncontained_doc = {
@@ -73,20 +73,17 @@ class DataSourceTestCase(unittest.TestCase):
             data_source_collection=data_source_collection,
         )
 
-        document_service = get_mock_document_service(
-            repository_provider=lambda x, y: data_source,
-            blueprint_provider=self.mock_blueprint_provider,
-            user=test_user,
-        )
+        self.mock_document_service.repository_provider = lambda x, y: data_source
+        self.mock_document_service.user = test_user
 
         node: Node = tree_node_from_dict(
             uncontained_doc,
             uid="1",
-            blueprint_provider=document_service.get_blueprint,
+            blueprint_provider=self.mock_document_service.get_blueprint,
             recipe_provider=mock_storage_recipe_provider,
         )
 
-        document_service.save(node, "testing", update_uncontained=True)
+        self.mock_document_service.save(node, "testing", update_uncontained=True)
 
         # Test that both repos gets written into
         assert blob_doc_storage and default_doc_storage
@@ -138,20 +135,17 @@ class DataSourceTestCase(unittest.TestCase):
             data_source_collection=data_source_collection,
         )
 
-        document_service = get_mock_document_service(
-            repository_provider=lambda x, y: data_source,
-            blueprint_provider=self.mock_blueprint_provider,
-            user=test_user,
-        )
+        self.mock_document_service.repository_provider = lambda x, y: data_source
+        self.mock_document_service.user = test_user
 
         node: Node = tree_node_from_dict(
             blob_doc,
             uid="1",
-            blueprint_provider=document_service.get_blueprint,
+            blueprint_provider=self.mock_document_service.get_blueprint,
             recipe_provider=mock_storage_recipe_provider,
         )
 
-        document_service.save(node, "testing")
+        self.mock_document_service.save(node, "testing")
 
         # Test that only the blob storage is written into
         assert blob_doc_storage and not default_doc_storage
@@ -207,18 +201,14 @@ class DataSourceTestCase(unittest.TestCase):
             repositories={"default": default_repo, "blob": blob_repo},
             data_source_collection=data_source_collection,
         )
-
-        document_service = get_mock_document_service(
-            repository_provider=lambda x, y: data_source,
-            blueprint_provider=self.mock_blueprint_provider,
-            user=test_user,
-        )
+        self.mock_document_service.repository_provider = lambda x, y: data_source
+        self.mock_document_service.user = test_user
 
         node: Node = tree_node_from_dict(
-            blob_doc, document_service.get_blueprint, uid="1", recipe_provider=mock_storage_recipe_provider
+            blob_doc, self.mock_document_service.get_blueprint, uid="1", recipe_provider=mock_storage_recipe_provider
         )
 
-        document_service.save(node, "testing", update_uncontained=True)
+        self.mock_document_service.save(node, "testing", update_uncontained=True)
 
         # Test that both repos gets written into
         assert blob_doc_storage and default_doc_storage

--- a/src/tests/unit/services/document_service/test_data_source_and_repositories.py
+++ b/src/tests/unit/services/document_service/test_data_source_and_repositories.py
@@ -18,7 +18,10 @@ test_user = User(**{"user_id": "unit-test", "full_name": "Unit Test", "email": "
 class DataSourceTestCase(unittest.TestCase):
     def setUp(self) -> None:
         simos_blueprints = ["dmss://system/SIMOS/NamedEntity"]
-        mock_blueprint_provider = MockBlueprintProvider(simos_blueprints_available_for_test=simos_blueprints)
+        mock_blueprint_folder = "src/tests/unit/mock_data/mock_blueprints"
+        mock_blueprint_provider = MockBlueprintProvider(
+            mock_blueprint_folder=mock_blueprint_folder, simos_blueprints_available_for_test=simos_blueprints
+        )
         self.mock_document_service = get_mock_document_service(blueprint_provider=mock_blueprint_provider)
 
     def test_save_into_multiple_repositories(self):

--- a/src/tests/unit/services/document_service/test_data_source_and_repositories.py
+++ b/src/tests/unit/services/document_service/test_data_source_and_repositories.py
@@ -19,8 +19,16 @@ class DataSourceTestCase(unittest.TestCase):
     def setUp(self) -> None:
         simos_blueprints = ["dmss://system/SIMOS/NamedEntity"]
         mock_blueprint_folder = "src/tests/unit/mock_data/mock_blueprints"
+        mock_blueprints_and_file_names = {
+            "blobContainer": "blobContainer.blueprint.json",
+            "blob": "blob.blueprint.json",
+            "basic_blueprint": "basic_blueprint.blueprint.json",
+            "uncontained_blueprint": "uncontained_blueprint.blueprint.json",
+        }
         mock_blueprint_provider = MockBlueprintProvider(
-            mock_blueprint_folder=mock_blueprint_folder, simos_blueprints_available_for_test=simos_blueprints
+            mock_blueprints_and_file_names=mock_blueprints_and_file_names,
+            mock_blueprint_folder=mock_blueprint_folder,
+            simos_blueprints_available_for_test=simos_blueprints,
         )
         self.mock_document_service = get_mock_document_service(blueprint_provider=mock_blueprint_provider)
 

--- a/src/tests/unit/services/document_service/test_document_service_get_document.py
+++ b/src/tests/unit/services/document_service/test_document_service_get_document.py
@@ -69,7 +69,10 @@ class GetDocumentInputTestCase(unittest.TestCase):
         self.document_repository.find = self.mock_find
 
         simos_blueprints = ["dmss://system/SIMOS/NamedEntity", "dmss://system/SIMOS/Reference"]
-        mock_blueprint_provider = MockBlueprintProvider(simos_blueprints_available_for_test=simos_blueprints)
+        mock_blueprint_folder = "src/tests/unit/mock_data/mock_blueprints"
+        mock_blueprint_provider = MockBlueprintProvider(
+            mock_blueprint_folder=mock_blueprint_folder, simos_blueprints_available_for_test=simos_blueprints
+        )
         self.document_service = get_mock_document_service(
             repository_provider=lambda x, y: self.document_repository, blueprint_provider=mock_blueprint_provider
         )

--- a/src/tests/unit/services/document_service/test_document_service_get_document.py
+++ b/src/tests/unit/services/document_service/test_document_service_get_document.py
@@ -70,8 +70,17 @@ class GetDocumentInputTestCase(unittest.TestCase):
 
         simos_blueprints = ["dmss://system/SIMOS/NamedEntity", "dmss://system/SIMOS/Reference"]
         mock_blueprint_folder = "src/tests/unit/mock_data/mock_blueprints"
+        mock_blueprints_and_file_names = {
+            "CarRental": "CarRental.blueprint.json",
+            "RentalCar": "RentalCar.blueprint.json",
+            "EngineTest": "EngineTest.blueprint.json",
+            "FuelPumpTest": "FuelPumpTest.blueprint.json",
+            "Customer": "Customer.blueprint.json",
+        }
         mock_blueprint_provider = MockBlueprintProvider(
-            mock_blueprint_folder=mock_blueprint_folder, simos_blueprints_available_for_test=simos_blueprints
+            mock_blueprints_and_file_names=mock_blueprints_and_file_names,
+            mock_blueprint_folder=mock_blueprint_folder,
+            simos_blueprints_available_for_test=simos_blueprints,
         )
         self.document_service = get_mock_document_service(
             repository_provider=lambda x, y: self.document_repository, blueprint_provider=mock_blueprint_provider

--- a/src/tests/unit/services/document_service/test_get_extended_blueprint.py
+++ b/src/tests/unit/services/document_service/test_get_extended_blueprint.py
@@ -55,12 +55,11 @@ class GetExtendedBlueprintTestCase(unittest.TestCase):
 
         repository.get = lambda doc_id: doc_storage[doc_id]
         repository.update = mock_update
-        document_service = get_mock_document_service(
-            repository_provider=lambda x, y: repository, blueprint_provider=self.mock_blueprint_provider
-        )
 
-        node: Node = document_service.get_document(Address.from_absolute("testing/$1"))
+        self.document_service.repository_provider = lambda x, y: repository
+
+        node: Node = self.document_service.get_document(Address.from_absolute("testing/$1"))
         node.update(doc_1_after)
-        document_service.save(node, "testing")
+        self.document_service.save(node, "testing")
 
         assert get_and_print_diff(doc_storage["1"], doc_1_after) == []

--- a/src/tests/unit/services/document_service/test_get_extended_blueprint.py
+++ b/src/tests/unit/services/document_service/test_get_extended_blueprint.py
@@ -12,7 +12,10 @@ from tests.unit.mock_data.mock_document_service import get_mock_document_service
 class GetExtendedBlueprintTestCase(unittest.TestCase):
     def setUp(self):
         simos_blueprints = ["dmss://system/SIMOS/NamedEntity"]
-        self.mock_blueprint_provider = MockBlueprintProvider(simos_blueprints_available_for_test=simos_blueprints)
+        mock_blueprint_folder = "src/tests/unit/mock_data/mock_blueprints"
+        self.mock_blueprint_provider = MockBlueprintProvider(
+            mock_blueprint_folder=mock_blueprint_folder, simos_blueprints_available_for_test=simos_blueprints
+        )
         self.document_service = get_mock_document_service(blueprint_provider=self.mock_blueprint_provider)
 
     def test_get_simple_extended(self):

--- a/src/tests/unit/services/document_service/test_get_extended_blueprint.py
+++ b/src/tests/unit/services/document_service/test_get_extended_blueprint.py
@@ -13,10 +13,17 @@ class GetExtendedBlueprintTestCase(unittest.TestCase):
     def setUp(self):
         simos_blueprints = ["dmss://system/SIMOS/NamedEntity"]
         mock_blueprint_folder = "src/tests/unit/mock_data/mock_blueprints"
-        self.mock_blueprint_provider = MockBlueprintProvider(
-            mock_blueprint_folder=mock_blueprint_folder, simos_blueprints_available_for_test=simos_blueprints
+        mock_blueprints_and_file_names = {
+            "basic_blueprint": "basic_blueprint.blueprint.json",
+            "SecondLevelExtendedBlueprint": "SecondLevelExtendedBlueprint.blueprint.json",
+            "ExtendedBlueprint": "ExtendedBlueprint.blueprint.json",
+        }
+        mock_blueprint_provider = MockBlueprintProvider(
+            mock_blueprints_and_file_names=mock_blueprints_and_file_names,
+            mock_blueprint_folder=mock_blueprint_folder,
+            simos_blueprints_available_for_test=simos_blueprints,
         )
-        self.document_service = get_mock_document_service(blueprint_provider=self.mock_blueprint_provider)
+        self.document_service = get_mock_document_service(blueprint_provider=mock_blueprint_provider)
 
     def test_get_simple_extended(self):
         full_blueprint: Blueprint = self.document_service.get_blueprint("ExtendedBlueprint")

--- a/src/tests/unit/services/document_service/test_reference_resolve.py
+++ b/src/tests/unit/services/document_service/test_reference_resolve.py
@@ -16,7 +16,10 @@ from tests.unit.mock_data.mock_document_service import get_mock_document_service
 class GetDocumentResolveTestCase(unittest.TestCase):
     def setUp(self) -> None:
         simos_blueprints = ["dmss://system/SIMOS/Package", "dmss://system/SIMOS/NamedEntity"]
-        mock_blueprint_provider = MockBlueprintProvider(simos_blueprints_available_for_test=simos_blueprints)
+        mock_blueprint_folder = "src/tests/unit/mock_data/mock_blueprints"
+        mock_blueprint_provider = MockBlueprintProvider(
+            mock_blueprint_folder=mock_blueprint_folder, simos_blueprints_available_for_test=simos_blueprints
+        )
         self.mock_document_service = get_mock_document_service(blueprint_provider=mock_blueprint_provider)
 
     def test_references_that_uses_wrong_protocol(self):

--- a/src/tests/unit/services/document_service/test_reference_resolve.py
+++ b/src/tests/unit/services/document_service/test_reference_resolve.py
@@ -17,8 +17,17 @@ class GetDocumentResolveTestCase(unittest.TestCase):
     def setUp(self) -> None:
         simos_blueprints = ["dmss://system/SIMOS/Package", "dmss://system/SIMOS/NamedEntity"]
         mock_blueprint_folder = "src/tests/unit/mock_data/mock_blueprints"
+        mock_blueprints_and_file_names = {
+            "CarRental": "CarRental.blueprint.json",
+            "EngineTest": "EngineTest.blueprint.json",
+            "FuelPumpTest": "FuelPumpTest.blueprint.json",
+            "RentalCar": "RentalCar.blueprint.json",
+            "Customer": "Customer.blueprint.json",
+        }
         mock_blueprint_provider = MockBlueprintProvider(
-            mock_blueprint_folder=mock_blueprint_folder, simos_blueprints_available_for_test=simos_blueprints
+            mock_blueprints_and_file_names=mock_blueprints_and_file_names,
+            mock_blueprint_folder=mock_blueprint_folder,
+            simos_blueprints_available_for_test=simos_blueprints,
         )
         self.mock_document_service = get_mock_document_service(blueprint_provider=mock_blueprint_provider)
 

--- a/src/tests/unit/services/document_service/test_remove.py
+++ b/src/tests/unit/services/document_service/test_remove.py
@@ -23,7 +23,10 @@ class DocumentServiceTestCase(unittest.TestCase):
             "dmss://system/SIMOS/Reference",
             "dmss://system/SIMOS/Blob",
         ]
-        self.mock_blueprint_provider = MockBlueprintProvider(simos_blueprints_available_for_test=simos_blueprints)
+        mock_blueprint_folder = "src/tests/unit/mock_data/mock_blueprints"
+        self.mock_blueprint_provider = MockBlueprintProvider(
+            mock_blueprint_folder=mock_blueprint_folder, simos_blueprints_available_for_test=simos_blueprints
+        )
         self.mock_document_service = get_mock_document_service(
             repository_provider=lambda x, y: self.repository, blueprint_provider=self.mock_blueprint_provider
         )

--- a/src/tests/unit/services/document_service/test_remove.py
+++ b/src/tests/unit/services/document_service/test_remove.py
@@ -24,8 +24,19 @@ class DocumentServiceTestCase(unittest.TestCase):
             "dmss://system/SIMOS/Blob",
         ]
         mock_blueprint_folder = "src/tests/unit/mock_data/mock_blueprints"
+        mock_blueprints_and_file_names = {
+            "basic_blueprint": "basic_blueprint.blueprint.json",
+            "uncontained_blueprint": "uncontained_blueprint.blueprint.json",
+            "all_contained_cases_blueprint": "all_contained_cases_blueprint.blueprint.json",
+            "blueprint_with_blob": "blueprint_with_blob.blueprint.json",
+            "blueprint_with_optional_attr": "blueprint_with_optional_attr.blueprint.json",
+            "CarRental": "CarRental.blueprint.json",
+            "Customer": "Customer.blueprint.json",
+        }
         self.mock_blueprint_provider = MockBlueprintProvider(
-            mock_blueprint_folder=mock_blueprint_folder, simos_blueprints_available_for_test=simos_blueprints
+            mock_blueprints_and_file_names=mock_blueprints_and_file_names,
+            mock_blueprint_folder=mock_blueprint_folder,
+            simos_blueprints_available_for_test=simos_blueprints,
         )
         self.mock_document_service = get_mock_document_service(
             repository_provider=lambda x, y: self.repository, blueprint_provider=self.mock_blueprint_provider

--- a/src/tests/unit/services/document_service/test_save.py
+++ b/src/tests/unit/services/document_service/test_save.py
@@ -18,7 +18,10 @@ from tests.unit.mock_data.mock_document_service import get_mock_document_service
 class DocumentServiceTestCase(unittest.TestCase):
     def setUp(self) -> None:
         simos_blueprints = ["dmss://system/SIMOS/NamedEntity", "dmss://system/SIMOS/Reference"]
-        self.mock_blueprint_provider = MockBlueprintProvider(simos_blueprints_available_for_test=simos_blueprints)
+        mock_blueprint_folder = "src/tests/unit/mock_data/mock_blueprints"
+        self.mock_blueprint_provider = MockBlueprintProvider(
+            mock_blueprint_folder=mock_blueprint_folder, simos_blueprints_available_for_test=simos_blueprints
+        )
         self.mock_document_service = get_mock_document_service(blueprint_provider=self.mock_blueprint_provider)
 
     def test_save_update(self):

--- a/src/tests/unit/services/document_service/test_save.py
+++ b/src/tests/unit/services/document_service/test_save.py
@@ -19,8 +19,17 @@ class DocumentServiceTestCase(unittest.TestCase):
     def setUp(self) -> None:
         simos_blueprints = ["dmss://system/SIMOS/NamedEntity", "dmss://system/SIMOS/Reference"]
         mock_blueprint_folder = "src/tests/unit/mock_data/mock_blueprints"
+        mock_blueprints_and_file_names = {
+            "basic_blueprint": "basic_blueprint.blueprint.json",
+            "uncontained_blueprint": "uncontained_blueprint.blueprint.json",
+            "two_contained_deep_attributes": "two_contained_deep_attributes.blueprint.json",
+            "all_contained_cases_blueprint": "all_contained_cases_blueprint.blueprint.json",
+            "blueprint_with_second_level_nested_uncontained_attribute": "blueprint_with_second_level_nested_uncontained_attribute.blueprint.json",
+        }
         self.mock_blueprint_provider = MockBlueprintProvider(
-            mock_blueprint_folder=mock_blueprint_folder, simos_blueprints_available_for_test=simos_blueprints
+            mock_blueprints_and_file_names=mock_blueprints_and_file_names,
+            mock_blueprint_folder=mock_blueprint_folder,
+            simos_blueprints_available_for_test=simos_blueprints,
         )
         self.mock_document_service = get_mock_document_service(blueprint_provider=self.mock_blueprint_provider)
 

--- a/src/tests/unit/services/document_service/test_update_document_complex_arrays.py
+++ b/src/tests/unit/services/document_service/test_update_document_complex_arrays.py
@@ -76,7 +76,7 @@ higher_rank_array_blueprint = {
 file_repository_test = LocalFileRepository()
 
 
-class BlueprintProvider:
+class _BlueprintProvider:
     def get_blueprint(self, template_type: str):
         if template_type == "higher_rank_array":
             blueprint = Blueprint(higher_rank_array_blueprint)
@@ -90,10 +90,11 @@ class BlueprintProvider:
         return blueprint
 
 
-blueprint_provider = BlueprintProvider()
-
-
 class ArraysDocumentServiceTestCase(unittest.TestCase):
+    def setUp(self) -> None:
+        blueprint_provider = _BlueprintProvider()
+        self.mock_document_service = get_mock_document_service(blueprint_provider=blueprint_provider)
+
     @skip
     def test_create_complex_array(self):
         doc_storage = {
@@ -120,10 +121,8 @@ class ArraysDocumentServiceTestCase(unittest.TestCase):
             if data_source_id == "testing":
                 return document_repository
 
-        document_service = get_mock_document_service(
-            repository_provider=repository_provider, blueprint_provider=blueprint_provider
-        )
-        document_service.add_document(
+        self.mock_document_service.repository_provider = repository_provider
+        self.mock_document_service.add_document(
             data_source_id="testing",
             parent_id="1",
             data={"type": "higher_rank_array", "name": "complexArraysEntity"},
@@ -268,9 +267,8 @@ class ArraysDocumentServiceTestCase(unittest.TestCase):
             if data_source_id == "testing":
                 return document_repository
 
-        document_service = get_mock_document_service(
-            repository_provider=repository_provider, blueprint_provider=blueprint_provider
-        )
+        self.mock_document_service.repository_provider = repository_provider
+
         # fmt: off
         data = {
             "_id": "1",
@@ -344,7 +342,7 @@ class ArraysDocumentServiceTestCase(unittest.TestCase):
         update_document_use_case(
             data=data,
             address=Address.from_absolute("dmss://testing/$1"),
-            document_service=document_service
+            document_service=self.mock_document_service
         )
 
         expected_1 = {

--- a/src/tests/unit/use_cases/test_check_existence.py
+++ b/src/tests/unit/use_cases/test_check_existence.py
@@ -25,8 +25,11 @@ class CheckExistenceTestCase(unittest.TestCase):
 
         simos_blueprints = ["dmss://system/SIMOS/NamedEntity"]
         mock_blueprint_folder = "src/tests/unit/mock_data/mock_blueprints"
+        mock_blueprints_and_file_names = {"basic_blueprint": "basic_blueprint.blueprint.json"}
         mock_blueprint_provider = MockBlueprintProvider(
-            mock_blueprint_folder=mock_blueprint_folder, simos_blueprints_available_for_test=simos_blueprints
+            mock_blueprints_and_file_names=mock_blueprints_and_file_names,
+            mock_blueprint_folder=mock_blueprint_folder,
+            simos_blueprints_available_for_test=simos_blueprints,
         )
         self.document_service = get_mock_document_service(
             repository_provider=lambda x, y: self.repository, blueprint_provider=mock_blueprint_provider

--- a/src/tests/unit/use_cases/test_check_existence.py
+++ b/src/tests/unit/use_cases/test_check_existence.py
@@ -24,7 +24,10 @@ class CheckExistenceTestCase(unittest.TestCase):
         self.repository.delete = self.mock_delete
 
         simos_blueprints = ["dmss://system/SIMOS/NamedEntity"]
-        mock_blueprint_provider = MockBlueprintProvider(simos_blueprints_available_for_test=simos_blueprints)
+        mock_blueprint_folder = "src/tests/unit/mock_data/mock_blueprints"
+        mock_blueprint_provider = MockBlueprintProvider(
+            mock_blueprint_folder=mock_blueprint_folder, simos_blueprints_available_for_test=simos_blueprints
+        )
         self.document_service = get_mock_document_service(
             repository_provider=lambda x, y: self.repository, blueprint_provider=mock_blueprint_provider
         )

--- a/src/tests/unit/use_cases/test_reference.py
+++ b/src/tests/unit/use_cases/test_reference.py
@@ -16,7 +16,10 @@ from tests.unit.mock_data.mock_document_service import get_mock_document_service
 class ReferenceTestCase(unittest.TestCase):
     def setUp(self) -> None:
         simos_blueprints = ["dmss://system/SIMOS/NamedEntity", "dmss://system/SIMOS/Reference"]
-        mock_blueprint_provider = MockBlueprintProvider(simos_blueprints_available_for_test=simos_blueprints)
+        mock_blueprint_folder = "src/tests/unit/mock_data/mock_blueprints"
+        mock_blueprint_provider = MockBlueprintProvider(
+            mock_blueprint_folder=mock_blueprint_folder, simos_blueprints_available_for_test=simos_blueprints
+        )
         self.document_service = get_mock_document_service(blueprint_provider=mock_blueprint_provider)
 
     def test_insert_reference(self):

--- a/src/tests/unit/use_cases/test_reference.py
+++ b/src/tests/unit/use_cases/test_reference.py
@@ -16,7 +16,8 @@ from tests.unit.mock_data.mock_document_service import get_mock_document_service
 class ReferenceTestCase(unittest.TestCase):
     def setUp(self) -> None:
         simos_blueprints = ["dmss://system/SIMOS/NamedEntity", "dmss://system/SIMOS/Reference"]
-        self.mock_blueprint_provider = MockBlueprintProvider(simos_blueprints_available_for_test=simos_blueprints)
+        mock_blueprint_provider = MockBlueprintProvider(simos_blueprints_available_for_test=simos_blueprints)
+        self.document_service = get_mock_document_service(blueprint_provider=mock_blueprint_provider)
 
     def test_insert_reference(self):
         repository = mock.Mock()
@@ -47,9 +48,7 @@ class ReferenceTestCase(unittest.TestCase):
 
         repository.get = lambda x: doc_storage[str(x)]
         repository.update = mock_update
-        document_service = get_mock_document_service(
-            repository_provider=lambda x, y: repository, blueprint_provider=self.mock_blueprint_provider
-        )
+        self.document_service.repository_provider = lambda x, y: repository
         reference = {
             "address": "$2d7c3249-985d-43d2-83cf-a887e440825a",
             "type": SIMOS.REFERENCE.value,
@@ -58,7 +57,7 @@ class ReferenceTestCase(unittest.TestCase):
         update_document_use_case(
             data=reference,
             address=Address("$1.uncontained_in_every_way", "testing"),
-            document_service=document_service,
+            document_service=self.document_service,
         )
         assert doc_storage["1"]["uncontained_in_every_way"] == reference
 
@@ -94,9 +93,7 @@ class ReferenceTestCase(unittest.TestCase):
 
         repository.get = mock_get
         repository.update = mock_update
-        document_service = get_mock_document_service(
-            repository_provider=lambda x, y: repository, blueprint_provider=self.mock_blueprint_provider
-        )
+        self.document_service.repository_provider = lambda x, y: repository
 
         reference_entity = {
             "address": "$2d7c3249-985d-43d2-83cf-a887e440825a",
@@ -110,7 +107,7 @@ class ReferenceTestCase(unittest.TestCase):
             update_document_use_case(
                 data=reference_entity,
                 address=Address("$1.uncontained_in_every_way", "testing"),
-                document_service=document_service,
+                document_service=self.document_service,
             )
 
     def test_insert_reference_missing_required_attribute(self):
@@ -139,16 +136,14 @@ class ReferenceTestCase(unittest.TestCase):
 
         repository.get = mock_get
         repository.update = mock_update
-        document_service = get_mock_document_service(
-            repository_provider=lambda x, y: repository, blueprint_provider=self.mock_blueprint_provider
-        )
+        self.document_service.repository_provider = lambda x, y: repository
 
         reference_entity_with_missing_attribute = {"address": "$123", "type": SIMOS.REFERENCE.value}
         with self.assertRaises(ValidationException):
             update_document_use_case(
                 data=reference_entity_with_missing_attribute,
                 address=Address("$1.uncontained_in_every_way", "testing"),
-                document_service=document_service,
+                document_service=self.document_service,
             )
 
     def test_remove_reference(self):
@@ -181,12 +176,10 @@ class ReferenceTestCase(unittest.TestCase):
 
         repository.get = lambda id: doc_storage[id]
         repository.update = mock_update
-        document_service = get_mock_document_service(
-            repository_provider=lambda x, y: repository, blueprint_provider=self.mock_blueprint_provider
-        )
+        self.document_service.repository_provider = lambda x, y: repository
 
         self.assertRaises(
-            ValidationException, document_service.remove, Address("$1.uncontained_in_every_way", "testing")
+            ValidationException, self.document_service.remove, Address("$1.uncontained_in_every_way", "testing")
         )
 
     def test_remove_nested_reference(self):
@@ -224,13 +217,11 @@ class ReferenceTestCase(unittest.TestCase):
 
         repository.get = lambda id: doc_storage[id]
         repository.update = mock_update
-        document_service = get_mock_document_service(
-            repository_provider=lambda x, y: repository, blueprint_provider=self.mock_blueprint_provider
-        )
+        self.document_service.repository_provider = lambda x, y: repository
 
         self.assertRaises(
             ValidationException,
-            document_service.remove,
+            self.document_service.remove,
             Address("$1.i_have_a_uncontained_attribute.uncontained_in_every_way", "testing"),
         )
 
@@ -273,12 +264,9 @@ class ReferenceTestCase(unittest.TestCase):
 
         repository.get = lambda x: doc_storage[str(x)]
         repository.update = mock_update
-        document_service = get_mock_document_service(
-            repository_provider=lambda x, y: repository, blueprint_provider=self.mock_blueprint_provider
-        )
-
+        self.document_service.repository_provider = lambda x, y: repository
         self.assertRaises(
-            ValidationException, document_service.remove, Address("$1.uncontained_in_every_way[0]", "testing")
+            ValidationException, self.document_service.remove, Address("$1.uncontained_in_every_way[0]", "testing")
         )
 
     def test_add_reference_in_list(self):
@@ -315,9 +303,7 @@ class ReferenceTestCase(unittest.TestCase):
 
         repository.get = lambda x: doc_storage[str(x)]
         repository.update = mock_update
-        document_service = get_mock_document_service(
-            repository_provider=lambda x, y: repository, blueprint_provider=self.mock_blueprint_provider
-        )
+        self.document_service.repository_provider = lambda x, y: repository
         reference = {
             "address": "$42dbe4a5-0eb0-4ee2-826c-695172c3c35a",
             "type": SIMOS.REFERENCE.value,
@@ -327,7 +313,7 @@ class ReferenceTestCase(unittest.TestCase):
             address=Address("$1.uncontained_in_every_way", "testing"),
             document=reference,
             update_uncontained=True,
-            document_service=document_service,
+            document_service=self.document_service,
         )
         assert len(doc_storage["1"]["uncontained_in_every_way"]) == 2
         assert doc_storage["1"]["uncontained_in_every_way"][1] == reference

--- a/src/tests/unit/use_cases/test_reference.py
+++ b/src/tests/unit/use_cases/test_reference.py
@@ -17,8 +17,16 @@ class ReferenceTestCase(unittest.TestCase):
     def setUp(self) -> None:
         simos_blueprints = ["dmss://system/SIMOS/NamedEntity", "dmss://system/SIMOS/Reference"]
         mock_blueprint_folder = "src/tests/unit/mock_data/mock_blueprints"
+        mock_blueprints_and_file_names = {
+            "basic_blueprint": "basic_blueprint.blueprint.json",
+            "uncontained_blueprint": "uncontained_blueprint.blueprint.json",
+            "blueprint_with_second_level_nested_uncontained_attribute": "blueprint_with_second_level_nested_uncontained_attribute.blueprint.json",
+            "uncontained_list_blueprint": "uncontained_list_blueprint.blueprint.json",
+        }
         mock_blueprint_provider = MockBlueprintProvider(
-            mock_blueprint_folder=mock_blueprint_folder, simos_blueprints_available_for_test=simos_blueprints
+            mock_blueprints_and_file_names=mock_blueprints_and_file_names,
+            mock_blueprint_folder=mock_blueprint_folder,
+            simos_blueprints_available_for_test=simos_blueprints,
         )
         self.document_service = get_mock_document_service(blueprint_provider=mock_blueprint_provider)
 


### PR DESCRIPTION
## What does this pull request change?

In order to make the mocker reusable we want to make it data-less. 
Thus we remove the references from the `MockBlueprintProvider` and requrie instead each test to specify what blueprints it should have available for testing. 

This makes it very easy to see what blueprints the tests are dependent on. 

## Why is this pull request needed?

## Issues related to this change:

#495 
