### PR TITLE
Fix: Not throw on empty role assignments

### DIFF
--- a/src/authentication/utils.py
+++ b/src/authentication/utils.py
@@ -19,8 +19,6 @@ def remove_pat_roles_not_assigned_by_auth_provider(
     else:
         pat_roles: Set[str] = set(pat_data.roles)
         application_role_assignments: dict[str, set[str]] = role_assignments_provider.get_assignments()
-        app_role_assignments_for_user = application_role_assignments.get(
-            pat_data.user_id, set()
-        )  # default is empty set
+        app_role_assignments_for_user = application_role_assignments.get(pat_data.user_id, set())
         pat_data.roles = list(pat_roles & app_role_assignments_for_user)
     return pat_data

--- a/src/authentication/utils.py
+++ b/src/authentication/utils.py
@@ -13,12 +13,14 @@ def remove_pat_roles_not_assigned_by_auth_provider(
     Takes app role assignments and removes roles in pat_data that are not defined by app role assignments.
     """
     if not config.AUTH_PROVIDER_FOR_ROLE_CHECK:
-        logger.warn("PAT role assignment validation is not supported with the current OAuth provider.")
+        logger.warning("PAT role assignment validation is not supported with the current OAuth provider.")
     elif config.TEST_TOKEN:
-        logger.warn("PAT role assignment validation skipped due to 'TEST_TOKEN=True'")
+        logger.warning("PAT role assignment validation skipped due to 'TEST_TOKEN=True'")
     else:
         pat_roles: Set[str] = set(pat_data.roles)
-        application_role_assignments = role_assignments_provider.get_assignments()
-        app_role_assignments_for_user = application_role_assignments[pat_data.user_id]
+        application_role_assignments: dict[str, set[str]] = role_assignments_provider.get_assignments()
+        app_role_assignments_for_user = application_role_assignments.get(
+            pat_data.user_id, set()
+        )  # default is empty set
         pat_data.roles = list(pat_roles & app_role_assignments_for_user)
     return pat_data

--- a/src/tests/unit/authentication/test_utils.py
+++ b/src/tests/unit/authentication/test_utils.py
@@ -1,6 +1,6 @@
 import unittest
 from datetime import datetime
-from unittest import mock, skip
+from unittest import mock
 
 from authentication.models import AccessLevel, PATData
 from authentication.utils import remove_pat_roles_not_assigned_by_auth_provider
@@ -22,7 +22,6 @@ class RemovePatRolesNotAssignedByAuthProviderTestCase(unittest.TestCase):
         config.TEST_TOKEN = self.original_config.TEST_TOKEN
         config.AUTH_PROVIDER_FOR_ROLE_CHECK = self.original_config.AUTH_PROVIDER_FOR_ROLE_CHECK
 
-    @skip(reason="Now throws due to keyError. Trying to fetch roleAssignments['user_id'] which does not exist.")
     def test_assert_returns_no_roles_when_roles_from_auth_provider_is_empty(self):
         self.mock_role_provider.get_assignments.return_value = {}
 


### PR DESCRIPTION
## What does this pull request change?

There is a method which was throwing since it used direct access with [], now switched to `dict.get()` so it does not throw

Also changed `.warn()` -> `.warning()` since `.warn()` is deprecated

## Why is this pull request needed?

## Issues related to this change:
