### PR TITLE
refactor: remove unused methods in tree node

### DIFF
--- a/src/common/tree_node_serializer.py
+++ b/src/common/tree_node_serializer.py
@@ -69,8 +69,8 @@ def tree_node_to_ref_dict(node: Node | ListNode) -> dict:
     Rebuilds the entity as it should be stored based on the passed child entities that can be either contained
     documents, or references.
     """
-    if node.is_empty():
-        return node.entity
+    if not node.entity:
+        return {}
     data = {}
     if node.uid and node.type != SIMOS.REFERENCE.value:
         data = {"_id": node.uid}

--- a/src/domain_classes/tree_node.py
+++ b/src/domain_classes/tree_node.py
@@ -147,20 +147,8 @@ class NodeBase:
     def is_array(self):
         return isinstance(self, ListNode)
 
-    def is_complex_array(self):
-        return self.attribute.is_matrix
-
-    def is_single(self):
-        return isinstance(self, Node)
-
     def is_root(self):
         if self.parent is None:
-            return True
-        else:
-            return False
-
-    def is_leaf(self):
-        if len(self.children) == 0:
             return True
         else:
             return False
@@ -191,13 +179,6 @@ class NodeBase:
                     new_node.parent = node
                     node.children[i] = new_node
 
-    def has_children(self):
-        return len(self.children) > 0
-
-    def contains(self, name: str):
-        keys = [child.key for child in self.children]
-        return name in keys
-
     def get_by_path(self, keys: List[str]):
         """
         Uses a list of keys to find and return the correct child node
@@ -208,18 +189,6 @@ class NodeBase:
             return self
 
         next_node = next((x for x in self.children if x.key == keys[0].strip("[]")), None)
-        if not next_node:
-            return
-        keys.pop(0)
-        next_node = next_node.get_by_path(keys)
-        return next_node
-
-    def get_by_ref_part(self, keys: List[str]):
-        # TODO: Only supports AttributeItems now
-        if len(keys) == 0:
-            return self
-
-        next_node = next((x for x in self.children if x.key == keys[0]), None)
         if not next_node:
             return
         keys.pop(0)

--- a/src/domain_classes/tree_node.py
+++ b/src/domain_classes/tree_node.py
@@ -60,16 +60,6 @@ class NodeBase:
             return create_default_storage_recipe()
         return context_recipes
 
-    def is_empty(self):
-        return not self.entity
-
-    @property
-    def parent_node_id(self):
-        if not self.parent:
-            return None
-
-        return self.parent.node_id
-
     @property
     def storage_contained(self):
         if not self.parent or self.parent.type == SIMOS.DATASOURCE.value:
@@ -147,19 +137,13 @@ class NodeBase:
     def is_array(self):
         return isinstance(self, ListNode)
 
-    def is_root(self):
-        if self.parent is None:
-            return True
-        else:
-            return False
-
     def add_child(self, child_node):
         child_node.parent = self
         self.children.append(child_node)
 
     def depth(self):
         """Depth of current node"""
-        if self.is_root():
+        if self.parent is None:
             return 0
         else:
             return 1 + self.parent.depth()
@@ -245,9 +229,6 @@ class Node(NodeBase):
             key, attribute, uid, parent, blueprint_provider, entity=entity, recipe_provider=recipe_provider
         )
         self.entity: dict = entity if entity else {}
-
-    def is_root(self):
-        return super().is_root()
 
     # Replace the entire data of the node with the input dict. If it matches the blueprint...
     def update(self, data: dict):

--- a/src/tests/unit/tree_functionality/test_tree_node_helpers.py
+++ b/src/tests/unit/tree_functionality/test_tree_node_helpers.py
@@ -26,36 +26,11 @@ def flatten_dict(dd, separator="_", prefix=""):
     )
 
 
-class TreenodeTestCase(unittest.TestCase):
+class TreeNodeHelpersTestCase(unittest.TestCase):
     def setUp(self) -> None:
         self.recipe_provider = MockStorageRecipeProvider(
             "src/tests/unit/mock_data/mock_storage_recipes/mock_storage_recipes.json"
         ).provider
-
-    def test_is_root(self):
-        root_data = {"_id": 1, "name": "root", "description": "", "type": "all_contained_cases_blueprint"}
-        root = Node(
-            key="root",
-            uid="1",
-            entity=root_data,
-            blueprint_provider=mock_document_service.get_blueprint,
-            attribute=BlueprintAttribute(name="", attribute_type="all_contained_cases_blueprint"),
-            recipe_provider=self.recipe_provider,
-        )
-
-        nested_data = {"name": "Nested", "description": "", "type": "Garden"}
-        nested = Node(
-            key="nested",
-            uid="",
-            entity=nested_data,
-            blueprint_provider=mock_document_service.get_blueprint,
-            parent=root,
-            attribute=BlueprintAttribute(name="", attribute_type="Garden"),
-            recipe_provider=self.recipe_provider,
-        )
-
-        assert root.is_root()
-        assert not nested.is_root()
 
     def test_replace(self):
         root_data = {"_id": 1, "name": "root", "description": "", "type": "all_contained_cases_blueprint"}


### PR DESCRIPTION
## What does this pull request change?

So there was like 7-8 methods in tree node that had 0 usages. 
That class is quite large and hard-to-read, so it's nice to clean it up a bit. 

The methods were mostly small helper methods, which can be easily re-written or found in the git log if they are required again 

## Why is this pull request needed?

Because we need to keep it simple, small, and easy to read

## Issues related to this change:
