### PR TITLE
refactor: for separation of concern: moving 'default' and 'constructor' into the classes

### DIFF
--- a/src/authentication/access_control.py
+++ b/src/authentication/access_control.py
@@ -34,15 +34,3 @@ def assert_user_has_access(acl: AccessControlList, access_level_required: Access
 
     # No access high enough granted neither as 'owner', 'roles', 'users', nor 'others'.
     raise MissingPrivilegeException(f"The requested operation requires '{access_level_required.name}' privileges")
-
-
-def create_access_control_list(user: User) -> AccessControlList:
-    """Used when there is no ACL to inherit. Sets the current user as owner, and rest copies DEFAULT_ACL"""
-    return AccessControlList(
-        owner=user.user_id, roles=DEFAULT_ACCESS_CONTROL_LIST.roles, others=DEFAULT_ACCESS_CONTROL_LIST.others
-    )
-
-
-DEFAULT_ACCESS_CONTROL_LIST = AccessControlList(
-    owner=config.DMSS_ADMIN, roles={config.DMSS_ADMIN_ROLE: AccessLevel.WRITE}, others=AccessLevel.READ
-)

--- a/src/authentication/authentication.py
+++ b/src/authentication/authentication.py
@@ -11,7 +11,7 @@ from authentication.personal_access_token import get_user_from_pat
 from common.exceptions import credentials_exception
 from common.utils.logging import logger
 from common.utils.mock_token_generator import mock_rsa_public_key
-from config import config, default_user
+from config import config
 
 oauth2_scheme = OAuth2AuthorizationCodeBearer(
     authorizationUrl=config.OAUTH_AUTH_ENDPOINT, tokenUrl=config.OAUTH_TOKEN_ENDPOINT
@@ -42,7 +42,7 @@ def fetch_openid_configuration() -> dict:
 
 def auth_with_jwt(jwt_token: str = Security(oauth2_scheme)) -> User:
     if not config.AUTH_ENABLED:
-        return default_user
+        return User.default()
     # If TEST_TOKEN is true, we are running tests. Use the self-signed keys. If not, get keys from auth server.
     key = mock_rsa_public_key if config.TEST_TOKEN else {"keys": fetch_openid_configuration()["jwks"]}
 
@@ -72,7 +72,7 @@ async def auth_w_jwt_or_pat(
     personal_access_token: str = Security(APIKeyHeader(name="Access-Key", auto_error=False)),
 ) -> User:
     if not config.AUTH_ENABLED:
-        return default_user
+        return User.default()
 
     if personal_access_token:
         return get_user_from_pat(personal_access_token)

--- a/src/authentication/models.py
+++ b/src/authentication/models.py
@@ -56,7 +56,7 @@ class User(BaseModel):
 
     @classmethod
     def default(cls):
-        return cls(**{"user_id": "nologin", "full_name": "Not Authenticated", "email": "nologin@example.com"})
+        return cls(user_id="nologin", full_name="Not Authenticated", email="nologin@example.com")
 
     def __hash__(self):
         return hash(self.user_id)

--- a/src/common/utils/mock_token_generator.py
+++ b/src/common/utils/mock_token_generator.py
@@ -1,7 +1,6 @@
 from jose import jwt
 
 from authentication.models import User
-from config import default_user
 
 # Generated with: 'openssl req  -nodes -new -x509  -keyout server.key -out server.cert'
 mock_rsa_private_key = """
@@ -50,7 +49,7 @@ gwIDAQAB
 """
 
 
-def generate_mock_token(user: User = default_user):
+def generate_mock_token(user: User = User.default()):
     """
     This function is for testing purposes only
     Used for behave testing

--- a/src/config.py
+++ b/src/config.py
@@ -2,7 +2,6 @@ from pathlib import Path
 
 from pydantic import BaseSettings, Field
 
-from authentication.models import User
 from enums import AuthProviderForRoleCheck
 
 
@@ -67,5 +66,3 @@ if config.AUTH_PROVIDER_FOR_ROLE_CHECK:
         and not config.AAD_ENTERPRISE_APP_OID
     ):
         raise EnvironmentError("Missing required environment variable 'AAD_ENTERPRISE_APP_OID'")
-
-default_user: User = User(**{"user_id": "nologin", "full_name": "Not Authenticated", "email": "nologin@example.com"})

--- a/src/features/lookup_table/use_cases/create_lookup_table.py
+++ b/src/features/lookup_table/use_cases/create_lookup_table.py
@@ -1,8 +1,5 @@
-from authentication.access_control import (
-    DEFAULT_ACCESS_CONTROL_LIST,
-    assert_user_has_access,
-)
-from authentication.models import AccessLevel, User
+from authentication.access_control import assert_user_has_access
+from authentication.models import AccessControlList, AccessLevel, User
 from common.address import Address
 from domain_classes.lookup import Lookup
 from domain_classes.storage_recipe import StorageAttribute, StorageRecipe
@@ -19,7 +16,7 @@ def create_lookup_table_use_case(
     """
     Create lookup table. If the lookup table already exist, the lookup table will be updated.
     """
-    assert_user_has_access(DEFAULT_ACCESS_CONTROL_LIST, AccessLevel.WRITE, user)
+    assert_user_has_access(AccessControlList.default(), AccessLevel.WRITE, user)
 
     document_service = DocumentService(repository_provider=repository_provider, user=user)
     lookup_class_attributes = list(Lookup.__annotations__.keys())

--- a/src/features/lookup_table/use_cases/get_lookup_table.py
+++ b/src/features/lookup_table/use_cases/get_lookup_table.py
@@ -1,11 +1,8 @@
-from authentication.access_control import (
-    DEFAULT_ACCESS_CONTROL_LIST,
-    assert_user_has_access,
-)
+from authentication.access_control import AccessControlList, assert_user_has_access
 from authentication.models import AccessLevel, User
 from storage.internal.lookup_tables import get_lookup
 
 
 def get_lookup_table_use_case(lookup_id: str, user: User) -> dict:
-    assert_user_has_access(DEFAULT_ACCESS_CONTROL_LIST, AccessLevel.READ, user)
+    assert_user_has_access(AccessControlList.default(), AccessLevel.READ, user)
     return get_lookup(lookup_id).dict()

--- a/src/services/document_service.py
+++ b/src/services/document_service.py
@@ -4,6 +4,7 @@ from functools import lru_cache
 from typing import Callable, Dict, List, Union
 from uuid import uuid4
 
+from authentication.models import User
 from common.address import Address
 from common.exceptions import (
     ApplicationException,
@@ -28,7 +29,7 @@ from common.utils.logging import logger
 from common.utils.resolve_address import ResolvedAddress, resolve_address
 from common.utils.sort_entities_by_attribute import sort_dtos_by_attribute
 from common.utils.validators import validate_entity_against_self
-from config import config, default_user
+from config import config
 from domain_classes.blueprint import Blueprint
 from domain_classes.storage_recipe import StorageRecipe
 from domain_classes.tree_node import ListNode, Node
@@ -46,7 +47,7 @@ class DocumentService:
         self,
         repository_provider=get_data_source,
         blueprint_provider=None,
-        user=default_user,
+        user=User.default(),
         context: str = None,
         recipe_provider=None,
     ):

--- a/src/storage/data_source_class.py
+++ b/src/storage/data_source_class.py
@@ -4,11 +4,7 @@ from uuid import uuid4
 
 from pydantic import UUID4
 
-from authentication.access_control import (
-    DEFAULT_ACCESS_CONTROL_LIST,
-    assert_user_has_access,
-    create_access_control_list,
-)
+from authentication.access_control import assert_user_has_access
 from authentication.models import AccessControlList, AccessLevel, User
 from common.exceptions import (
     BadRequestException,
@@ -34,7 +30,7 @@ class DataSource:
         self,
         name: str,
         user: User,
-        acl: AccessControlList = DEFAULT_ACCESS_CONTROL_LIST,
+        acl: AccessControlList = AccessControlList.default(),
         repositories=None,
         data_source_collection=data_source_collection,
     ):
@@ -50,7 +46,7 @@ class DataSource:
         return cls(
             a_dict["name"],
             user,
-            AccessControlList(**a_dict.get("acl", DEFAULT_ACCESS_CONTROL_LIST.dict())),
+            AccessControlList(**a_dict.get("acl", AccessControlList.default().dict())),
             {key: Repository(name=key, **value) for key, value in a_dict["repositories"].items()},
         )
 
@@ -197,7 +193,7 @@ class DataSource:
             lookup_id=uid,
             repository=repo.name,
             database_id=uid,
-            acl=create_access_control_list(self.user),
+            acl=AccessControlList.default_with_owner(self.user),
             storage_affinity=StorageDataTypes.BLOB.value,
             meta=meta,
         )

--- a/src/storage/internal/data_source_repository.py
+++ b/src/storage/internal/data_source_repository.py
@@ -3,10 +3,7 @@ from typing import Dict, List, Optional
 from pydantic import BaseModel
 from pymongo.errors import DuplicateKeyError, ServerSelectionTimeoutError
 
-from authentication.access_control import (
-    DEFAULT_ACCESS_CONTROL_LIST,
-    assert_user_has_access,
-)
+from authentication.access_control import assert_user_has_access
 from authentication.models import AccessControlList, AccessLevel, User
 from common.exceptions import (
     ApplicationException,
@@ -73,7 +70,7 @@ class DataSourceRepository:
         return all_sources
 
     def create(self, id: str, document: DataSourceRequest):
-        assert_user_has_access(DEFAULT_ACCESS_CONTROL_LIST, AccessLevel.WRITE, self.user)
+        assert_user_has_access(AccessControlList.default(), AccessLevel.WRITE, self.user)
         document = document.dict()
         document["_id"] = id
         try:


### PR DESCRIPTION
## What does this pull request change?

So the default `user` and the default `AccessControlList` were not together with the class, which made it quite messy. 
Now there is separation of concern. 

1. Removed the constant `DEFAULT_ACCESS_CONTROL_LIST`, and moved that into classmethod `AccessControlList.default()`
2. Moved the ´create_access_control_list(user)´ method into the classmethod ´AccessControlList.create_with_owner()´ which is what it actually is used for. 
3. Removed the config `default_user`, and moved that into the classmethod `User.default()`
4. Updated usages for `default_user` and `DEFAULT_ACCESS_CONTROL_LIST`. 


## Why is this pull request needed?

## Issues related to this change:
