### PR TITLE
feat: adding optional description to CORE:BlueprintAttribute

### DIFF
--- a/src/home/system/SIMOS/BlueprintAttribute.json
+++ b/src/home/system/SIMOS/BlueprintAttribute.json
@@ -49,6 +49,12 @@
       "optional": true
     },
     {
+      "name": "description",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "attributeType": "string",
+      "optional": true
+    },
+    {
       "name": "contained",
       "type": "dmss://system/SIMOS/BlueprintAttribute",
       "attributeType": "boolean",


### PR DESCRIPTION
## What does this pull request change?

Adding optional description to CORE:BlueprintAttribute

This is so that one can give context to the attributes when writing a Blueprint. 


## Why is this pull request needed?

## Issues related to this change:
