### PR TITLE
test: for some test, moving blueprints 'down'

### DIFF
--- a/src/tests/unit/services/document_service/mock_blueprints/blob_blueprints/blob.blueprint.json
+++ b/src/tests/unit/services/document_service/mock_blueprints/blob_blueprints/blob.blueprint.json
@@ -1,0 +1,15 @@
+{
+  "name": "blob",
+  "type": "dmss://system/SIMOS/Blueprint",
+  "description": "Test for a blueprint with storageAffinity in storageRecipe",
+  "extends": [
+    "dmss://system/SIMOS/NamedEntity"
+  ],
+  "attributes": [
+    {
+      "name": "someData",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "attributeType": "string"
+    }
+  ]
+}

--- a/src/tests/unit/services/document_service/mock_blueprints/blob_blueprints/blobContainer.blueprint.json
+++ b/src/tests/unit/services/document_service/mock_blueprints/blob_blueprints/blobContainer.blueprint.json
@@ -1,0 +1,15 @@
+{
+  "name": "blobContainer",
+  "type": "dmss://system/SIMOS/Blueprint",
+  "description": "A basic blueprint that has a non-storageContained blob, none specified storageAffinity ",
+  "extends": [
+    "dmss://system/SIMOS/NamedEntity"
+  ],
+  "attributes": [
+    {
+      "name": "blob",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "attributeType": "blob"
+    }
+  ]
+}

--- a/src/tests/unit/services/document_service/mock_blueprints/blob_blueprints/uncontained_blueprint.blueprint.json
+++ b/src/tests/unit/services/document_service/mock_blueprints/blob_blueprints/uncontained_blueprint.blueprint.json
@@ -1,0 +1,16 @@
+{
+  "name": "uncontained_blueprint",
+  "type": "dmss://system/SIMOS/Blueprint",
+  "description": "uncontained_blueprint",
+  "extends": [
+    "dmss://system/SIMOS/NamedEntity"
+  ],
+  "attributes": [
+    {
+      "name": "uncontained_in_every_way",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "attributeType": "dmss://system/SIMOS/NamedEntity",
+      "contained": false
+    }
+  ]
+}

--- a/src/tests/unit/services/document_service/mock_blueprints/car_rental_blueprints/CarRental.blueprint.json
+++ b/src/tests/unit/services/document_service/mock_blueprints/car_rental_blueprints/CarRental.blueprint.json
@@ -1,0 +1,28 @@
+{
+  "name": "CarRental",
+  "type": "system/SIMOS/Blueprint",
+  "attributes": [
+    {
+      "name": "name",
+      "type": "system/SIMOS/BlueprintAttribute",
+      "attributeType": "string"
+    },
+    {
+      "name": "type",
+      "type": "system/SIMOS/BlueprintAttribute",
+      "attributeType": "string"
+    },
+    {
+      "name": "cars",
+      "type": "system/SIMOS/BlueprintAttribute",
+      "dimensions": "*",
+      "attributeType": "RentalCar"
+    },
+    {
+      "name": "customers",
+      "type": "system/SIMOS/BlueprintAttribute",
+      "dimensions": "*",
+      "attributeType": "Customer"
+    }
+  ]
+}

--- a/src/tests/unit/services/document_service/mock_blueprints/car_rental_blueprints/Customer.blueprint.json
+++ b/src/tests/unit/services/document_service/mock_blueprints/car_rental_blueprints/Customer.blueprint.json
@@ -1,0 +1,17 @@
+{
+  "name": "Customer",
+  "type": "system/SIMOS/Blueprint",
+  "attributes": [
+    {
+      "name": "name",
+      "type": "system/SIMOS/BlueprintAttribute",
+      "attributeType": "string"
+    },
+    {
+      "name": "car",
+      "type": "system/SIMOS/BlueprintAttribute",
+      "attributeType": "RentalCar",
+      "contained": false
+    }
+  ]
+}

--- a/src/tests/unit/services/document_service/mock_blueprints/car_rental_blueprints/EngineTest.blueprint.json
+++ b/src/tests/unit/services/document_service/mock_blueprints/car_rental_blueprints/EngineTest.blueprint.json
@@ -1,0 +1,38 @@
+{
+  "name": "EngineTest",
+  "type": "system/SIMOS/Blueprint",
+  "description": "This describes an engine",
+  "attributes": [
+    {
+      "name": "name",
+      "type": "system/SIMOS/BlueprintAttribute",
+      "attributeType": "string"
+    },
+    {
+      "name": "type",
+      "type": "system/SIMOS/BlueprintAttribute",
+      "attributeType": "string"
+    },
+    {
+      "name": "description",
+      "type": "system/SIMOS/BlueprintAttribute",
+      "attributeType": "string"
+    },
+    {
+      "name": "power",
+      "type": "system/SIMOS/BlueprintAttribute",
+      "attributeType": "integer",
+      "default": 120
+    },
+    {
+      "name": "fuelPump",
+      "type": "system/SIMOS/BlueprintAttribute",
+      "attributeType": "FuelPumpTest",
+      "default": {
+        "name": "fuelPump",
+        "type": "FuelPumpTest",
+        "description": "A standard fuel pump"
+      }
+    }
+  ]
+}

--- a/src/tests/unit/services/document_service/mock_blueprints/car_rental_blueprints/FuelPumpTest.blueprint.json
+++ b/src/tests/unit/services/document_service/mock_blueprints/car_rental_blueprints/FuelPumpTest.blueprint.json
@@ -1,0 +1,23 @@
+{
+  "name": "FuelPumpTest",
+  "type": "system/SIMOS/Blueprint",
+  "description": "This describes a fuel pump",
+  "attributes": [
+    {
+      "name": "name",
+      "type": "system/SIMOS/BlueprintAttribute",
+      "attributeType": "string"
+    },
+    {
+      "name": "description",
+      "type": "system/SIMOS/BlueprintAttribute",
+      "attributeType": "string",
+      "default": "A standard fuel pump"
+    },
+    {
+      "name": "type",
+      "type": "system/SIMOS/BlueprintAttribute",
+      "attributeType": "string"
+    }
+  ]
+}

--- a/src/tests/unit/services/document_service/mock_blueprints/car_rental_blueprints/RentalCar.blueprint.json
+++ b/src/tests/unit/services/document_service/mock_blueprints/car_rental_blueprints/RentalCar.blueprint.json
@@ -1,0 +1,29 @@
+{
+  "name": "RentalCar",
+  "type": "system/SIMOS/Blueprint",
+  "attributes": [
+    {
+      "name": "name",
+      "type": "system/SIMOS/BlueprintAttribute",
+      "attributeType": "string",
+      "default": "RentalCar"
+    },
+    {
+      "name": "type",
+      "type": "system/SIMOS/BlueprintAttribute",
+      "attributeType": "string",
+      "default": "RentalCar"
+    },
+    {
+      "name": "plateNumber",
+      "type": "system/SIMOS/BlueprintAttribute",
+      "attributeType": "string"
+    },
+    {
+      "name": "engine",
+      "type": "system/SIMOS/BlueprintAttribute",
+      "attributeType": "EngineTest",
+      "optional": true
+    }
+  ]
+}

--- a/src/tests/unit/services/document_service/mock_blueprints/extended_blueprints/ExtendedBlueprint.blueprint.json
+++ b/src/tests/unit/services/document_service/mock_blueprints/extended_blueprints/ExtendedBlueprint.blueprint.json
@@ -1,0 +1,15 @@
+{
+  "name": "ExtendedBlueprint",
+  "type": "dmss://system/SIMOS/Blueprint",
+  "description": "This Blueprint extends namedEntity",
+  "extends": [
+    "dmss://system/SIMOS/NamedEntity"
+  ],
+  "attributes": [
+    {
+      "name": "another_value",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "attributeType": "string"
+    }
+  ]
+}

--- a/src/tests/unit/services/document_service/mock_blueprints/extended_blueprints/SecondLevelExtendedBlueprint.blueprint.json
+++ b/src/tests/unit/services/document_service/mock_blueprints/extended_blueprints/SecondLevelExtendedBlueprint.blueprint.json
@@ -1,0 +1,15 @@
+{
+  "name": "SecondLevelExtendedBlueprint",
+  "type": "dmss://system/SIMOS/Blueprint",
+  "description": "This Blueprint extends 'ExtendedBlueprint'",
+  "extends": [
+    "ExtendedBlueprint"
+  ],
+  "attributes": [
+    {
+      "name": "a_third_value",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "attributeType": "string"
+    }
+  ]
+}

--- a/src/tests/unit/services/document_service/test_data_source_and_repositories.py
+++ b/src/tests/unit/services/document_service/test_data_source_and_repositories.py
@@ -18,11 +18,10 @@ test_user = User(**{"user_id": "unit-test", "full_name": "Unit Test", "email": "
 class DataSourceTestCase(unittest.TestCase):
     def setUp(self) -> None:
         simos_blueprints = ["dmss://system/SIMOS/NamedEntity"]
-        mock_blueprint_folder = "src/tests/unit/mock_data/mock_blueprints"
+        mock_blueprint_folder = "src/tests/unit/services/document_service/mock_blueprints/blob_blueprints"
         mock_blueprints_and_file_names = {
             "blobContainer": "blobContainer.blueprint.json",
             "blob": "blob.blueprint.json",
-            "basic_blueprint": "basic_blueprint.blueprint.json",
             "uncontained_blueprint": "uncontained_blueprint.blueprint.json",
         }
         mock_blueprint_provider = MockBlueprintProvider(
@@ -37,7 +36,7 @@ class DataSourceTestCase(unittest.TestCase):
             "name": "Parent",
             "description": "",
             "type": "uncontained_blueprint",
-            "uncontained_in_every_way": {"name": "a_reference", "type": "basic_blueprint"},
+            "uncontained_in_every_way": {"name": "a_reference", "type": "dmss://system/SIMOS/NamedEntity"},
         }
 
         default_doc_storage = {}

--- a/src/tests/unit/services/document_service/test_document_service_get_document.py
+++ b/src/tests/unit/services/document_service/test_document_service_get_document.py
@@ -69,7 +69,7 @@ class GetDocumentInputTestCase(unittest.TestCase):
         self.document_repository.find = self.mock_find
 
         simos_blueprints = ["dmss://system/SIMOS/NamedEntity", "dmss://system/SIMOS/Reference"]
-        mock_blueprint_folder = "src/tests/unit/mock_data/mock_blueprints"
+        mock_blueprint_folder = "src/tests/unit/services/document_service/mock_blueprints/car_rental_blueprints"
         mock_blueprints_and_file_names = {
             "CarRental": "CarRental.blueprint.json",
             "RentalCar": "RentalCar.blueprint.json",

--- a/src/tests/unit/services/document_service/test_get_extended_blueprint.py
+++ b/src/tests/unit/services/document_service/test_get_extended_blueprint.py
@@ -12,9 +12,8 @@ from tests.unit.mock_data.mock_document_service import get_mock_document_service
 class GetExtendedBlueprintTestCase(unittest.TestCase):
     def setUp(self):
         simos_blueprints = ["dmss://system/SIMOS/NamedEntity"]
-        mock_blueprint_folder = "src/tests/unit/mock_data/mock_blueprints"
+        mock_blueprint_folder = "src/tests/unit/services/document_service/mock_blueprints/extended_blueprints"
         mock_blueprints_and_file_names = {
-            "basic_blueprint": "basic_blueprint.blueprint.json",
             "SecondLevelExtendedBlueprint": "SecondLevelExtendedBlueprint.blueprint.json",
             "ExtendedBlueprint": "ExtendedBlueprint.blueprint.json",
         }

--- a/src/tests/unit/services/document_service/test_reference_resolve.py
+++ b/src/tests/unit/services/document_service/test_reference_resolve.py
@@ -16,7 +16,7 @@ from tests.unit.mock_data.mock_document_service import get_mock_document_service
 class GetDocumentResolveTestCase(unittest.TestCase):
     def setUp(self) -> None:
         simos_blueprints = ["dmss://system/SIMOS/Package", "dmss://system/SIMOS/NamedEntity"]
-        mock_blueprint_folder = "src/tests/unit/mock_data/mock_blueprints"
+        mock_blueprint_folder = "src/tests/unit/services/document_service/mock_blueprints/car_rental_blueprints"
         mock_blueprints_and_file_names = {
             "CarRental": "CarRental.blueprint.json",
             "EngineTest": "EngineTest.blueprint.json",


### PR DESCRIPTION
## What does this pull request change?

Hello. 

Previously we had a huge mocker that had one BIG folder with all the ´mock_blueprints´ for all the tests.
This is not desirable, because we want the unit tests to be as separated as possible. 

Therefore we now move the test data 'down' into the tree structure, closer to the unit tests. 

This is now done for 3 tests. 

1. Created a folder in ´document_service´ unit tests, called ´mock_blueprints´
2. Moved the car example down, which is used by two tests
3. Moved a ´blob_example´ down, which is used by one test
4. Moved ´extended_example´down, which is used by one tes. 
5. Removed the references to blueprint ´basic_blueprint´, because it is a duplicate of ´dmss://system/SIMOS/NamedEntity´ in the tests we are modifying now. 


## Why is this pull request needed?

## Issues related to this change:
