### PR TITLE
Test: Refactor finish test tree node helpers and tree node to dict

### DIFF
--- a/src/tests/unit/tree_functionality/test_tree_node_delete.py
+++ b/src/tests/unit/tree_functionality/test_tree_node_delete.py
@@ -3,98 +3,99 @@ import unittest
 from common.tree_node_serializer import tree_node_from_dict, tree_node_to_dict
 from domain_classes.blueprint_attribute import BlueprintAttribute
 from domain_classes.tree_node import Node
-from tests.unit.mock_data.mock_recipe_provider import MockStorageRecipeProvider
-from tests.unit.tree_functionality.mock_data_for_tree_tests.mock_document_service_for_tree_tests import (
-    mock_document_service,
-)
+from tests.unit.mock_data.mock_blueprint_provider import MockBlueprintProvider
 
 
 class TreeNodeDeleteTest(unittest.TestCase):
     def setUp(self) -> None:
-        self.recipe_provider = MockStorageRecipeProvider(
-            "src/tests/unit/mock_data/mock_storage_recipes/mock_storage_recipes.json"
-        ).provider
+        simos_blueprints = []
+        mock_blueprint_folder = (
+            "src/tests/unit/tree_functionality/mock_data_for_tree_tests/mock_blueprints_for_tree_tests"
+        )
+        mock_blueprints_and_file_names = {
+            "Blueprint4": "Blueprint4.blueprint.json",
+            "Bush": "Bush.blueprint.json",
+            "Garden": "Garden.blueprint.json",
+            "all_contained_cases_blueprint": "all_contained_cases_blueprint.blueprint.json",
+        }
+        self.mock_blueprint_provider = MockBlueprintProvider(
+            mock_blueprints_and_file_names=mock_blueprints_and_file_names,
+            mock_blueprint_folder=mock_blueprint_folder,
+            simos_blueprints_available_for_test=simos_blueprints,
+        ).get_blueprint
 
     def test_delete_root_child(self):
-        root_data = {"_id": 1, "name": "root", "description": "", "type": "all_contained_cases_blueprint"}
+        root_data = {"_id": 1, "name": "root", "type": "all_contained_cases_blueprint"}
         root = Node(
             key="root",
             uid="1",
             entity=root_data,
-            blueprint_provider=mock_document_service.get_blueprint,
+            blueprint_provider=self.mock_blueprint_provider,
             attribute=BlueprintAttribute(name="", attribute_type="all_contained_cases_blueprint"),
-            recipe_provider=self.recipe_provider,
         )
 
-        nested_1_data = {"name": "Nested1", "description": "", "type": "Garden"}
+        nested_1_data = {"name": "Nested1", "type": "Garden"}
         nested_1 = Node(
             key="nested",
             uid="",
             entity=nested_1_data,
-            blueprint_provider=mock_document_service.get_blueprint,
+            blueprint_provider=self.mock_blueprint_provider,
             parent=root,
             attribute=BlueprintAttribute(name="", attribute_type="Garden"),
-            recipe_provider=self.recipe_provider,
         )
 
         actual_before = {
             "_id": "1",
             "name": "root",
-            "description": "",
             "type": "all_contained_cases_blueprint",
-            "nested": {"name": "Nested1", "description": "", "type": "Garden"},
+            "nested": {"name": "Nested1", "type": "Garden"},
         }
 
         assert actual_before == tree_node_to_dict(root)
 
         root.remove_by_path(["nested"])
 
-        actual_after_delete = {"_id": "1", "name": "root", "description": "", "type": "all_contained_cases_blueprint"}
+        actual_after_delete = {"_id": "1", "name": "root", "type": "all_contained_cases_blueprint"}
 
         assert actual_after_delete == tree_node_to_dict(root)
 
     def test_delete_nested_child(self):
-        root_data = {"_id": 1, "name": "root", "description": "", "type": "all_contained_cases_blueprint"}
+        root_data = {"_id": 1, "name": "root", "type": "all_contained_cases_blueprint"}
         root = Node(
             key="root",
             uid="1",
             entity=root_data,
-            blueprint_provider=mock_document_service.get_blueprint,
+            blueprint_provider=self.mock_blueprint_provider,
             attribute=BlueprintAttribute(name="", attribute_type="all_contained_cases_blueprint"),
-            recipe_provider=self.recipe_provider,
         )
 
-        nested_1_data = {"name": "Nested1", "description": "", "type": "Garden"}
+        nested_1_data = {"name": "Nested1", "type": "Garden"}
         nested_1 = Node(
             key="nested",
             uid="",
             entity=nested_1_data,
-            blueprint_provider=mock_document_service.get_blueprint,
+            blueprint_provider=self.mock_blueprint_provider,
             parent=root,
             attribute=BlueprintAttribute(name="", attribute_type="Garden"),
-            recipe_provider=self.recipe_provider,
         )
-        nested_2_data = {"name": "Nested2", "description": "", "type": "Bush"}
+        nested_2_data = {"name": "Nested2", "type": "Bush"}
         nested_2 = Node(
             key="nested2",
             uid="",
             entity=nested_2_data,
-            blueprint_provider=mock_document_service.get_blueprint,
+            blueprint_provider=self.mock_blueprint_provider,
             parent=nested_1,
             attribute=BlueprintAttribute(name="", attribute_type="Bush"),
-            recipe_provider=self.recipe_provider,
         )
 
         actual_before = {
             "_id": "1",
             "name": "root",
-            "description": "",
             "type": "all_contained_cases_blueprint",
             "nested": {
                 "name": "Nested1",
-                "description": "",
                 "type": "Garden",
-                "nested2": {"name": "Nested2", "description": "", "type": "Bush"},
+                "nested2": {"name": "Nested2", "type": "Bush"},
             },
         }
 
@@ -105,9 +106,8 @@ class TreeNodeDeleteTest(unittest.TestCase):
         actual_after_delete = {
             "_id": "1",
             "name": "root",
-            "description": "",
             "type": "all_contained_cases_blueprint",
-            "nested": {"name": "Nested1", "description": "", "type": "Garden"},
+            "nested": {"name": "Nested1", "type": "Garden"},
         }
 
         assert actual_after_delete == tree_node_to_dict(root)
@@ -116,40 +116,35 @@ class TreeNodeDeleteTest(unittest.TestCase):
         document = {
             "_id": "1",
             "name": "root",
-            "description": "",
             "type": "Blueprint4",
             "a_list": [
                 {
                     "name": "Nested1",
-                    "description": "",
                     "type": "Blueprint4",
                     "a_list": [
-                        {"name": "Nested2-index-0", "description": "", "type": "Blueprint4", "a_list": []},
-                        {"name": "Nested2-index-1", "description": "", "type": "Blueprint4", "a_list": []},
+                        {"name": "Nested2-index-0", "type": "Blueprint4", "a_list": []},
+                        {"name": "Nested2-index-1", "type": "Blueprint4", "a_list": []},
                     ],
                 }
             ],
         }
         root = tree_node_from_dict(
             document,
-            mock_document_service.get_blueprint,
+            self.mock_blueprint_provider,
             uid=document.get("_id"),
-            recipe_provider=self.recipe_provider,
         )
 
         actual_before = {
             "_id": "1",
             "name": "root",
-            "description": "",
             "type": "Blueprint4",
             "a_list": [
                 {
                     "name": "Nested1",
-                    "description": "",
                     "type": "Blueprint4",
                     "a_list": [
-                        {"name": "Nested2-index-0", "description": "", "type": "Blueprint4", "a_list": []},
-                        {"name": "Nested2-index-1", "description": "", "type": "Blueprint4", "a_list": []},
+                        {"name": "Nested2-index-0", "type": "Blueprint4", "a_list": []},
+                        {"name": "Nested2-index-1", "type": "Blueprint4", "a_list": []},
                     ],
                 }
             ],
@@ -162,14 +157,12 @@ class TreeNodeDeleteTest(unittest.TestCase):
         actual_after_delete = {
             "_id": "1",
             "name": "root",
-            "description": "",
             "type": "Blueprint4",
             "a_list": [
                 {
                     "name": "Nested1",
-                    "description": "",
                     "type": "Blueprint4",
-                    "a_list": [{"name": "Nested2-index-0", "description": "", "type": "Blueprint4", "a_list": []}],
+                    "a_list": [{"name": "Nested2-index-0", "type": "Blueprint4", "a_list": []}],
                 }
             ],
         }

--- a/src/tests/unit/tree_functionality/test_tree_node_from_dict.py
+++ b/src/tests/unit/tree_functionality/test_tree_node_from_dict.py
@@ -2,7 +2,6 @@ import json
 import unittest
 
 from common.tree_node_serializer import tree_node_from_dict, tree_node_to_dict
-from common.utils.data_structure.compare import get_and_print_diff
 from enums import REFERENCE_TYPES, SIMOS
 from tests.unit.tree_functionality.mock_data_for_tree_tests.mock_blueprint_provider_for_tree_tests import (
     BlueprintProvider,
@@ -107,92 +106,92 @@ class TreeNodeFromDictTestCase(unittest.TestCase):
             ],
         }
 
-        assert get_and_print_diff(actual, tree_node_to_dict(root)) == []
+        self.assertDictEqual(actual, tree_node_to_dict(root))
 
-        def test_from_dict_using_dict_importer(self):
-            document_1 = {
-                "_id": "1",
-                "name": "Parent",
+    def test_from_dict_using_dict_importer(self):
+        document_1 = {
+            "_id": "1",
+            "name": "Parent",
+            "description": "",
+            "type": "all_contained_cases_blueprint",
+            "nested": {
+                "name": "Nested",
                 "description": "",
-                "type": "all_contained_cases_blueprint",
+                "type": "Garden",
+                "_blueprint": Garden,
                 "nested": {
                     "name": "Nested",
                     "description": "",
-                    "type": "Garden",
-                    "_blueprint": Garden,
-                    "nested": {
-                        "name": "Nested",
-                        "description": "",
-                        "type": "Bush",
-                        "_blueprint": Bush,
-                        "reference": {
-                            "address": "$5",
-                            "type": SIMOS.REFERENCE.value,
-                            "referenceType": REFERENCE_TYPES.LINK.value,
-                        },
+                    "type": "Bush",
+                    "_blueprint": Bush,
+                    "reference": {
+                        "address": "$5",
+                        "type": SIMOS.REFERENCE.value,
+                        "referenceType": REFERENCE_TYPES.LINK.value,
                     },
                 },
-                "reference": {
-                    "_id": "2",
-                    "name": "Reference",
+            },
+            "reference": {
+                "_id": "2",
+                "name": "Reference",
+                "description": "",
+                "type": "Garden",
+                "_blueprint": Garden,
+            },
+            "references": [
+                {
+                    "_id": "3",
+                    "name": "Reference-1",
                     "description": "",
                     "type": "Garden",
                     "_blueprint": Garden,
                 },
-                "references": [
-                    {
-                        "_id": "3",
-                        "name": "Reference-1",
-                        "description": "",
-                        "type": "Garden",
-                        "_blueprint": Garden,
-                    },
-                    {
-                        "_id": "4",
-                        "name": "Reference-2",
-                        "description": "",
-                        "type": "Garden",
-                        "_blueprint": Garden,
-                    },
-                ],
-                "_blueprint": all_contained_cases_blueprint,
-            }
+                {
+                    "_id": "4",
+                    "name": "Reference-2",
+                    "description": "",
+                    "type": "Garden",
+                    "_blueprint": Garden,
+                },
+            ],
+            "_blueprint": all_contained_cases_blueprint,
+        }
 
-            actual = {
-                "_id": "1",
-                "name": "Parent",
+        actual = {
+            "_id": "1",
+            "name": "Parent",
+            "description": "",
+            "type": "all_contained_cases_blueprint",
+            "nested": {
+                "name": "Nested",
                 "description": "",
-                "type": "all_contained_cases_blueprint",
+                "type": "Garden",
                 "nested": {
                     "name": "Nested",
                     "description": "",
-                    "type": "Garden",
-                    "nested": {
-                        "name": "Nested",
-                        "description": "",
-                        "type": "Bush",
-                        "reference": {
-                            "address": "$5",
-                            "type": SIMOS.REFERENCE.value,
-                            "referenceType": REFERENCE_TYPES.LINK.value,
-                        },
+                    "type": "Bush",
+                    "reference": {
+                        "address": "$5",
+                        "type": SIMOS.REFERENCE.value,
+                        "referenceType": REFERENCE_TYPES.LINK.value,
                     },
                 },
-                "reference": {"_id": "2", "name": "Reference", "description": "", "type": "Garden", "nested": {}},
-                "references": [
-                    {"_id": "3", "name": "Reference-1", "description": "", "type": "Garden", "nested": {}},
-                    {"_id": "4", "name": "Reference-2", "description": "", "type": "Garden", "nested": {}},
-                ],
-            }
+            },
+            "reference": {"_id": "2", "name": "Reference", "description": "", "type": "Garden", "nested": {}},
+            "references": [
+                {"_id": "3", "name": "Reference-1", "description": "", "type": "Garden", "nested": {}},
+                {"_id": "4", "name": "Reference-2", "description": "", "type": "Garden", "nested": {}},
+            ],
+        }
 
-            root = tree_node_from_dict(
-                document_1,
-                BlueprintProvider.get_blueprint,
-                uid=document_1.get("_id"),
-                recipe_provider=mock_storage_recipe_provider,
-            )
+        root = tree_node_from_dict(
+            document_1,
+            BlueprintProvider.get_blueprint,
+            uid=document_1.get("_id"),
+            recipe_provider=mock_storage_recipe_provider,
+        )
 
-            assert get_and_print_diff(actual, tree_node_to_dict(root)) == []
+        self.assertDictEqual(actual, tree_node_to_dict(root))
 
     def test_from_dict_optional_values(self):
         doc = {

--- a/src/tests/unit/tree_functionality/test_tree_node_helpers.py
+++ b/src/tests/unit/tree_functionality/test_tree_node_helpers.py
@@ -1,16 +1,12 @@
 import unittest
 
 from common.tree_node_serializer import tree_node_from_dict, tree_node_to_dict
-from common.utils.data_structure.compare import get_and_print_diff
 from domain_classes.blueprint_attribute import BlueprintAttribute
 from domain_classes.tree_node import ListNode, Node
 from tests.unit.mock_data.mock_blueprint_provider import MockBlueprintProvider
 from tests.unit.mock_data.mock_recipe_provider import MockStorageRecipeProvider
 from tests.unit.tree_functionality.mock_data_for_tree_tests.get_node_for_tree_tests import (
     get_engine_package_node,
-)
-from tests.unit.tree_functionality.mock_data_for_tree_tests.mock_document_service_for_tree_tests import (
-    mock_document_service,
 )
 
 
@@ -168,7 +164,7 @@ class TreeNodeHelpersTestCase(unittest.TestCase):
             key="root",
             uid="1",
             entity=root_data,
-            blueprint_provider=mock_document_service.get_blueprint,
+            blueprint_provider=self.mock_blueprint_provider,
             attribute=BlueprintAttribute(name="", attribute_type="all_contained_cases_blueprint"),
         )
 
@@ -177,7 +173,7 @@ class TreeNodeHelpersTestCase(unittest.TestCase):
             key="nested",
             uid="",
             entity=nested_data,
-            blueprint_provider=mock_document_service.get_blueprint,
+            blueprint_provider=self.mock_blueprint_provider,
             parent=root,
             attribute=BlueprintAttribute(name="", attribute_type="Garden"),
         )
@@ -187,7 +183,7 @@ class TreeNodeHelpersTestCase(unittest.TestCase):
             key="nested",
             uid="",
             entity=nested_2_data,
-            blueprint_provider=mock_document_service.get_blueprint,
+            blueprint_provider=self.mock_blueprint_provider,
             parent=nested,
             attribute=BlueprintAttribute(name="", attribute_type="Bush"),
         )
@@ -202,7 +198,7 @@ class TreeNodeHelpersTestCase(unittest.TestCase):
             key="",
             uid="1",
             entity=root_data,
-            blueprint_provider=mock_document_service.get_blueprint,
+            blueprint_provider=self.mock_blueprint_provider,
             attribute=BlueprintAttribute(name="", attribute_type="all_contained_cases_blueprint"),
         )
 
@@ -211,7 +207,7 @@ class TreeNodeHelpersTestCase(unittest.TestCase):
             key="nested",
             uid="",
             entity=nested_data,
-            blueprint_provider=mock_document_service.get_blueprint,
+            blueprint_provider=self.mock_blueprint_provider,
             parent=root,
             attribute=BlueprintAttribute(name="", attribute_type="Garden"),
         )
@@ -221,7 +217,7 @@ class TreeNodeHelpersTestCase(unittest.TestCase):
             key="nested",
             uid="",
             entity=nested_2_data,
-            blueprint_provider=mock_document_service.get_blueprint,
+            blueprint_provider=self.mock_blueprint_provider,
             parent=nested,
             attribute=BlueprintAttribute(name="", attribute_type="Bush"),
         )
@@ -231,7 +227,7 @@ class TreeNodeHelpersTestCase(unittest.TestCase):
             key="reference",
             uid="2",
             entity=nested_2_reference_data,
-            blueprint_provider=mock_document_service.get_blueprint,
+            blueprint_provider=self.mock_blueprint_provider,
             parent=nested_2,
             attribute=BlueprintAttribute(name="", attribute_type="Garden"),
         )
@@ -241,7 +237,7 @@ class TreeNodeHelpersTestCase(unittest.TestCase):
             key="list",
             uid="",
             entity=list_data,
-            blueprint_provider=mock_document_service.get_blueprint,
+            blueprint_provider=self.mock_blueprint_provider,
             parent=root,
             attribute=BlueprintAttribute(name="", attribute_type="Bush"),
         )
@@ -251,18 +247,18 @@ class TreeNodeHelpersTestCase(unittest.TestCase):
             key="0",
             uid="",
             entity=item_1_data,
-            blueprint_provider=mock_document_service.get_blueprint,
+            blueprint_provider=self.mock_blueprint_provider,
             parent=list_node,
             attribute=BlueprintAttribute(name="", attribute_type="Garden"),
         )
 
-        assert root.node_id == "1"
-        assert nested.node_id == "1.nested"
-        assert nested_2.node_id == "1.nested.nested"
-        assert nested_2.node_id == "1.nested.nested"
-        assert reference.node_id == "1.nested.nested.reference"
-        assert list_node.node_id == "1.list"
-        assert item_1.node_id == "1.list.0"
+        self.assertEqual(root.node_id, "1")
+        self.assertEqual(nested.node_id, "1.nested")
+        self.assertEqual(nested_2.node_id, "1.nested.nested")
+        self.assertEqual(nested_2.node_id, "1.nested.nested")
+        self.assertEqual(reference.node_id, "1.nested.nested.reference")
+        self.assertEqual(list_node.node_id, "1.list")
+        self.assertEqual(item_1.node_id, "1.list.0")
 
     def test_search(self):
         document_1 = {
@@ -293,11 +289,11 @@ class TreeNodeHelpersTestCase(unittest.TestCase):
 
         child_1 = root.search("1.nested.nested")
 
-        assert child_1.node_id == "1.nested.nested"
+        self.assertEqual(child_1.node_id, "1.nested.nested")
 
         child_2 = root.search("1.nested.nested.reference")
 
-        assert child_2.node_id == "1.nested.nested.reference"
+        self.assertEqual(child_2.node_id, "1.nested.nested.reference")
 
     def test_get_by_keys(self):
         document_1 = {
@@ -326,11 +322,11 @@ class TreeNodeHelpersTestCase(unittest.TestCase):
 
         child_1 = root.get_by_path(["nested", "nested"])
 
-        assert child_1.node_id == "1.nested.nested"
+        self.assertEqual(child_1.node_id, "1.nested.nested")
 
         child_2 = root.get_by_path(["nested", "nested", "reference"])
 
-        assert child_2.uid == "2"
+        self.assertEqual(child_2.uid, "2")
 
     def test_update(self):
         document_1 = {
@@ -380,7 +376,7 @@ class TreeNodeHelpersTestCase(unittest.TestCase):
 
         root.update(update_0)
 
-        assert get_and_print_diff(tree_node_to_dict(root), {**update_0, "_id": "1"}) == []
+        self.assertDictEqual(tree_node_to_dict(root), {**update_0, "_id": "1"})
 
         update_1 = {
             "name": "New-name",
@@ -403,7 +399,7 @@ class TreeNodeHelpersTestCase(unittest.TestCase):
 
         root.update(update_1)
 
-        assert get_and_print_diff(tree_node_to_dict(root), {**update_1, "_id": "1"}) == []
+        self.assertDictEqual(tree_node_to_dict(root), {**update_1, "_id": "1"})
 
         update_2 = {
             "name": "New-name",
@@ -426,7 +422,7 @@ class TreeNodeHelpersTestCase(unittest.TestCase):
 
         root.update(update_2)
 
-        assert get_and_print_diff(tree_node_to_dict(root), {**update_2, "_id": "1"}) == []
+        self.assertDictEqual(tree_node_to_dict(root), {**update_2, "_id": "1"})
 
         expected = {
             "_id": "1",
@@ -454,11 +450,11 @@ class TreeNodeHelpersTestCase(unittest.TestCase):
         expected_flat = flatten_dict(expected)
         actual_flat = flatten_dict(tree_node_to_dict(root))
         # less than only works on flat dictionaries.
-        assert expected_flat.items() <= actual_flat.items()
+        self.assertTrue(expected_flat.items() <= actual_flat.items())
 
     def test_is_storage_contained(self):
         engine_package_node = get_engine_package_node()
         engine_ref_node = engine_package_node.children[0].children[0]
 
-        assert engine_ref_node.storage_contained is True
-        assert engine_ref_node.parent.storage_recipes[0].is_contained(engine_ref_node.attribute.name) is True
+        self.assertTrue(engine_ref_node.storage_contained)
+        self.assertTrue(engine_ref_node.parent.storage_recipes[0].is_contained(engine_ref_node.attribute.name))

--- a/src/tests/unit/tree_functionality/test_tree_node_to_dict.py
+++ b/src/tests/unit/tree_functionality/test_tree_node_to_dict.py
@@ -3,15 +3,26 @@ import unittest
 from common.tree_node_serializer import tree_node_to_dict
 from domain_classes.blueprint_attribute import BlueprintAttribute
 from domain_classes.tree_node import ListNode, Node
-from tests.unit.tree_functionality.mock_data_for_tree_tests.mock_blueprint_provider_for_tree_tests import (
-    BlueprintProvider,
-)
-from tests.unit.tree_functionality.mock_data_for_tree_tests.mock_storage_recipe_provider import (
-    mock_storage_recipe_provider,
-)
+from tests.unit.mock_data.mock_blueprint_provider import MockBlueprintProvider
 
 
 class TreeNodeToDictTestCase(unittest.TestCase):
+    def setUp(self) -> None:
+        simos_blueprints = []
+        mock_blueprint_folder = (
+            "src/tests/unit/tree_functionality/mock_data_for_tree_tests/mock_blueprints_for_tree_tests"
+        )
+        mock_blueprints_and_file_names = {
+            "all_contained_cases_blueprint": "all_contained_cases_blueprint.blueprint.json",
+            "Garden": "Garden.blueprint.json",
+            "Bush": "Bush.blueprint.json",
+        }
+        self.mock_blueprint_provider = MockBlueprintProvider(
+            mock_blueprints_and_file_names=mock_blueprints_and_file_names,
+            mock_blueprint_folder=mock_blueprint_folder,
+            simos_blueprints_available_for_test=simos_blueprints,
+        ).get_blueprint
+
     def test_to_dict(self):
         root_data = {
             "_id": 1,
@@ -32,65 +43,59 @@ class TreeNodeToDictTestCase(unittest.TestCase):
             "references": [],
         }
         root = Node(
-            recipe_provider=mock_storage_recipe_provider,
             key="root",
             uid="1",
             entity=root_data,
-            blueprint_provider=BlueprintProvider.get_blueprint,
+            blueprint_provider=self.mock_blueprint_provider,
             attribute=BlueprintAttribute(name="", attribute_type="all_contained_cases_blueprint"),
         )
 
         nested_data = {"name": "Nested", "description": "", "type": "Garden"}
         nested = Node(
-            recipe_provider=mock_storage_recipe_provider,
             key="nested",
             uid="",
             entity=nested_data,
-            blueprint_provider=BlueprintProvider.get_blueprint,
+            blueprint_provider=self.mock_blueprint_provider,
             parent=root,
             attribute=BlueprintAttribute(name="", attribute_type="Garden"),
         )
 
         nested_2_data = {"name": "Nested", "description": "", "type": "Bush"}
         nested_2 = Node(
-            recipe_provider=mock_storage_recipe_provider,
             key="nested",
             uid="",
             entity=nested_2_data,
-            blueprint_provider=BlueprintProvider.get_blueprint,
+            blueprint_provider=self.mock_blueprint_provider,
             parent=nested,
             attribute=BlueprintAttribute(name="", attribute_type="Bush"),
         )
 
         nested_2_reference_data = {"_id": "2", "name": "Reference", "description": "", "type": "Garden"}
         Node(
-            recipe_provider=mock_storage_recipe_provider,
             key="reference",
             uid="2",
             entity=nested_2_reference_data,
-            blueprint_provider=BlueprintProvider.get_blueprint,
+            blueprint_provider=self.mock_blueprint_provider,
             parent=nested_2,
             attribute=BlueprintAttribute(name="", attribute_type="Garden"),
         )
 
         list_data = {"name": "List", "type": "Bush"}
         list_node = ListNode(
-            recipe_provider=mock_storage_recipe_provider,
             key="list",
             uid="",
             entity=list_data,
             parent=root,
-            blueprint_provider=BlueprintProvider.get_blueprint,
+            blueprint_provider=self.mock_blueprint_provider,
             attribute=BlueprintAttribute(name="", attribute_type="Bush"),
         )
 
         item_1_data = {"name": "Item1", "description": "", "type": "Garden"}
         item_1 = Node(
-            recipe_provider=mock_storage_recipe_provider,
             key="0",
             uid="",
             entity=item_1_data,
-            blueprint_provider=BlueprintProvider.get_blueprint,
+            blueprint_provider=self.mock_blueprint_provider,
             parent=list_node,
             attribute=BlueprintAttribute(name="", attribute_type="Garden"),
         )
@@ -126,11 +131,9 @@ class TreeNodeToDictTestCase(unittest.TestCase):
                 "reference": {"_id": "2", "name": "Reference", "description": "", "type": "Garden"},
             },
         }
-
-        self.assertEqual(actual_nested, tree_node_to_dict(nested))
-
         item_1_actual = {"name": "Item1", "description": "", "type": "Garden"}
 
+        self.assertEqual(actual_nested, tree_node_to_dict(nested))
         self.assertEqual(item_1_actual, tree_node_to_dict(item_1))
 
 

--- a/src/tests/unit/tree_functionality/test_tree_node_update.py
+++ b/src/tests/unit/tree_functionality/test_tree_node_update.py
@@ -67,7 +67,6 @@ class DocumentServiceTestCase(unittest.TestCase):
         chest = {
             "_id": "1",
             "name": "TreasureChest",
-            "description": "",
             "type": "ChestWithOptionalBoxInside",
         }
         self.doc_storage = {"1": chest}
@@ -91,7 +90,6 @@ class DocumentServiceTestCase(unittest.TestCase):
         entity = {
             "_id": "1",
             "name": "Parent",
-            "description": "",
             "type": "ChestWithOptionalBoxInside",
         }
         self.doc_storage = {"1": deepcopy(entity)}
@@ -111,7 +109,6 @@ class DocumentServiceTestCase(unittest.TestCase):
             "1": {
                 "_id": "1",
                 "name": "parent",
-                "description": "",
                 "type": "Parent",
                 "SomeChild": {},
             }
@@ -133,11 +130,9 @@ class DocumentServiceTestCase(unittest.TestCase):
         entity = {
             "_id": "1",
             "name": "Parent",
-            "description": "",
             "type": "RoomWithOptionalChestInside",
             "chest": {
                 "name": "chest",
-                "description": "",
                 "type": "ChestWithOptionalBoxInside",
             },
         }
@@ -164,11 +159,9 @@ class DocumentServiceTestCase(unittest.TestCase):
             "1": {
                 "_id": "1",
                 "name": "chest",
-                "description": "",
                 "type": "ChestWithOptionalBoxInside",
                 "box": {
                     "name": "duplicate",
-                    "description": "",
                     "type": "Box",
                 },
             }
@@ -182,7 +175,7 @@ class DocumentServiceTestCase(unittest.TestCase):
             )
 
     def test_add_valid_specialized_child_type(self):
-        entity = {"_id": "1", "name": "parent", "description": "", "type": "Parent", "SomeChild": {}}
+        entity = {"_id": "1", "name": "parent", "type": "Parent", "SomeChild": {}}
         child = {"name": "whatever", "type": "SpecialChild", "AnExtraValue": "Hallo there!", "AValue": 13}
 
         self.doc_storage = {"1": deepcopy(entity)}
@@ -199,7 +192,7 @@ class DocumentServiceTestCase(unittest.TestCase):
         )
 
     def test_add_valid_second_level_specialized_child_type(self):
-        self.doc_storage = {"1": {"_id": "1", "name": "Parent", "description": "", "type": "Parent", "SomeChild": {}}}
+        self.doc_storage = {"1": {"_id": "1", "name": "Parent", "type": "Parent", "SomeChild": {}}}
         child = {
             "name": "whatever",
             "type": "ExtraSpecialChild",
@@ -215,9 +208,7 @@ class DocumentServiceTestCase(unittest.TestCase):
         self.assertDictEqual(self.doc_storage["1"]["SomeChild"], child)
 
     def test_add_valid_second_level_specialized_child_type_to_list_attribute(self):
-        self.doc_storage = {
-            "1": {"_id": "1", "name": "parent", "description": "", "type": "ParentWithListOfChildren", "SomeChild": []}
-        }
+        self.doc_storage = {"1": {"_id": "1", "name": "parent", "type": "ParentWithListOfChildren", "SomeChild": []}}
         child_list = [
             {"name": "whatever", "type": "SpecialChild", "AnExtraValue": "Hallo there!", "AValue": 13},
             {
@@ -237,9 +228,7 @@ class DocumentServiceTestCase(unittest.TestCase):
         self.assertListEqual(self.doc_storage["1"]["SomeChild"], child_list)
 
     def test_add_invalid_child_type_to_list_attribute(self):
-        self.doc_storage = {
-            "1": {"_id": "1", "name": "parent", "description": "", "type": "ParentWithListOfChildren", "SomeChild": []}
-        }
+        self.doc_storage = {"1": {"_id": "1", "name": "parent", "type": "ParentWithListOfChildren", "SomeChild": []}}
         invalid_child_list = [
             {"name": "whatever", "type": "SpecialChild", "AnExtraValue": "Hallo there!", "AValue": 13},
             {
@@ -261,13 +250,10 @@ class DocumentServiceTestCase(unittest.TestCase):
         self.assertListEqual(self.doc_storage["1"]["SomeChild"], [])
 
     def test_add_child_with_empty_list(self):
-        self.doc_storage = {
-            "1": {"_id": "1", "name": "parent", "description": "", "type": "WrappsParentWithList", "Parent-w-list": {}}
-        }
+        self.doc_storage = {"1": {"_id": "1", "name": "parent", "type": "WrappsParentWithList", "Parent-w-list": {}}}
         child = {
             "_id": "1",
             "name": "parent",
-            "description": "",
             "type": "WrappsParentWithList",
             "Parent-w-list": {"name": "whatever", "type": "ParentWithListOfChildren", "SomeChild": []},
         }


### PR DESCRIPTION
## What does this pull request change?

⚠️ review #624 first

1. The file `test_tree_node_helpers` now use the correct mocker. 
2. Further cleaning, by switching to the built-in `self.assertDictEqual` etc

## Why is this pull request needed?

## Issues related to this change:
