### PR TITLE
Test: Start of tree-node unit tests refactor

### DIFF
--- a/src/tests/unit/tree_functionality/test_tree_node_helpers.py
+++ b/src/tests/unit/tree_functionality/test_tree_node_helpers.py
@@ -4,6 +4,7 @@ from common.tree_node_serializer import tree_node_from_dict, tree_node_to_dict
 from common.utils.data_structure.compare import get_and_print_diff
 from domain_classes.blueprint_attribute import BlueprintAttribute
 from domain_classes.tree_node import ListNode, Node
+from tests.unit.mock_data.mock_blueprint_provider import MockBlueprintProvider
 from tests.unit.mock_data.mock_recipe_provider import MockStorageRecipeProvider
 from tests.unit.tree_functionality.mock_data_for_tree_tests.get_node_for_tree_tests import (
     get_engine_package_node,
@@ -31,6 +32,23 @@ class TreeNodeHelpersTestCase(unittest.TestCase):
         self.recipe_provider = MockStorageRecipeProvider(
             "src/tests/unit/mock_data/mock_storage_recipes/mock_storage_recipes.json"
         ).provider
+        simos_blueprints = [
+            "dmss://system/SIMOS/NamedEntity",
+            "dmss://system/SIMOS/Reference",
+            "dmss://system/SIMOS/Blob",
+        ]
+        mock_blueprint_folder = (
+            "src/tests/unit/tree_functionality/mock_data_for_tree_tests/mock_blueprints_for_tree_tests"
+        )
+        mock_blueprints_and_file_names = {
+            "all_contained_cases_blueprint": "all_contained_cases_blueprint.blueprint.json",
+            "Garden": "Garden.blueprint.json",
+        }
+        self.mock_blueprint_provider = MockBlueprintProvider(
+            mock_blueprints_and_file_names=mock_blueprints_and_file_names,
+            mock_blueprint_folder=mock_blueprint_folder,
+            simos_blueprints_available_for_test=simos_blueprints,
+        ).get_blueprint
 
     def test_replace(self):
         root_data = {"_id": 1, "name": "root", "description": "", "type": "all_contained_cases_blueprint"}
@@ -38,7 +56,7 @@ class TreeNodeHelpersTestCase(unittest.TestCase):
             key="",
             uid="1",
             entity=root_data,
-            blueprint_provider=mock_document_service.get_blueprint,
+            blueprint_provider=self.mock_blueprint_provider,
             attribute=BlueprintAttribute(name="", attribute_type="all_contained_cases_blueprint"),
             recipe_provider=self.recipe_provider,
         )
@@ -48,7 +66,7 @@ class TreeNodeHelpersTestCase(unittest.TestCase):
             key="nested",
             uid="",
             entity=nested_1_data,
-            blueprint_provider=mock_document_service.get_blueprint,
+            blueprint_provider=self.mock_blueprint_provider,
             parent=root,
             attribute=BlueprintAttribute(name="", attribute_type="Garden"),
             recipe_provider=self.recipe_provider,
@@ -59,7 +77,7 @@ class TreeNodeHelpersTestCase(unittest.TestCase):
             key="nested",
             uid="",
             entity=nested_2_data,
-            blueprint_provider=mock_document_service.get_blueprint,
+            blueprint_provider=self.mock_blueprint_provider,
             attribute=BlueprintAttribute(name="", attribute_type="Garden"),
             recipe_provider=self.recipe_provider,
         )

--- a/src/tests/unit/tree_functionality/test_tree_node_helpers.py
+++ b/src/tests/unit/tree_functionality/test_tree_node_helpers.py
@@ -57,7 +57,6 @@ class TreeNodeHelpersTestCase(unittest.TestCase):
             entity=root_data,
             blueprint_provider=self.mock_blueprint_provider,
             attribute=BlueprintAttribute(name="", attribute_type="all_contained_cases_blueprint"),
-            recipe_provider=self.recipe_provider,
         )
 
         nested_1_data = {"name": "Nested1", "description": "", "type": "Garden"}
@@ -68,7 +67,6 @@ class TreeNodeHelpersTestCase(unittest.TestCase):
             blueprint_provider=self.mock_blueprint_provider,
             parent=root,
             attribute=BlueprintAttribute(name="", attribute_type="Garden"),
-            recipe_provider=self.recipe_provider,
         )
 
         nested_2_data = {"name": "Nested2", "description": "", "type": "Garden"}
@@ -78,7 +76,6 @@ class TreeNodeHelpersTestCase(unittest.TestCase):
             entity=nested_2_data,
             blueprint_provider=self.mock_blueprint_provider,
             attribute=BlueprintAttribute(name="", attribute_type="Garden"),
-            recipe_provider=self.recipe_provider,
         )
 
         actual_before = {
@@ -106,7 +103,6 @@ class TreeNodeHelpersTestCase(unittest.TestCase):
     def test_depth(self):
         root_data = {"_id": 1, "name": "root", "description": "", "type": "all_contained_cases_blueprint"}
         root = Node(
-            recipe_provider=self.recipe_provider,
             key="root",
             uid="1",
             entity=root_data,
@@ -116,7 +112,6 @@ class TreeNodeHelpersTestCase(unittest.TestCase):
 
         nested_data = {"name": "Nested", "description": "", "type": "Garden"}
         nested = Node(
-            recipe_provider=self.recipe_provider,
             key="nested",
             uid="",
             entity=nested_data,
@@ -170,7 +165,6 @@ class TreeNodeHelpersTestCase(unittest.TestCase):
     def test_traverse_reverse(self):
         root_data = {"_id": 1, "name": "root", "description": "", "type": "all_contained_cases_blueprint"}
         root = Node(
-            recipe_provider=self.recipe_provider,
             key="root",
             uid="1",
             entity=root_data,
@@ -180,7 +174,6 @@ class TreeNodeHelpersTestCase(unittest.TestCase):
 
         nested_data = {"name": "Nested1", "description": "", "type": "Garden"}
         nested = Node(
-            recipe_provider=self.recipe_provider,
             key="nested",
             uid="",
             entity=nested_data,
@@ -191,7 +184,6 @@ class TreeNodeHelpersTestCase(unittest.TestCase):
 
         nested_2_data = {"name": "Nested2", "description": "", "type": "Bush"}
         nested_2 = Node(
-            recipe_provider=self.recipe_provider,
             key="nested",
             uid="",
             entity=nested_2_data,
@@ -207,7 +199,6 @@ class TreeNodeHelpersTestCase(unittest.TestCase):
     def test_node_id(self):
         root_data = {"_id": 1, "name": "root", "description": "", "type": "all_contained_cases_blueprint"}
         root = Node(
-            recipe_provider=self.recipe_provider,
             key="",
             uid="1",
             entity=root_data,
@@ -217,7 +208,6 @@ class TreeNodeHelpersTestCase(unittest.TestCase):
 
         nested_data = {"name": "Nested", "description": "", "type": "Garden"}
         nested = Node(
-            recipe_provider=self.recipe_provider,
             key="nested",
             uid="",
             entity=nested_data,
@@ -228,7 +218,6 @@ class TreeNodeHelpersTestCase(unittest.TestCase):
 
         nested_2_data = {"name": "Nested", "description": "", "type": "Bush"}
         nested_2 = Node(
-            recipe_provider=self.recipe_provider,
             key="nested",
             uid="",
             entity=nested_2_data,
@@ -239,7 +228,6 @@ class TreeNodeHelpersTestCase(unittest.TestCase):
 
         nested_2_reference_data = {"_id": "2", "name": "Reference", "description": "", "type": "Garden"}
         reference = Node(
-            recipe_provider=self.recipe_provider,
             key="reference",
             uid="2",
             entity=nested_2_reference_data,
@@ -250,7 +238,6 @@ class TreeNodeHelpersTestCase(unittest.TestCase):
 
         list_data = {"name": "List", "type": "Bush"}
         list_node = ListNode(
-            recipe_provider=self.recipe_provider,
             key="list",
             uid="",
             entity=list_data,
@@ -261,7 +248,6 @@ class TreeNodeHelpersTestCase(unittest.TestCase):
 
         item_1_data = {"name": "Item1", "description": "", "type": "Garden"}
         item_1 = Node(
-            recipe_provider=self.recipe_provider,
             key="0",
             uid="",
             entity=item_1_data,
@@ -303,7 +289,6 @@ class TreeNodeHelpersTestCase(unittest.TestCase):
             document_1,
             self.mock_blueprint_provider,
             uid=document_1.get("_id"),
-            recipe_provider=self.recipe_provider,
         )
 
         child_1 = root.search("1.nested.nested")
@@ -337,7 +322,6 @@ class TreeNodeHelpersTestCase(unittest.TestCase):
             document_1,
             self.mock_blueprint_provider,
             uid=document_1.get("_id"),
-            recipe_provider=self.recipe_provider,
         )
 
         child_1 = root.get_by_path(["nested", "nested"])
@@ -373,7 +357,6 @@ class TreeNodeHelpersTestCase(unittest.TestCase):
             document_1,
             self.mock_blueprint_provider,
             uid=document_1.get("_id"),
-            recipe_provider=self.recipe_provider,
         )
 
         update_0 = {

--- a/src/tests/unit/tree_functionality/test_tree_node_helpers.py
+++ b/src/tests/unit/tree_functionality/test_tree_node_helpers.py
@@ -33,9 +33,7 @@ class TreeNodeHelpersTestCase(unittest.TestCase):
             "src/tests/unit/mock_data/mock_storage_recipes/mock_storage_recipes.json"
         ).provider
         simos_blueprints = [
-            "dmss://system/SIMOS/NamedEntity",
             "dmss://system/SIMOS/Reference",
-            "dmss://system/SIMOS/Blob",
         ]
         mock_blueprint_folder = (
             "src/tests/unit/tree_functionality/mock_data_for_tree_tests/mock_blueprints_for_tree_tests"

--- a/src/tests/unit/tree_functionality/test_tree_node_helpers.py
+++ b/src/tests/unit/tree_functionality/test_tree_node_helpers.py
@@ -111,7 +111,7 @@ class TreeNodeHelpersTestCase(unittest.TestCase):
             key="root",
             uid="1",
             entity=root_data,
-            blueprint_provider=mock_document_service.get_blueprint,
+            blueprint_provider=self.mock_blueprint_provider,
             attribute=BlueprintAttribute(name="", attribute_type="all_contained_cases_blueprint"),
         )
 
@@ -121,7 +121,7 @@ class TreeNodeHelpersTestCase(unittest.TestCase):
             key="nested",
             uid="",
             entity=nested_data,
-            blueprint_provider=mock_document_service.get_blueprint,
+            blueprint_provider=self.mock_blueprint_provider,
             parent=root,
             attribute=BlueprintAttribute(name="", attribute_type="Garden"),
         )

--- a/src/tests/unit/tree_functionality/test_tree_node_helpers.py
+++ b/src/tests/unit/tree_functionality/test_tree_node_helpers.py
@@ -43,6 +43,7 @@ class TreeNodeHelpersTestCase(unittest.TestCase):
         mock_blueprints_and_file_names = {
             "all_contained_cases_blueprint": "all_contained_cases_blueprint.blueprint.json",
             "Garden": "Garden.blueprint.json",
+            "Bush": "Bush.blueprint.json",
         }
         self.mock_blueprint_provider = MockBlueprintProvider(
             mock_blueprints_and_file_names=mock_blueprints_and_file_names,
@@ -151,7 +152,7 @@ class TreeNodeHelpersTestCase(unittest.TestCase):
 
         root = tree_node_from_dict(
             document_1,
-            mock_document_service.get_blueprint,
+            self.mock_blueprint_provider,
             uid=document_1.get("_id"),
             recipe_provider=self.recipe_provider,
         )
@@ -302,7 +303,7 @@ class TreeNodeHelpersTestCase(unittest.TestCase):
 
         root = tree_node_from_dict(
             document_1,
-            mock_document_service.get_blueprint,
+            self.mock_blueprint_provider,
             uid=document_1.get("_id"),
             recipe_provider=self.recipe_provider,
         )
@@ -336,7 +337,7 @@ class TreeNodeHelpersTestCase(unittest.TestCase):
 
         root = tree_node_from_dict(
             document_1,
-            mock_document_service.get_blueprint,
+            self.mock_blueprint_provider,
             uid=document_1.get("_id"),
             recipe_provider=self.recipe_provider,
         )
@@ -372,7 +373,7 @@ class TreeNodeHelpersTestCase(unittest.TestCase):
 
         root = tree_node_from_dict(
             document_1,
-            mock_document_service.get_blueprint,
+            self.mock_blueprint_provider,
             uid=document_1.get("_id"),
             recipe_provider=self.recipe_provider,
         )


### PR DESCRIPTION
## What does this pull request change?

We created a blueprint mocker a while ago that was to be used in all the unit tests. 
Now we are starting to use that in the `tree_tests` as well. 

Also some refactoring in the tests to have less duplication of code. More happens in the setup. 


## Why is this pull request needed?

## Issues related to this change:
