### PR TITLE
refactor: remove last bits on "update_uncontained"

### DIFF
--- a/src/features/document/document_feature.py
+++ b/src/features/document/document_feature.py
@@ -56,7 +56,6 @@ def update(
     id_address: str,
     data: Json = Form(...),
     files: Optional[List[UploadFile]] = File(None),
-    update_uncontained: Optional[bool] = False,
     user: User = Depends(auth_w_jwt_or_pat),
 ):
     """Update an Existing Document in the Database.
@@ -71,7 +70,6 @@ def update(
       - The PROTOCOL is optional, and the default is dmss.
     - document (dict): The document to replace the previous version.
     - files: Optional list of files to be stored as part of this document.
-    - update_uncontained (bool): Optional flag specifying whether to also update uncontained attributes in the document.
     - user (User): The authenticated user accessing the endpoint, automatically generated from provided bearer token or Access-Key.
 
     Returns:
@@ -89,7 +87,6 @@ def update(
         address=Address.from_absolute(id_address),
         data=data,
         files=files,
-        update_uncontained=update_uncontained,
         document_service=document_service,
     )
 
@@ -100,7 +97,6 @@ def add_document(
     address: str,
     document: Json = Form(...),
     files: Optional[List[UploadFile]] = File(None),
-    update_uncontained: Optional[bool] = False,
     user: User = Depends(auth_w_jwt_or_pat),
 ):
     """Add a document to a package or a data source using an address.
@@ -118,7 +114,6 @@ def add_document(
       - The PROTOCOL is optional, and the default is dmss.
     - document (dict): The document that is to be stored.
     - files: Optional list of files to be stored as part of this document.
-    - update_uncontained (bool): Optional flag specifying whether to also update uncontained attributes in the document.
     - user (User): The authenticated user accessing the endpoint, automatically generated from provided bearer token or Access-Key.
 
     Returns:
@@ -137,7 +132,6 @@ def add_document(
         address=Address.from_absolute(address),
         document=document,
         files=files,
-        update_uncontained=update_uncontained,
         document_service=document_service,
     )
 

--- a/src/features/document/use_cases/update_document_use_case.py
+++ b/src/features/document/use_cases/update_document_use_case.py
@@ -18,7 +18,6 @@ def _update_document(
     data: Union[dict, list],
     document_service: DocumentService,
     files: dict[str, BinaryIO] | None,
-    update_uncontained: Optional[bool],
 ):
     """
     Update a document.
@@ -50,7 +49,7 @@ def _update_document(
     if files:
         merge_entity_and_files(node, files)
 
-    document_service.save(node, address.data_source, update_uncontained=update_uncontained, initial=True)
+    document_service.save(node, address.data_source, initial=True)
     logger.info(f"Updated entity '{address}'")
     return {"data": tree_node_to_dict(node)}
 
@@ -60,7 +59,6 @@ def update_document_use_case(
     data: Union[dict, list],
     document_service: DocumentService,
     files: Optional[List[UploadFile]] = None,
-    update_uncontained: Optional[bool] = True,
 ):
     """Update document.
 
@@ -69,7 +67,6 @@ def update_document_use_case(
         data: The data to be updated
         document_service: The document service
         files: Dict with names and files of the files contained in the document
-        update_uncontained: Whether to update uncontained children (deprecated)
     Returns:
         A dict that contains the updated document.
     """
@@ -79,7 +76,6 @@ def update_document_use_case(
         data=data,
         document_service=document_service,
         files={f.filename: f.file for f in files} if files else None,
-        update_uncontained=update_uncontained,
     )
     # Do not invalidate the blueprint cache if it was not a blueprint that was changed
     if "type" in document["data"] and document["data"]["type"] == SIMOS.BLUEPRINT.value:

--- a/src/features/export/use_cases/export_use_case.py
+++ b/src/features/export/use_cases/export_use_case.py
@@ -23,13 +23,17 @@ def save_node_to_zipfile(
         if document_meta:
             document_node.entity["_meta_"] = document_meta
         storage_client = ZipFileClient(zip_file)
-        document_service.save(
-            document_node,
-            data_source_id,
-            storage_client,
-            update_uncontained=True,
-            combined_document_meta=document_meta,
-        )
+        path = ""  # Path here is used to get the proper file structure in the zip file
+        for node in document_node.traverse():
+            if not node.storage_contained and not node.is_array():
+                path = f"{path}/{node.entity['name']}/" if path else f"{node.entity['name']}"
+                document_service.save(
+                    node=node,
+                    data_source_id=data_source_id,
+                    path=path,
+                    repository=storage_client,
+                    combined_document_meta=document_meta,
+                )
 
 
 def create_zip_export(document_service: DocumentService, address: Address, user: User) -> str:

--- a/src/tests/bdd/authentication/create_entity_with_user_as_owner.feature
+++ b/src/tests/bdd/authentication/create_entity_with_user_as_owner.feature
@@ -19,7 +19,7 @@ Feature: Set logged in user as owner when creating an entity
       """
       Given the logged in user is "johndoe" with roles "dmss-admin"
       Given authentication is enabled
-      Given i access the resource url "/api/documents/test-DS/$2.content?update_uncontained=False"
+      Given i access the resource url "/api/documents/test-DS/$2.content"
       When i make a form-data "POST" request
       """
       {

--- a/src/tests/bdd/document/add_file.feature
+++ b/src/tests/bdd/document/add_file.feature
@@ -339,7 +339,7 @@ Feature: Explorer - Add file
     """
 
   Scenario: Add file - not contained
-    Given i access the resource url "/api/documents/test-DS/$1.content?update_uncontained=True"
+    Given i access the resource url "/api/documents/test-DS/$1.content"
     When i make a form-data "POST" request
     """
     {
@@ -502,7 +502,7 @@ Feature: Explorer - Add file
     Then the response status should be "OK"
 
   Scenario: Add Parent entity without a name attribute with -by-path endpoint
-    Given i access the resource url "/api/documents/test-DS/root_package?update_uncontained=True"
+    Given i access the resource url "/api/documents/test-DS/root_package"
     When i make a "POST" request with "1" files
     """
     {
@@ -557,7 +557,7 @@ Feature: Explorer - Add file
     And the response should have valid uid
 
   Scenario: Add Comment entity without a name attribute with -by-path endpoint
-    Given i access the resource url "/api/documents/test-DS/root_package?update_uncontained=True"
+    Given i access the resource url "/api/documents/test-DS/root_package"
     When i make a "POST" request with "1" files
     """
     {
@@ -572,7 +572,7 @@ Feature: Explorer - Add file
     Then the response status should be "OK"
 
   Scenario: Add blueprint without a name attribute with -by-path endpoint should fail
-    Given i access the resource url "/api/documents/test-DS/root_package?update_uncontained=True"
+    Given i access the resource url "/api/documents/test-DS/root_package"
     When i make a "POST" request with "1" files
     """
     {
@@ -596,7 +596,7 @@ Feature: Explorer - Add file
     """
 
   Scenario: Add package without a name attribute with -by-path endpoint should fail
-    Given i access the resource url "/api/documents/test-DS/root_package?update_uncontained=True"
+    Given i access the resource url "/api/documents/test-DS/root_package"
     When i make a "POST" request with "1" files
     """
     {
@@ -620,7 +620,7 @@ Feature: Explorer - Add file
     """
 
   Scenario: Add parent entity without a name attribute with add_by_parent_id endpoint
-    Given i access the resource url "/api/documents/test-DS/1.content?update_uncontained=True"
+    Given i access the resource url "/api/documents/test-DS/1.content"
     When i make a form-data "POST" request
     """
     {
@@ -643,7 +643,7 @@ Feature: Explorer - Add file
     """
 
   Scenario: Add comment entity without a name attribute with add_by_parent_id endpoint
-    Given i access the resource url "/api/documents/test-DS/$1.content?update_uncontained=True"
+    Given i access the resource url "/api/documents/test-DS/$1.content"
     When i make a form-data "POST" request
     """
     {
@@ -703,7 +703,7 @@ Feature: Explorer - Add file
     """
 
   Scenario: Add file with multiple PDFs
-    Given i access the resource url "/api/documents/test-DS/root_package?update_uncontained=True"
+    Given i access the resource url "/api/documents/test-DS/root_package"
     When i make a "POST" request with "4" files
     """
     {

--- a/src/tests/bdd/document/remove.feature
+++ b/src/tests/bdd/document/remove.feature
@@ -19,7 +19,7 @@ Feature: Explorer - Remove
       | 4   | 1          | sub_package_2 |             | dmss://system/SIMOS/Package     |
       | 3   | 2          | document_1    |             | dmss://system/SIMOS/Blueprint |
 
-  Scenario: Remove root package
+  Scenario: Remove root package by id
     Given i access the resource url "/api/documents/data-source-name/$1"
     When i make a "DELETE" request
     Then the response status should be "OK"

--- a/src/tests/bdd/document/remove_2.feature
+++ b/src/tests/bdd/document/remove_2.feature
@@ -13,7 +13,7 @@ Feature: Explorer - Remove by path
       | 4   | 1          | sub_package_2 |             | dmss://system/SIMOS/Package   |
       | 3   | 2          | document_1    |             | dmss://system/SIMOS/Blueprint |
 
-  Scenario: Remove root package
+  Scenario: Remove root package by name
     Given i access the resource url "/api/documents/data-source-name/blueprints"
     When i make a "DELETE" request
     Then the response status should be "OK"

--- a/src/tests/bdd/steps/domain.py
+++ b/src/tests/bdd/steps/domain.py
@@ -93,7 +93,9 @@ def step_impl_documents(context, data_source_id: str, collection: str):
     document_service = DocumentService(get_data_source, user=context.user)
     tree: Node = generate_tree(data_source_id, context.table, document_service)
     tree.show_tree()
-    document_service.save(node=tree, data_source_id=data_source_id, update_uncontained=True)
+    for node in tree.traverse():
+        if not node.storage_contained and not node.is_array():
+            document_service.save(node=node, data_source_id=data_source_id)
 
 
 @given('AccessControlList for document "{document_id}" in data-source "{data_source}" is')

--- a/src/tests/unit/services/document_service/test_data_source_and_repositories.py
+++ b/src/tests/unit/services/document_service/test_data_source_and_repositories.py
@@ -38,7 +38,11 @@ class DataSourceTestCase(unittest.TestCase):
             "name": "Parent",
             "description": "",
             "type": "uncontained_blueprint",
-            "uncontained_in_every_way": {"name": "a_reference", "type": "dmss://system/SIMOS/NamedEntity"},
+            "uncontained_in_every_way": {
+                "name": "a_reference",
+                "type": "dmss://system/SIMOS/NamedEntity",
+                "_id": "$2",
+            },
         }
 
         default_doc_storage = {}
@@ -95,7 +99,9 @@ class DataSourceTestCase(unittest.TestCase):
             recipe_provider=self.recipe_provider,
         )
 
-        self.mock_document_service.save(node, "testing", update_uncontained=True)
+        for sub_node in node.traverse():
+            if not sub_node.storage_contained and not sub_node.is_array():
+                self.mock_document_service.save(node=sub_node, data_source_id="testing")
 
         # Test that both repos gets written into
         assert blob_doc_storage and default_doc_storage
@@ -220,7 +226,9 @@ class DataSourceTestCase(unittest.TestCase):
             blob_doc, self.mock_document_service.get_blueprint, uid="1", recipe_provider=self.recipe_provider
         )
 
-        self.mock_document_service.save(node, "testing", update_uncontained=True)
+        for sub_node in node.traverse():
+            if not sub_node.storage_contained and not sub_node.is_array():
+                self.mock_document_service.save(node=sub_node, data_source_id="testing")
 
         # Test that both repos gets written into
         assert blob_doc_storage and default_doc_storage

--- a/src/tests/unit/services/document_service/test_save.py
+++ b/src/tests/unit/services/document_service/test_save.py
@@ -72,7 +72,9 @@ class DocumentServiceTestCase(unittest.TestCase):
         contained_node.update(
             {"_id": "4", "name": "ref2", "description": "TEST_MODIFY", "type": "dmss://system/SIMOS/NamedEntity"}
         )
-        self.mock_document_service.save(node, "testing", update_uncontained=True)
+        for sub_node in node.traverse():
+            if not sub_node.storage_contained and not sub_node.is_array():
+                self.mock_document_service.save(node=sub_node, data_source_id="testing")
 
         assert doc_storage["4"] == {
             "_id": "4",
@@ -108,7 +110,7 @@ class DocumentServiceTestCase(unittest.TestCase):
         contained_node.update(
             {"name": "RENAMED", "description": "TEST_MODIFY", "type": "dmss://system/SIMOS/NamedEntity"}
         )
-        self.mock_document_service.save(contained_node, "testing", update_uncontained=True, initial=True)
+        self.mock_document_service.save(contained_node, "testing", initial=True)
 
         assert doc_storage["1"]["containedPersonInfo"]["description"] == "TEST_MODIFY"
 

--- a/src/tests/unit/tree_functionality/test_tree_node_update.py
+++ b/src/tests/unit/tree_functionality/test_tree_node_update.py
@@ -104,7 +104,6 @@ class DocumentServiceTestCase(unittest.TestCase):
         add_document_use_case(
             address=Address("$1.box", "testing"),
             document={"type": "Box", "name": "box", "description": "box"},
-            update_uncontained=True,
             document_service=document_service,
         )
         assert get_and_print_diff(doc_storage["1"], doc_1_after) == []
@@ -198,7 +197,6 @@ class DocumentServiceTestCase(unittest.TestCase):
         add_document_use_case(
             address=Address("$1.chest.box", "testing"),
             document={"name": "box", "description": "box", "type": "Box"},
-            update_uncontained=True,
             document_service=document_service,
         )
 
@@ -236,7 +234,6 @@ class DocumentServiceTestCase(unittest.TestCase):
             add_document_use_case(
                 address=Address("$1.box", "testing"),
                 document={"type": "Box", "name": "duplicate", "description": "box"},
-                update_uncontained=True,
                 document_service=document_service,
             )
 

--- a/src/tests/unit/use_cases/test_reference.py
+++ b/src/tests/unit/use_cases/test_reference.py
@@ -323,7 +323,6 @@ class ReferenceTestCase(unittest.TestCase):
         add_document_use_case(
             address=Address("$1.uncontained_in_every_way", "testing"),
             document=reference,
-            update_uncontained=True,
             document_service=self.document_service,
         )
         assert len(doc_storage["1"]["uncontained_in_every_way"]) == 2


### PR DESCRIPTION
## What does this pull request change?
 - Remove the option for "document_service.save()" to act recursively

NOTE: Some features (export zip and some tests) relied on this feature. The logic has been moved up into these places.
 
## Why is this pull request needed?
Deprecated feature

## Issues related to this change:
closes #617 
