### PR TITLE
test: mock storage recipe provicer data-less

### DIFF
--- a/src/tests/unit/mock_data/mock_recipe_provider.py
+++ b/src/tests/unit/mock_data/mock_recipe_provider.py
@@ -1,70 +1,14 @@
+import json
 from collections import defaultdict
 
 from domain_classes.storage_recipe import StorageAttribute, StorageRecipe
 from enums import StorageDataTypes
 
-all_storage_recipes = defaultdict(list)
-
-all_storage_recipes.update(
-    {
-        "all_contained_cases_blueprint": [
-            {
-                "type": "dmss://system/SIMOS/StorageRecipe",
-                "name": "DefaultStorageRecipe",
-                "description": "",
-                "attributes": [
-                    {"name": "reference", "type": "dmss://system/SIMOS/Entity", "contained": False},
-                    {"name": "references", "type": "dmss://system/SIMOS/Entity", "contained": False},
-                ],
-            }
-        ],
-        "uncontained_blueprint": [
-            {
-                "type": "dmss://system/SIMOS/StorageRecipe",
-                "name": "DefaultStorageRecipe",
-                "description": "",
-                "attributes": [
-                    {
-                        "name": "uncontained_in_every_way",
-                        "type": "does_this_matter?",
-                        "contained": False,
-                        "storageAffinity": "blob",
-                    }
-                ],
-            }
-        ],
-        "ExtendedBlueprint": [
-            {
-                "name": "default",
-                "type": "dmss://system/SIMOS/StorageRecipe",
-                "description": "",
-                "storageAffinity": "blob",
-                "attributes": [],
-            }
-        ],
-        # "uncontained_blueprint": uncontained_blueprint,
-        "blob": [
-            {
-                "name": "default",
-                "type": "dmss://system/SIMOS/StorageRecipe",
-                "description": "",
-                "storageAffinity": "blob",
-                "attributes": [],
-            }
-        ],
-        "blobContainer": [
-            {
-                "name": "default",
-                "type": "dmss://system/SIMOS/StorageRecipe",
-                "description": "",
-                "attributes": [{"name": "blob", "type": "does_this_matter?", "contained": False}],
-            }
-        ],
-    }
-)
-
 
 def mock_storage_recipe_provider(type: str, context: str) -> list[StorageRecipe]:
+    all_storage_recipes = defaultdict(list)
+    with open("src/tests/unit/mock_data/mock_storage_recipes/mock_storage_recipes.json") as f:
+        all_storage_recipes.update(json.load(f))
     return [
         StorageRecipe(
             name=sr.get("name"),

--- a/src/tests/unit/mock_data/mock_storage_recipes/mock_storage_recipes.json
+++ b/src/tests/unit/mock_data/mock_storage_recipes/mock_storage_recipes.json
@@ -1,0 +1,68 @@
+{
+  "all_contained_cases_blueprint": [
+    {
+      "name": "DefaultStorageRecipe",
+      "type": "dmss://system/SIMOS/StorageRecipe",
+      "description": "",
+      "attributes": [
+        {
+          "name": "reference",
+          "type": "dmss://system/SIMOS/Entity",
+          "contained": false
+        },
+        {
+          "name": "references",
+          "type": "dmss://system/SIMOS/Entity",
+          "contained": false
+        }
+      ]
+    }
+  ],
+  "uncontained_blueprint": [
+    {
+      "name": "DefaultStorageRecipe",
+      "type": "dmss://system/SIMOS/StorageRecipe",
+      "description": "",
+      "attributes": [
+        {
+          "name": "uncontained_in_every_way",
+          "type": "does_this_matter?",
+          "contained": false,
+          "storageAffinity": "blob"
+        }
+      ]
+    }
+  ],
+  "ExtendedBlueprint": [
+    {
+      "name": "default",
+      "type": "dmss://system/SIMOS/StorageRecipe",
+      "description": "",
+      "storageAffinity": "blob",
+      "attributes": []
+    }
+  ],
+  "blob": [
+    {
+      "name": "default",
+      "type": "dmss://system/SIMOS/StorageRecipe",
+      "description": "",
+      "storageAffinity": "blob",
+      "attributes": []
+    }
+  ],
+  "blobContainer": [
+    {
+      "name": "default",
+      "type": "dmss://system/SIMOS/StorageRecipe",
+      "description": "",
+      "attributes": [
+        {
+          "name": "blob",
+          "type": "does_this_matter?",
+          "contained": false
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## What does this pull request change?

This PR is the first of multiple in the quest to make the recipe-provider data-less. 
This first step moves all the storage recipes out from the mocker, instead reading it from file.


## Why is this pull request needed?

## Issues related to this change:
