### PR TITLE
test: 👩‍🍳 More on the mock-recipe-provider

### DIFF
--- a/src/tests/unit/common/utils/test_create_default_array.py
+++ b/src/tests/unit/common/utils/test_create_default_array.py
@@ -8,7 +8,6 @@ from domain_classes.dimension import Dimension
 from enums import SIMOS
 from services.document_service import DocumentService
 from storage.repositories.file import LocalFileRepository
-from tests.unit.mock_data.mock_recipe_provider import mock_storage_recipe_provider
 
 basic_blueprint = {
     "type": SIMOS.BLUEPRINT.value,
@@ -74,9 +73,7 @@ class BlueprintProvider:
             return Blueprint(file_repository_test.get(template_type))
 
 
-document_service = DocumentService(
-    recipe_provider=mock_storage_recipe_provider, repository_provider=None, blueprint_provider=BlueprintProvider()
-)
+document_service = DocumentService(repository_provider=None, blueprint_provider=BlueprintProvider())
 blueprint_provider = document_service.get_blueprint
 
 

--- a/src/tests/unit/common/utils/validators/test_validate_entity.py
+++ b/src/tests/unit/common/utils/validators/test_validate_entity.py
@@ -5,7 +5,6 @@ from common.tree_node_serializer import tree_node_from_dict, tree_node_to_dict
 from common.utils.validators import validate_entity, validate_entity_against_self
 from tests.unit.mock_data.mock_blueprint_provider import MockBlueprintProvider
 from tests.unit.mock_data.mock_document_service import get_mock_document_service
-from tests.unit.mock_data.mock_recipe_provider import mock_storage_recipe_provider
 
 
 class ValidateEntityTestCase(unittest.TestCase):
@@ -275,9 +274,7 @@ class ValidateEntityTestCase(unittest.TestCase):
             "customers": [],
         }
 
-        parent_node = tree_node_from_dict(
-            test_entity, self.mock_document_service.get_blueprint, recipe_provider=mock_storage_recipe_provider
-        )
+        parent_node = tree_node_from_dict(test_entity, self.mock_document_service.get_blueprint)
         new_node = parent_node.get_by_path(["cars"])
         blueprint = new_node.blueprint
 

--- a/src/tests/unit/mock_data/mock_document_service.py
+++ b/src/tests/unit/mock_data/mock_document_service.py
@@ -1,15 +1,13 @@
 from services.document_service import DocumentService
-from tests.unit.mock_data.mock_recipe_provider import (
-    mock_storage_recipe_provider_generator,
-)
+from tests.unit.mock_data.mock_recipe_provider import MockStorageRecipeProvider
 
 
 def get_mock_document_service(
     blueprint_provider,
     repository_provider=None,
-    recipe_provider=mock_storage_recipe_provider_generator(
-        "src/tests/unit/mock_data/mock_storage_recipes/mock_storage_recipes.json"
-    ),
+    recipe_provider=MockStorageRecipeProvider(
+        path_to_mock_storage_recipes="src/tests/unit/mock_data/mock_storage_recipes/mock_storage_recipes.json"
+    ).provider,
     user=None,
     context=None,
 ):

--- a/src/tests/unit/mock_data/mock_document_service.py
+++ b/src/tests/unit/mock_data/mock_document_service.py
@@ -1,11 +1,15 @@
 from services.document_service import DocumentService
-from tests.unit.mock_data.mock_recipe_provider import mock_storage_recipe_provider
+from tests.unit.mock_data.mock_recipe_provider import (
+    mock_storage_recipe_provider_generator,
+)
 
 
 def get_mock_document_service(
     blueprint_provider,
     repository_provider=None,
-    recipe_provider=mock_storage_recipe_provider,
+    recipe_provider=mock_storage_recipe_provider_generator(
+        "src/tests/unit/mock_data/mock_storage_recipes/mock_storage_recipes.json"
+    ),
     user=None,
     context=None,
 ):

--- a/src/tests/unit/mock_data/mock_document_service.py
+++ b/src/tests/unit/mock_data/mock_document_service.py
@@ -6,7 +6,7 @@ def get_mock_document_service(
     blueprint_provider,
     repository_provider=None,
     recipe_provider=MockStorageRecipeProvider(
-        path_to_mock_storage_recipes="src/tests/unit/mock_data/mock_storage_recipes/mock_storage_recipes.json"
+        "src/tests/unit/mock_data/mock_storage_recipes/mock_storage_recipes.json"
     ).provider,
     user=None,
     context=None,

--- a/src/tests/unit/mock_data/mock_recipe_provider.py
+++ b/src/tests/unit/mock_data/mock_recipe_provider.py
@@ -5,20 +5,23 @@ from domain_classes.storage_recipe import StorageAttribute, StorageRecipe
 from enums import StorageDataTypes
 
 
-def mock_storage_recipe_provider(type: str, context: str) -> list[StorageRecipe]:
-    all_storage_recipes = defaultdict(list)
-    with open("src/tests/unit/mock_data/mock_storage_recipes/mock_storage_recipes.json") as f:
-        all_storage_recipes.update(json.load(f))
-    return [
-        StorageRecipe(
-            name=sr.get("name"),
-            storage_affinity=StorageDataTypes(sr.get("storageAffinity", "default")),
-            attributes={
-                a["name"]: StorageAttribute(
-                    name=a["name"], contained=a["contained"], storage_affinity=a.get("storageAffinity", "default")
-                )
-                for a in sr.get("attributes", [])
-            },
-        )
-        for sr in all_storage_recipes[type]
-    ]
+def mock_storage_recipe_provider_generator(path_to_mock_storage_recipes: str = None):
+    def mock_storage_recipe_provider(type: str, context: str) -> list[StorageRecipe]:
+        all_storage_recipes = defaultdict(list)
+        with open(path_to_mock_storage_recipes) as f:
+            all_storage_recipes.update(json.load(f))
+        return [
+            StorageRecipe(
+                name=sr.get("name"),
+                storage_affinity=StorageDataTypes(sr.get("storageAffinity", "default")),
+                attributes={
+                    a["name"]: StorageAttribute(
+                        name=a["name"], contained=a["contained"], storage_affinity=a.get("storageAffinity", "default")
+                    )
+                    for a in sr.get("attributes", [])
+                },
+            )
+            for sr in all_storage_recipes[type]
+        ]
+
+    return mock_storage_recipe_provider

--- a/src/tests/unit/mock_data/mock_recipe_provider.py
+++ b/src/tests/unit/mock_data/mock_recipe_provider.py
@@ -5,10 +5,13 @@ from domain_classes.storage_recipe import StorageAttribute, StorageRecipe
 from enums import StorageDataTypes
 
 
-def mock_storage_recipe_provider_generator(path_to_mock_storage_recipes: str = None):
-    def mock_storage_recipe_provider(type: str, context: str) -> list[StorageRecipe]:
+class MockStorageRecipeProvider:
+    def __init__(self, path_to_mock_storage_recipes: str):
+        self.path_to_mock_storage_recipes = path_to_mock_storage_recipes
+
+    def provider(self, type: str, context: str) -> list[StorageRecipe]:
         all_storage_recipes = defaultdict(list)
-        with open(path_to_mock_storage_recipes) as f:
+        with open(self.path_to_mock_storage_recipes) as f:
             all_storage_recipes.update(json.load(f))
         return [
             StorageRecipe(
@@ -23,5 +26,3 @@ def mock_storage_recipe_provider_generator(path_to_mock_storage_recipes: str = N
             )
             for sr in all_storage_recipes[type]
         ]
-
-    return mock_storage_recipe_provider

--- a/src/tests/unit/services/document_service/test_data_source_and_repositories.py
+++ b/src/tests/unit/services/document_service/test_data_source_and_repositories.py
@@ -9,9 +9,7 @@ from enums import StorageDataTypes
 from storage.data_source_class import DataSource
 from tests.unit.mock_data.mock_blueprint_provider import MockBlueprintProvider
 from tests.unit.mock_data.mock_document_service import get_mock_document_service
-from tests.unit.mock_data.mock_recipe_provider import (
-    mock_storage_recipe_provider_generator,
-)
+from tests.unit.mock_data.mock_recipe_provider import MockStorageRecipeProvider
 
 config.AUTH_ENABLED = False
 test_user = User(**{"user_id": "unit-test", "full_name": "Unit Test", "email": "unit-test@example.com"})
@@ -31,9 +29,9 @@ class DataSourceTestCase(unittest.TestCase):
             mock_blueprint_folder=mock_blueprint_folder,
             simos_blueprints_available_for_test=simos_blueprints,
         )
-        self.mock_storage_recipe_provider = mock_storage_recipe_provider_generator(
+        self.mock_storage_recipe_provider = MockStorageRecipeProvider(
             path_to_mock_storage_recipes="src/tests/unit/mock_data/mock_storage_recipes/mock_storage_recipes.json"
-        )
+        ).provider
         self.mock_document_service = get_mock_document_service(blueprint_provider=mock_blueprint_provider)
 
     def test_save_into_multiple_repositories(self):

--- a/src/tests/unit/services/document_service/test_data_source_and_repositories.py
+++ b/src/tests/unit/services/document_service/test_data_source_and_repositories.py
@@ -9,7 +9,9 @@ from enums import StorageDataTypes
 from storage.data_source_class import DataSource
 from tests.unit.mock_data.mock_blueprint_provider import MockBlueprintProvider
 from tests.unit.mock_data.mock_document_service import get_mock_document_service
-from tests.unit.mock_data.mock_recipe_provider import mock_storage_recipe_provider
+from tests.unit.mock_data.mock_recipe_provider import (
+    mock_storage_recipe_provider_generator,
+)
 
 config.AUTH_ENABLED = False
 test_user = User(**{"user_id": "unit-test", "full_name": "Unit Test", "email": "unit-test@example.com"})
@@ -28,6 +30,9 @@ class DataSourceTestCase(unittest.TestCase):
             mock_blueprints_and_file_names=mock_blueprints_and_file_names,
             mock_blueprint_folder=mock_blueprint_folder,
             simos_blueprints_available_for_test=simos_blueprints,
+        )
+        self.mock_storage_recipe_provider = mock_storage_recipe_provider_generator(
+            path_to_mock_storage_recipes="src/tests/unit/mock_data/mock_storage_recipes/mock_storage_recipes.json"
         )
         self.mock_document_service = get_mock_document_service(blueprint_provider=mock_blueprint_provider)
 
@@ -90,7 +95,7 @@ class DataSourceTestCase(unittest.TestCase):
             uncontained_doc,
             uid="1",
             blueprint_provider=self.mock_document_service.get_blueprint,
-            recipe_provider=mock_storage_recipe_provider,
+            recipe_provider=self.mock_storage_recipe_provider,
         )
 
         self.mock_document_service.save(node, "testing", update_uncontained=True)
@@ -152,7 +157,7 @@ class DataSourceTestCase(unittest.TestCase):
             blob_doc,
             uid="1",
             blueprint_provider=self.mock_document_service.get_blueprint,
-            recipe_provider=mock_storage_recipe_provider,
+            recipe_provider=self.mock_storage_recipe_provider,
         )
 
         self.mock_document_service.save(node, "testing")
@@ -215,7 +220,10 @@ class DataSourceTestCase(unittest.TestCase):
         self.mock_document_service.user = test_user
 
         node: Node = tree_node_from_dict(
-            blob_doc, self.mock_document_service.get_blueprint, uid="1", recipe_provider=mock_storage_recipe_provider
+            blob_doc,
+            self.mock_document_service.get_blueprint,
+            uid="1",
+            recipe_provider=self.mock_storage_recipe_provider,
         )
 
         self.mock_document_service.save(node, "testing", update_uncontained=True)

--- a/src/tests/unit/services/document_service/test_data_source_and_repositories.py
+++ b/src/tests/unit/services/document_service/test_data_source_and_repositories.py
@@ -29,9 +29,8 @@ class DataSourceTestCase(unittest.TestCase):
             mock_blueprint_folder=mock_blueprint_folder,
             simos_blueprints_available_for_test=simos_blueprints,
         )
-        self.mock_storage_recipe_provider = MockStorageRecipeProvider(
-            path_to_mock_storage_recipes="src/tests/unit/mock_data/mock_storage_recipes/mock_storage_recipes.json"
-        ).provider
+        mock_recipe_folder = "src/tests/unit/mock_data/mock_storage_recipes/mock_storage_recipes.json"
+        self.mock_storage_recipe_provider = MockStorageRecipeProvider(mock_recipe_folder).provider
         self.mock_document_service = get_mock_document_service(blueprint_provider=mock_blueprint_provider)
 
     def test_save_into_multiple_repositories(self):

--- a/src/tests/unit/tree_functionality/test_tree_node_delete.py
+++ b/src/tests/unit/tree_functionality/test_tree_node_delete.py
@@ -3,7 +3,6 @@ import unittest
 from common.tree_node_serializer import tree_node_from_dict, tree_node_to_dict
 from domain_classes.blueprint_attribute import BlueprintAttribute
 from domain_classes.tree_node import Node
-from tests.unit.mock_data.mock_recipe_provider import mock_storage_recipe_provider
 from tests.unit.tree_functionality.mock_data_for_tree_tests.mock_document_service_for_tree_tests import (
     mock_document_service,
 )
@@ -18,7 +17,6 @@ class TreeNodeDeleteTest(unittest.TestCase):
             entity=root_data,
             blueprint_provider=mock_document_service.get_blueprint,
             attribute=BlueprintAttribute(name="", attribute_type="all_contained_cases_blueprint"),
-            recipe_provider=mock_storage_recipe_provider,
         )
 
         nested_1_data = {"name": "Nested1", "description": "", "type": "Garden"}
@@ -29,7 +27,6 @@ class TreeNodeDeleteTest(unittest.TestCase):
             blueprint_provider=mock_document_service.get_blueprint,
             parent=root,
             attribute=BlueprintAttribute(name="", attribute_type="Garden"),
-            recipe_provider=mock_storage_recipe_provider,
         )
 
         actual_before = {
@@ -56,7 +53,6 @@ class TreeNodeDeleteTest(unittest.TestCase):
             entity=root_data,
             blueprint_provider=mock_document_service.get_blueprint,
             attribute=BlueprintAttribute(name="", attribute_type="all_contained_cases_blueprint"),
-            recipe_provider=mock_storage_recipe_provider,
         )
 
         nested_1_data = {"name": "Nested1", "description": "", "type": "Garden"}
@@ -67,7 +63,6 @@ class TreeNodeDeleteTest(unittest.TestCase):
             blueprint_provider=mock_document_service.get_blueprint,
             parent=root,
             attribute=BlueprintAttribute(name="", attribute_type="Garden"),
-            recipe_provider=mock_storage_recipe_provider,
         )
         nested_2_data = {"name": "Nested2", "description": "", "type": "Bush"}
         nested_2 = Node(
@@ -77,7 +72,6 @@ class TreeNodeDeleteTest(unittest.TestCase):
             blueprint_provider=mock_document_service.get_blueprint,
             parent=nested_1,
             attribute=BlueprintAttribute(name="", attribute_type="Bush"),
-            recipe_provider=mock_storage_recipe_provider,
         )
 
         actual_before = {
@@ -129,7 +123,6 @@ class TreeNodeDeleteTest(unittest.TestCase):
             document,
             mock_document_service.get_blueprint,
             uid=document.get("_id"),
-            recipe_provider=mock_storage_recipe_provider,
         )
 
         actual_before = {

--- a/src/tests/unit/tree_functionality/test_tree_node_helpers.py
+++ b/src/tests/unit/tree_functionality/test_tree_node_helpers.py
@@ -4,7 +4,9 @@ from common.tree_node_serializer import tree_node_from_dict, tree_node_to_dict
 from common.utils.data_structure.compare import get_and_print_diff
 from domain_classes.blueprint_attribute import BlueprintAttribute
 from domain_classes.tree_node import ListNode, Node
-from tests.unit.mock_data.mock_recipe_provider import mock_storage_recipe_provider
+from tests.unit.mock_data.mock_recipe_provider import (
+    mock_storage_recipe_provider_generator,
+)
 from tests.unit.tree_functionality.mock_data_for_tree_tests.get_node_for_tree_tests import (
     get_engine_package_node,
 )
@@ -27,6 +29,11 @@ def flatten_dict(dd, separator="_", prefix=""):
 
 
 class TreenodeTestCase(unittest.TestCase):
+    def setUp(self) -> None:
+        self.mock_storage_recipe_provider = mock_storage_recipe_provider_generator(
+            "src/tests/unit/mock_data/mock_storage_recipes/mock_storage_recipes.json"
+        )
+
     def test_is_root(self):
         root_data = {"_id": 1, "name": "root", "description": "", "type": "all_contained_cases_blueprint"}
         root = Node(
@@ -35,7 +42,7 @@ class TreenodeTestCase(unittest.TestCase):
             entity=root_data,
             blueprint_provider=mock_document_service.get_blueprint,
             attribute=BlueprintAttribute(name="", attribute_type="all_contained_cases_blueprint"),
-            recipe_provider=mock_storage_recipe_provider,
+            recipe_provider=self.mock_storage_recipe_provider,
         )
 
         nested_data = {"name": "Nested", "description": "", "type": "Garden"}
@@ -46,7 +53,7 @@ class TreenodeTestCase(unittest.TestCase):
             blueprint_provider=mock_document_service.get_blueprint,
             parent=root,
             attribute=BlueprintAttribute(name="", attribute_type="Garden"),
-            recipe_provider=mock_storage_recipe_provider,
+            recipe_provider=self.mock_storage_recipe_provider,
         )
 
         assert root.is_root()
@@ -60,7 +67,7 @@ class TreenodeTestCase(unittest.TestCase):
             entity=root_data,
             blueprint_provider=mock_document_service.get_blueprint,
             attribute=BlueprintAttribute(name="", attribute_type="all_contained_cases_blueprint"),
-            recipe_provider=mock_storage_recipe_provider,
+            recipe_provider=self.mock_storage_recipe_provider,
         )
 
         nested_1_data = {"name": "Nested1", "description": "", "type": "Garden"}
@@ -71,7 +78,7 @@ class TreenodeTestCase(unittest.TestCase):
             blueprint_provider=mock_document_service.get_blueprint,
             parent=root,
             attribute=BlueprintAttribute(name="", attribute_type="Garden"),
-            recipe_provider=mock_storage_recipe_provider,
+            recipe_provider=self.mock_storage_recipe_provider,
         )
 
         nested_2_data = {"name": "Nested2", "description": "", "type": "Garden"}
@@ -81,7 +88,7 @@ class TreenodeTestCase(unittest.TestCase):
             entity=nested_2_data,
             blueprint_provider=mock_document_service.get_blueprint,
             attribute=BlueprintAttribute(name="", attribute_type="Garden"),
-            recipe_provider=mock_storage_recipe_provider,
+            recipe_provider=self.mock_storage_recipe_provider,
         )
 
         actual_before = {
@@ -109,7 +116,7 @@ class TreenodeTestCase(unittest.TestCase):
     def test_depth(self):
         root_data = {"_id": 1, "name": "root", "description": "", "type": "all_contained_cases_blueprint"}
         root = Node(
-            recipe_provider=mock_storage_recipe_provider,
+            recipe_provider=self.mock_storage_recipe_provider,
             key="root",
             uid="1",
             entity=root_data,
@@ -119,7 +126,7 @@ class TreenodeTestCase(unittest.TestCase):
 
         nested_data = {"name": "Nested", "description": "", "type": "Garden"}
         nested = Node(
-            recipe_provider=mock_storage_recipe_provider,
+            recipe_provider=self.mock_storage_recipe_provider,
             key="nested",
             uid="",
             entity=nested_data,
@@ -155,7 +162,7 @@ class TreenodeTestCase(unittest.TestCase):
             document_1,
             mock_document_service.get_blueprint,
             uid=document_1.get("_id"),
-            recipe_provider=mock_storage_recipe_provider,
+            recipe_provider=self.mock_storage_recipe_provider,
         )
         result = [node.node_id for node in root.traverse()]
         expected = [
@@ -173,7 +180,7 @@ class TreenodeTestCase(unittest.TestCase):
     def test_traverse_reverse(self):
         root_data = {"_id": 1, "name": "root", "description": "", "type": "all_contained_cases_blueprint"}
         root = Node(
-            recipe_provider=mock_storage_recipe_provider,
+            recipe_provider=self.mock_storage_recipe_provider,
             key="root",
             uid="1",
             entity=root_data,
@@ -183,7 +190,7 @@ class TreenodeTestCase(unittest.TestCase):
 
         nested_data = {"name": "Nested1", "description": "", "type": "Garden"}
         nested = Node(
-            recipe_provider=mock_storage_recipe_provider,
+            recipe_provider=self.mock_storage_recipe_provider,
             key="nested",
             uid="",
             entity=nested_data,
@@ -194,7 +201,7 @@ class TreenodeTestCase(unittest.TestCase):
 
         nested_2_data = {"name": "Nested2", "description": "", "type": "Bush"}
         nested_2 = Node(
-            recipe_provider=mock_storage_recipe_provider,
+            recipe_provider=self.mock_storage_recipe_provider,
             key="nested",
             uid="",
             entity=nested_2_data,
@@ -210,7 +217,7 @@ class TreenodeTestCase(unittest.TestCase):
     def test_node_id(self):
         root_data = {"_id": 1, "name": "root", "description": "", "type": "all_contained_cases_blueprint"}
         root = Node(
-            recipe_provider=mock_storage_recipe_provider,
+            recipe_provider=self.mock_storage_recipe_provider,
             key="",
             uid="1",
             entity=root_data,
@@ -220,7 +227,7 @@ class TreenodeTestCase(unittest.TestCase):
 
         nested_data = {"name": "Nested", "description": "", "type": "Garden"}
         nested = Node(
-            recipe_provider=mock_storage_recipe_provider,
+            recipe_provider=self.mock_storage_recipe_provider,
             key="nested",
             uid="",
             entity=nested_data,
@@ -231,7 +238,7 @@ class TreenodeTestCase(unittest.TestCase):
 
         nested_2_data = {"name": "Nested", "description": "", "type": "Bush"}
         nested_2 = Node(
-            recipe_provider=mock_storage_recipe_provider,
+            recipe_provider=self.mock_storage_recipe_provider,
             key="nested",
             uid="",
             entity=nested_2_data,
@@ -242,7 +249,7 @@ class TreenodeTestCase(unittest.TestCase):
 
         nested_2_reference_data = {"_id": "2", "name": "Reference", "description": "", "type": "Garden"}
         reference = Node(
-            recipe_provider=mock_storage_recipe_provider,
+            recipe_provider=self.mock_storage_recipe_provider,
             key="reference",
             uid="2",
             entity=nested_2_reference_data,
@@ -253,7 +260,7 @@ class TreenodeTestCase(unittest.TestCase):
 
         list_data = {"name": "List", "type": "Bush"}
         list_node = ListNode(
-            recipe_provider=mock_storage_recipe_provider,
+            recipe_provider=self.mock_storage_recipe_provider,
             key="list",
             uid="",
             entity=list_data,
@@ -264,7 +271,7 @@ class TreenodeTestCase(unittest.TestCase):
 
         item_1_data = {"name": "Item1", "description": "", "type": "Garden"}
         item_1 = Node(
-            recipe_provider=mock_storage_recipe_provider,
+            recipe_provider=self.mock_storage_recipe_provider,
             key="0",
             uid="",
             entity=item_1_data,
@@ -306,7 +313,7 @@ class TreenodeTestCase(unittest.TestCase):
             document_1,
             mock_document_service.get_blueprint,
             uid=document_1.get("_id"),
-            recipe_provider=mock_storage_recipe_provider,
+            recipe_provider=self.mock_storage_recipe_provider,
         )
 
         child_1 = root.search("1.nested.nested")
@@ -340,7 +347,7 @@ class TreenodeTestCase(unittest.TestCase):
             document_1,
             mock_document_service.get_blueprint,
             uid=document_1.get("_id"),
-            recipe_provider=mock_storage_recipe_provider,
+            recipe_provider=self.mock_storage_recipe_provider,
         )
 
         child_1 = root.get_by_path(["nested", "nested"])
@@ -376,7 +383,7 @@ class TreenodeTestCase(unittest.TestCase):
             document_1,
             mock_document_service.get_blueprint,
             uid=document_1.get("_id"),
-            recipe_provider=mock_storage_recipe_provider,
+            recipe_provider=self.mock_storage_recipe_provider,
         )
 
         update_0 = {

--- a/src/tests/unit/tree_functionality/test_tree_node_helpers.py
+++ b/src/tests/unit/tree_functionality/test_tree_node_helpers.py
@@ -28,9 +28,8 @@ def flatten_dict(dd, separator="_", prefix=""):
 
 class TreenodeTestCase(unittest.TestCase):
     def setUp(self) -> None:
-        self.mock_storage_recipe_provider = MockStorageRecipeProvider(
-            path_to_mock_storage_recipes="src/tests/unit/mock_data/mock_storage_recipes/mock_storage_recipes.json"
-        ).provider
+        mock_recipe_folder = "src/tests/unit/mock_data/mock_storage_recipes/mock_storage_recipes.json"
+        self.mock_storage_recipe_provider = MockStorageRecipeProvider(mock_recipe_folder).provider
 
     def test_is_root(self):
         root_data = {"_id": 1, "name": "root", "description": "", "type": "all_contained_cases_blueprint"}

--- a/src/tests/unit/tree_functionality/test_tree_node_helpers.py
+++ b/src/tests/unit/tree_functionality/test_tree_node_helpers.py
@@ -4,9 +4,7 @@ from common.tree_node_serializer import tree_node_from_dict, tree_node_to_dict
 from common.utils.data_structure.compare import get_and_print_diff
 from domain_classes.blueprint_attribute import BlueprintAttribute
 from domain_classes.tree_node import ListNode, Node
-from tests.unit.mock_data.mock_recipe_provider import (
-    mock_storage_recipe_provider_generator,
-)
+from tests.unit.mock_data.mock_recipe_provider import MockStorageRecipeProvider
 from tests.unit.tree_functionality.mock_data_for_tree_tests.get_node_for_tree_tests import (
     get_engine_package_node,
 )
@@ -30,9 +28,9 @@ def flatten_dict(dd, separator="_", prefix=""):
 
 class TreenodeTestCase(unittest.TestCase):
     def setUp(self) -> None:
-        self.mock_storage_recipe_provider = mock_storage_recipe_provider_generator(
-            "src/tests/unit/mock_data/mock_storage_recipes/mock_storage_recipes.json"
-        )
+        self.mock_storage_recipe_provider = MockStorageRecipeProvider(
+            path_to_mock_storage_recipes="src/tests/unit/mock_data/mock_storage_recipes/mock_storage_recipes.json"
+        ).provider
 
     def test_is_root(self):
         root_data = {"_id": 1, "name": "root", "description": "", "type": "all_contained_cases_blueprint"}


### PR DESCRIPTION
## What does this pull request change?

This is the next PR in line for making the mock-recipe-provider data less. 
So we want each tests to be able to specify the locations for the storage recipes, so that the storage recipes can be moved 'down' to the test. 




1. Created a class, which returns a mocker with the path specified. 
2. Removed calls to the mocker where it was not required. 




## Why is this pull request needed?

## Issues related to this change:
