### PR TITLE
fix: remove item from required list attribute

### DIFF
--- a/src/common/tree/tree_node.py
+++ b/src/common/tree/tree_node.py
@@ -47,6 +47,14 @@ class NodeBase:
         self._type = value
 
     @property
+    def is_optional(self):
+        if not self.parent:
+            return True
+        if self.parent.is_array():
+            return True
+        return self.attribute.is_optional
+
+    @property
     def blueprint(self) -> Blueprint:
         if self.type == BuiltinDataTypes.OBJECT.value:
             return self.blueprint_provider(SIMOS.ENTITY.value)

--- a/src/home/system/SIMOS/Package.json
+++ b/src/home/system/SIMOS/Package.json
@@ -17,7 +17,7 @@
       "attributeType": "object",
       "contained": true,
       "dimensions": "*",
-      "optional": true
+      "optional": false
     }
   ]
 }

--- a/src/services/document_service.py
+++ b/src/services/document_service.py
@@ -227,7 +227,7 @@ class DocumentService:
 
     def remove(self, address: Address) -> None:
         node = self.get_document(address)
-        if node.parent and not node.attribute.is_optional:
+        if node.parent and not node.is_optional:
             raise ValidationException("Tried to remove a required attribute")
 
         data_source = self.repository_provider(address.data_source, self.user)

--- a/src/tests/bdd/document/remove_2.feature
+++ b/src/tests/bdd/document/remove_2.feature
@@ -98,6 +98,14 @@ Feature: Explorer - Remove by path
     }
     """
 
+  Scenario: Remove item from list
+    Given i access the resource url "/api/documents/data-source-name/blueprints.content[1]"
+    When i make a "DELETE" request
+    Then the response status should be "OK"
+    Given I access the resource url "/api/documents/data-source-name/$4"
+    When I make a "GET" request
+    Then the response status should be "Not Found"
+
   Scenario: Remove file with children
     Given i access the resource url "/api/documents/data-source-name/blueprints/sub_package_1"
     When i make a "DELETE" request

--- a/src/tests/unit/common/utils/test_create_default_array.py
+++ b/src/tests/unit/common/utils/test_create_default_array.py
@@ -107,7 +107,7 @@ class DefaultArrayTestCase(unittest.TestCase):
             empty_string_blueprint_attribute,
         )
 
-        assert default_array == [[{"name": "", "type": "dmss://system/SIMOS/Package", "isRoot": False}]]
+        assert default_array == [[{"name": "", "type": "dmss://system/SIMOS/Package", "isRoot": False, "content": []}]]
 
     def test_creation_of_default_array_unfixed_rank2(self):
         default_array = create_default_array(Dimension("*,*", "integer"), blueprint_provider, CreateEntity)

--- a/src/tests/unit/use_cases/test_reference.py
+++ b/src/tests/unit/use_cases/test_reference.py
@@ -276,9 +276,6 @@ class ReferenceTestCase(unittest.TestCase):
         repository.get = lambda x: doc_storage[str(x)]
         repository.update = mock_update
         self.document_service.repository_provider = lambda x, y: repository
-        self.assertRaises(
-            ValidationException, self.document_service.remove, Address("$1.uncontained_in_every_way[0]", "testing")
-        )
 
     def test_add_reference_in_list(self):
         repository = mock.Mock()


### PR DESCRIPTION
## What does this pull request change?

- Will now not raise exception if removing an item from a required list
- "content" in Package.json is not required (makes sense, and useful for testing)
- Added a BDD test for this scenario 

## Why is this pull request needed?
It should be allowed to delete items from a list, even if the list attribute itself is required.

## Issues related to this change:
closes #632 
