### PR TITLE
Test/refactor move down blueprints

### DIFF
--- a/src/tests/unit/common/entity/validators/mock_data/BaseChild.blueprint.json
+++ b/src/tests/unit/common/entity/validators/mock_data/BaseChild.blueprint.json
@@ -1,0 +1,15 @@
+{
+  "name": "BaseChild",
+  "type": "dmss://system/SIMOS/Blueprint",
+  "description": "",
+  "extends": [
+    "dmss://system/SIMOS/NamedEntity"
+  ],
+  "attributes": [
+    {
+      "name": "AValue",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "attributeType": "integer"
+    }
+  ]
+}

--- a/src/tests/unit/common/entity/validators/mock_data/CarRental.blueprint.json
+++ b/src/tests/unit/common/entity/validators/mock_data/CarRental.blueprint.json
@@ -1,0 +1,28 @@
+{
+  "name": "CarRental",
+  "type": "system/SIMOS/Blueprint",
+  "attributes": [
+    {
+      "name": "name",
+      "type": "system/SIMOS/BlueprintAttribute",
+      "attributeType": "string"
+    },
+    {
+      "name": "type",
+      "type": "system/SIMOS/BlueprintAttribute",
+      "attributeType": "string"
+    },
+    {
+      "name": "cars",
+      "type": "system/SIMOS/BlueprintAttribute",
+      "dimensions": "*",
+      "attributeType": "RentalCar"
+    },
+    {
+      "name": "customers",
+      "type": "system/SIMOS/BlueprintAttribute",
+      "dimensions": "*",
+      "attributeType": "Customer"
+    }
+  ]
+}

--- a/src/tests/unit/common/entity/validators/mock_data/CarTest.blueprint.json
+++ b/src/tests/unit/common/entity/validators/mock_data/CarTest.blueprint.json
@@ -1,0 +1,118 @@
+{
+  "name": "CarTest",
+  "type": "system/SIMOS/Blueprint",
+  "attributes": [
+    {
+      "name": "name",
+      "type": "system/SIMOS/BlueprintAttribute",
+      "attributeType": "string",
+      "default": "CarTest"
+    },
+    {
+      "name": "type",
+      "type": "system/SIMOS/BlueprintAttribute",
+      "attributeType": "string",
+      "default": "CarTest"
+    },
+    {
+      "name": "plateNumber",
+      "type": "system/SIMOS/BlueprintAttribute",
+      "attributeType": "string"
+    },
+    {
+      "name": "wheel",
+      "type": "system/SIMOS/BlueprintAttribute",
+      "attributeType": "WheelTest"
+    },
+    {
+      "name": "wheels",
+      "type": "system/SIMOS/BlueprintAttribute",
+      "attributeType": "WheelTest",
+      "dimensions": "*"
+    },
+    {
+      "name": "seats",
+      "type": "system/SIMOS/BlueprintAttribute",
+      "attributeType": "integer",
+      "default": 2
+    },
+    {
+      "name": "is_sedan",
+      "type": "system/SIMOS/BlueprintAttribute",
+      "attributeType": "boolean",
+      "default": true
+    },
+    {
+      "name": "floatValues",
+      "type": "system/SIMOS/BlueprintAttribute",
+      "attributeType": "number",
+      "dimensions": "*",
+      "default": [
+        2.1,
+        3.1,
+        4.2
+      ]
+    },
+    {
+      "name": "intValues",
+      "type": "system/SIMOS/BlueprintAttribute",
+      "attributeType": "integer",
+      "dimensions": "*",
+      "default": [
+        1,
+        5,
+        4,
+        2
+      ]
+    },
+    {
+      "name": "boolValues",
+      "type": "system/SIMOS/BlueprintAttribute",
+      "attributeType": "boolean",
+      "dimensions": "*",
+      "default": [
+        true,
+        false,
+        true
+      ]
+    },
+    {
+      "name": "stringValues",
+      "type": "system/SIMOS/BlueprintAttribute",
+      "attributeType": "string",
+      "dimensions": "*",
+      "default": [
+        "one",
+        "two",
+        "three"
+      ]
+    },
+    {
+      "name": "engine",
+      "type": "system/SIMOS/BlueprintAttribute",
+      "attributeType": "EngineTest"
+    },
+    {
+      "name": "engine2",
+      "type": "system/SIMOS/BlueprintAttribute",
+      "optional": true,
+      "attributeType": "EngineTest"
+    },
+    {
+      "name": "engine3",
+      "type": "system/SIMOS/BlueprintAttribute",
+      "optional": true,
+      "attributeType": "EngineTest",
+      "default": {
+        "name": "default engine",
+        "type": "EngineTest",
+        "fuelPump": {
+          "name": "fuelPump",
+          "type": "FuelPumpTest",
+          "description": "A standard fuel pump"
+        },
+        "power": 9
+      }
+    }
+  ]
+}

--- a/src/tests/unit/common/entity/validators/mock_data/EngineTest.blueprint.json
+++ b/src/tests/unit/common/entity/validators/mock_data/EngineTest.blueprint.json
@@ -1,0 +1,38 @@
+{
+  "name": "EngineTest",
+  "type": "system/SIMOS/Blueprint",
+  "description": "This describes an engine",
+  "attributes": [
+    {
+      "name": "name",
+      "type": "system/SIMOS/BlueprintAttribute",
+      "attributeType": "string"
+    },
+    {
+      "name": "type",
+      "type": "system/SIMOS/BlueprintAttribute",
+      "attributeType": "string"
+    },
+    {
+      "name": "description",
+      "type": "system/SIMOS/BlueprintAttribute",
+      "attributeType": "string"
+    },
+    {
+      "name": "power",
+      "type": "system/SIMOS/BlueprintAttribute",
+      "attributeType": "integer",
+      "default": 120
+    },
+    {
+      "name": "fuelPump",
+      "type": "system/SIMOS/BlueprintAttribute",
+      "attributeType": "FuelPumpTest",
+      "default": {
+        "name": "fuelPump",
+        "type": "FuelPumpTest",
+        "description": "A standard fuel pump"
+      }
+    }
+  ]
+}

--- a/src/tests/unit/common/entity/validators/mock_data/FuelPumpTest.blueprint.json
+++ b/src/tests/unit/common/entity/validators/mock_data/FuelPumpTest.blueprint.json
@@ -1,0 +1,23 @@
+{
+  "name": "FuelPumpTest",
+  "type": "system/SIMOS/Blueprint",
+  "description": "This describes a fuel pump",
+  "attributes": [
+    {
+      "name": "name",
+      "type": "system/SIMOS/BlueprintAttribute",
+      "attributeType": "string"
+    },
+    {
+      "name": "description",
+      "type": "system/SIMOS/BlueprintAttribute",
+      "attributeType": "string",
+      "default": "A standard fuel pump"
+    },
+    {
+      "name": "type",
+      "type": "system/SIMOS/BlueprintAttribute",
+      "attributeType": "string"
+    }
+  ]
+}

--- a/src/tests/unit/common/entity/validators/mock_data/Parent.blueprint.json
+++ b/src/tests/unit/common/entity/validators/mock_data/Parent.blueprint.json
@@ -1,0 +1,15 @@
+{
+  "name": "Parent",
+  "type": "dmss://system/SIMOS/Blueprint",
+  "description": "",
+  "extends": [
+    "dmss://system/SIMOS/NamedEntity"
+  ],
+  "attributes": [
+    {
+      "name": "SomeChild",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "attributeType": "BaseChild"
+    }
+  ]
+}

--- a/src/tests/unit/common/entity/validators/mock_data/RentalCar.blueprint.json
+++ b/src/tests/unit/common/entity/validators/mock_data/RentalCar.blueprint.json
@@ -1,0 +1,29 @@
+{
+  "name": "RentalCar",
+  "type": "system/SIMOS/Blueprint",
+  "attributes": [
+    {
+      "name": "name",
+      "type": "system/SIMOS/BlueprintAttribute",
+      "attributeType": "string",
+      "default": "RentalCar"
+    },
+    {
+      "name": "type",
+      "type": "system/SIMOS/BlueprintAttribute",
+      "attributeType": "string",
+      "default": "RentalCar"
+    },
+    {
+      "name": "plateNumber",
+      "type": "system/SIMOS/BlueprintAttribute",
+      "attributeType": "string"
+    },
+    {
+      "name": "engine",
+      "type": "system/SIMOS/BlueprintAttribute",
+      "attributeType": "EngineTest",
+      "optional": true
+    }
+  ]
+}

--- a/src/tests/unit/common/entity/validators/mock_data/SpecialChild.blueprint.json
+++ b/src/tests/unit/common/entity/validators/mock_data/SpecialChild.blueprint.json
@@ -1,0 +1,15 @@
+{
+  "name": "SpecialChild",
+  "type": "dmss://system/SIMOS/Blueprint",
+  "description": "",
+  "extends": [
+    "BaseChild"
+  ],
+  "attributes": [
+    {
+      "name": "AnExtraValue",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "attributeType": "string"
+    }
+  ]
+}

--- a/src/tests/unit/common/entity/validators/mock_data/WheelTest.blueprint.json
+++ b/src/tests/unit/common/entity/validators/mock_data/WheelTest.blueprint.json
@@ -1,0 +1,23 @@
+{
+  "name": "WheelTest",
+  "type": "system/SIMOS/Blueprint",
+  "attributes": [
+    {
+      "name": "name",
+      "type": "system/SIMOS/BlueprintAttribute",
+      "attributeType": "string",
+      "default": "Wheel"
+    },
+    {
+      "name": "type",
+      "type": "system/SIMOS/BlueprintAttribute",
+      "attributeType": "string"
+    },
+    {
+      "name": "power",
+      "type": "system/SIMOS/BlueprintAttribute",
+      "attributeType": "number",
+      "default": 0.0
+    }
+  ]
+}

--- a/src/tests/unit/common/entity/validators/test_validate_entity.py
+++ b/src/tests/unit/common/entity/validators/test_validate_entity.py
@@ -15,7 +15,7 @@ class ValidateEntityTestCase(unittest.TestCase):
             "dmss://system/SIMOS/NamedEntity",
             "dmss://system/SIMOS/BlueprintAttribute",
         ]
-        mock_blueprint_folder = "src/tests/unit/mock_data/mock_blueprints"
+        mock_blueprint_folder = "src/tests/unit/common/entity/validators/mock_data"
         mock_blueprints_and_file_names = {
             "CarRental": "CarRental.blueprint.json",
             "RentalCar": "RentalCar.blueprint.json",

--- a/src/tests/unit/use_cases/add_document/mock_data/basic_blueprint.blueprint.json
+++ b/src/tests/unit/use_cases/add_document/mock_data/basic_blueprint.blueprint.json
@@ -1,0 +1,9 @@
+{
+  "name": "Blueprint 2",
+  "type": "dmss://system/SIMOS/Blueprint",
+  "description": "Second blueprint",
+  "extends": [
+    "dmss://system/SIMOS/NamedEntity"
+  ],
+  "attributes": []
+}

--- a/src/tests/unit/use_cases/add_document/mock_data/blueprint_with_second_level_nested_uncontained_attribute.blueprint.json
+++ b/src/tests/unit/use_cases/add_document/mock_data/blueprint_with_second_level_nested_uncontained_attribute.blueprint.json
@@ -1,0 +1,15 @@
+{
+  "name": "blueprint_with_second_level_nested_uncontained_attribute",
+  "type": "dmss://system/SIMOS/Blueprint",
+  "description": "",
+  "extends": [
+    "dmss://system/SIMOS/NamedEntity"
+  ],
+  "attributes": [
+    {
+      "name": "i_have_a_uncontained_attribute",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "attributeType": "uncontained_blueprint"
+    }
+  ]
+}

--- a/src/tests/unit/use_cases/add_document/mock_data/uncontained_blueprint.blueprint.json
+++ b/src/tests/unit/use_cases/add_document/mock_data/uncontained_blueprint.blueprint.json
@@ -1,0 +1,16 @@
+{
+  "name": "uncontained_blueprint",
+  "type": "dmss://system/SIMOS/Blueprint",
+  "description": "uncontained_blueprint",
+  "extends": [
+    "dmss://system/SIMOS/NamedEntity"
+  ],
+  "attributes": [
+    {
+      "name": "uncontained_in_every_way",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "attributeType": "basic_blueprint",
+      "contained": false
+    }
+  ]
+}

--- a/src/tests/unit/use_cases/add_document/mock_data/uncontained_list_blueprint.blueprint.json
+++ b/src/tests/unit/use_cases/add_document/mock_data/uncontained_list_blueprint.blueprint.json
@@ -1,0 +1,17 @@
+{
+  "name": "uncontained_list_blueprint",
+  "type": "dmss://system/SIMOS/Blueprint",
+  "description": "uncontained_list_blueprint",
+  "extends": [
+    "dmss://system/SIMOS/NamedEntity"
+  ],
+  "attributes": [
+    {
+      "name": "uncontained_in_every_way",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "attributeType": "basic_blueprint",
+      "contained": false,
+      "dimensions": "*"
+    }
+  ]
+}

--- a/src/tests/unit/use_cases/add_document/test_add_reference.py
+++ b/src/tests/unit/use_cases/add_document/test_add_reference.py
@@ -16,7 +16,7 @@ from tests.unit.mock_data.mock_document_service import get_mock_document_service
 class ReferenceTestCase(unittest.TestCase):
     def setUp(self) -> None:
         simos_blueprints = ["dmss://system/SIMOS/NamedEntity", "dmss://system/SIMOS/Reference"]
-        mock_blueprint_folder = "src/tests/unit/mock_data/mock_blueprints"
+        mock_blueprint_folder = "src/tests/unit/use_cases/add_document/mock_data"
         mock_blueprints_and_file_names = {
             "basic_blueprint": "basic_blueprint.blueprint.json",
             "uncontained_blueprint": "uncontained_blueprint.blueprint.json",

--- a/src/tests/unit/use_cases/instantiate_entity_use_case/mock_data/CarTest.blueprint.json
+++ b/src/tests/unit/use_cases/instantiate_entity_use_case/mock_data/CarTest.blueprint.json
@@ -1,0 +1,118 @@
+{
+  "name": "CarTest",
+  "type": "system/SIMOS/Blueprint",
+  "attributes": [
+    {
+      "name": "name",
+      "type": "system/SIMOS/BlueprintAttribute",
+      "attributeType": "string",
+      "default": "CarTest"
+    },
+    {
+      "name": "type",
+      "type": "system/SIMOS/BlueprintAttribute",
+      "attributeType": "string",
+      "default": "CarTest"
+    },
+    {
+      "name": "plateNumber",
+      "type": "system/SIMOS/BlueprintAttribute",
+      "attributeType": "string"
+    },
+    {
+      "name": "wheel",
+      "type": "system/SIMOS/BlueprintAttribute",
+      "attributeType": "WheelTest"
+    },
+    {
+      "name": "wheels",
+      "type": "system/SIMOS/BlueprintAttribute",
+      "attributeType": "WheelTest",
+      "dimensions": "*"
+    },
+    {
+      "name": "seats",
+      "type": "system/SIMOS/BlueprintAttribute",
+      "attributeType": "integer",
+      "default": 2
+    },
+    {
+      "name": "is_sedan",
+      "type": "system/SIMOS/BlueprintAttribute",
+      "attributeType": "boolean",
+      "default": true
+    },
+    {
+      "name": "floatValues",
+      "type": "system/SIMOS/BlueprintAttribute",
+      "attributeType": "number",
+      "dimensions": "*",
+      "default": [
+        2.1,
+        3.1,
+        4.2
+      ]
+    },
+    {
+      "name": "intValues",
+      "type": "system/SIMOS/BlueprintAttribute",
+      "attributeType": "integer",
+      "dimensions": "*",
+      "default": [
+        1,
+        5,
+        4,
+        2
+      ]
+    },
+    {
+      "name": "boolValues",
+      "type": "system/SIMOS/BlueprintAttribute",
+      "attributeType": "boolean",
+      "dimensions": "*",
+      "default": [
+        true,
+        false,
+        true
+      ]
+    },
+    {
+      "name": "stringValues",
+      "type": "system/SIMOS/BlueprintAttribute",
+      "attributeType": "string",
+      "dimensions": "*",
+      "default": [
+        "one",
+        "two",
+        "three"
+      ]
+    },
+    {
+      "name": "engine",
+      "type": "system/SIMOS/BlueprintAttribute",
+      "attributeType": "EngineTest"
+    },
+    {
+      "name": "engine2",
+      "type": "system/SIMOS/BlueprintAttribute",
+      "optional": true,
+      "attributeType": "EngineTest"
+    },
+    {
+      "name": "engine3",
+      "type": "system/SIMOS/BlueprintAttribute",
+      "optional": true,
+      "attributeType": "EngineTest",
+      "default": {
+        "name": "default engine",
+        "type": "EngineTest",
+        "fuelPump": {
+          "name": "fuelPump",
+          "type": "FuelPumpTest",
+          "description": "A standard fuel pump"
+        },
+        "power": 9
+      }
+    }
+  ]
+}

--- a/src/tests/unit/use_cases/instantiate_entity_use_case/mock_data/EngineTest.blueprint.json
+++ b/src/tests/unit/use_cases/instantiate_entity_use_case/mock_data/EngineTest.blueprint.json
@@ -1,0 +1,38 @@
+{
+  "name": "EngineTest",
+  "type": "system/SIMOS/Blueprint",
+  "description": "This describes an engine",
+  "attributes": [
+    {
+      "name": "name",
+      "type": "system/SIMOS/BlueprintAttribute",
+      "attributeType": "string"
+    },
+    {
+      "name": "type",
+      "type": "system/SIMOS/BlueprintAttribute",
+      "attributeType": "string"
+    },
+    {
+      "name": "description",
+      "type": "system/SIMOS/BlueprintAttribute",
+      "attributeType": "string"
+    },
+    {
+      "name": "power",
+      "type": "system/SIMOS/BlueprintAttribute",
+      "attributeType": "integer",
+      "default": 120
+    },
+    {
+      "name": "fuelPump",
+      "type": "system/SIMOS/BlueprintAttribute",
+      "attributeType": "FuelPumpTest",
+      "default": {
+        "name": "fuelPump",
+        "type": "FuelPumpTest",
+        "description": "A standard fuel pump"
+      }
+    }
+  ]
+}

--- a/src/tests/unit/use_cases/instantiate_entity_use_case/mock_data/FuelPumpTest.blueprint.json
+++ b/src/tests/unit/use_cases/instantiate_entity_use_case/mock_data/FuelPumpTest.blueprint.json
@@ -1,0 +1,23 @@
+{
+  "name": "FuelPumpTest",
+  "type": "system/SIMOS/Blueprint",
+  "description": "This describes a fuel pump",
+  "attributes": [
+    {
+      "name": "name",
+      "type": "system/SIMOS/BlueprintAttribute",
+      "attributeType": "string"
+    },
+    {
+      "name": "description",
+      "type": "system/SIMOS/BlueprintAttribute",
+      "attributeType": "string",
+      "default": "A standard fuel pump"
+    },
+    {
+      "name": "type",
+      "type": "system/SIMOS/BlueprintAttribute",
+      "attributeType": "string"
+    }
+  ]
+}

--- a/src/tests/unit/use_cases/instantiate_entity_use_case/mock_data/WheelTest.blueprint.json
+++ b/src/tests/unit/use_cases/instantiate_entity_use_case/mock_data/WheelTest.blueprint.json
@@ -1,0 +1,23 @@
+{
+  "name": "WheelTest",
+  "type": "system/SIMOS/Blueprint",
+  "attributes": [
+    {
+      "name": "name",
+      "type": "system/SIMOS/BlueprintAttribute",
+      "attributeType": "string",
+      "default": "Wheel"
+    },
+    {
+      "name": "type",
+      "type": "system/SIMOS/BlueprintAttribute",
+      "attributeType": "string"
+    },
+    {
+      "name": "power",
+      "type": "system/SIMOS/BlueprintAttribute",
+      "attributeType": "number",
+      "default": 0.0
+    }
+  ]
+}

--- a/src/tests/unit/use_cases/instantiate_entity_use_case/test_create_default_array.py
+++ b/src/tests/unit/use_cases/instantiate_entity_use_case/test_create_default_array.py
@@ -1,9 +1,7 @@
 import unittest
 
-from domain_classes.blueprint import Blueprint
 from domain_classes.blueprint_attribute import BlueprintAttribute
 from domain_classes.dimension import Dimension
-from enums import SIMOS
 from features.entity.use_cases.instantiate_entity_use_case.create_entity import (
     CreateEntity,
 )
@@ -12,92 +10,43 @@ from features.entity.use_cases.instantiate_entity_use_case.create_entity_arrays 
     remove_first_and_join,
 )
 from services.document_service.document_service import DocumentService
-from storage.repositories.file import LocalFileRepository
+from tests.unit.mock_data.mock_blueprint_provider import MockBlueprintProvider
 from tests.unit.mock_data.mock_recipe_provider import MockStorageRecipeProvider
-
-basic_blueprint = {
-    "type": SIMOS.BLUEPRINT.value,
-    "name": "A box",
-    "description": "First blueprint",
-    "attributes": [
-        {"attributeType": "string", "type": SIMOS.BLUEPRINT_ATTRIBUTE.value, "name": "name"},
-        {"attributeType": "string", "type": SIMOS.BLUEPRINT_ATTRIBUTE.value, "name": "type"},
-        {"attributeType": "string", "type": SIMOS.BLUEPRINT_ATTRIBUTE.value, "name": "description"},
-        {"attributeType": "integer", "type": SIMOS.BLUEPRINT_ATTRIBUTE.value, "name": "length"},
-    ],
-}
-
-higher_rank_array_blueprint = {
-    "type": SIMOS.BLUEPRINT.value,
-    "name": "Higher rank integer arrays",
-    "description": "First blueprint",
-    "attributes": [
-        {"attributeType": "string", "type": SIMOS.BLUEPRINT_ATTRIBUTE.value, "name": "name"},
-        {"attributeType": "string", "type": SIMOS.BLUEPRINT_ATTRIBUTE.value, "name": "type"},
-        {"attributeType": "string", "type": SIMOS.BLUEPRINT_ATTRIBUTE.value, "name": "description"},
-        {
-            "attributeType": "integer",
-            "type": SIMOS.BLUEPRINT_ATTRIBUTE.value,
-            "name": "1_dim-unfixed",
-            "dimensions": "*",
-        },
-        {
-            "attributeType": "basic_blueprint",
-            "type": SIMOS.BLUEPRINT_ATTRIBUTE.value,
-            "name": "1_dim-fixed_complex_type",
-            "dimensions": "5",
-        },
-        {
-            "attributeType": "integer",
-            "type": SIMOS.BLUEPRINT_ATTRIBUTE.value,
-            "name": "2_dim-unfixed",
-            "dimensions": "*,*",
-        },
-        {
-            "attributeType": "integer",
-            "type": SIMOS.BLUEPRINT_ATTRIBUTE.value,
-            "name": "3_dim-mix",
-            "dimensions": "*,1,100",
-        },
-    ],
-}
-
-empty_string_blueprint_attribute = BlueprintAttribute(name="", attribute_type="string")
-empty_integer_blueprint_attribute = BlueprintAttribute(name="", attribute_type="integer")
-integer_blueprint_attribute_with_default = BlueprintAttribute(name="", attribute_type="integer", default=[22, 33, 44])
-
-file_repository_test = LocalFileRepository()
-
-
-class BlueprintProvider:
-    def get_blueprint(self, template_type: str):
-        if template_type == "higher_rank_array":
-            return Blueprint(higher_rank_array_blueprint)
-        elif template_type == "basic_blueprint":
-            return Blueprint(basic_blueprint)
-        else:
-            return Blueprint(file_repository_test.get(template_type))
-
-
-recipe_provider = MockStorageRecipeProvider(
-    "src/tests/unit/mock_data/mock_storage_recipes/mock_storage_recipes.json"
-).provider
-document_service = DocumentService(
-    recipe_provider=recipe_provider, repository_provider=None, blueprint_provider=BlueprintProvider()
-)
-blueprint_provider = document_service.get_blueprint
 
 
 class DefaultArrayTestCase(unittest.TestCase):
-    def test_creation_of_array_simple(self):
-        default_array = create_default_array(Dimension("*", "integer"), blueprint_provider, CreateEntity)
+    def setUp(self) -> None:
+        simos_blueprints = [
+            "dmss://system/SIMOS/NamedEntity",
+            "dmss://system/SIMOS/Entity",
+            "dmss://system/SIMOS/AttributeTypes",
+            "dmss://system/SIMOS/Package",
+            "dmss://system/SIMOS/BlueprintAttribute",
+        ]
+        mock_blueprint_provider = MockBlueprintProvider(
+            mock_blueprints_and_file_names={},
+            mock_blueprint_folder="",
+            simos_blueprints_available_for_test=simos_blueprints,
+        )
+        recipe_provider = MockStorageRecipeProvider(
+            "src/tests/unit/mock_data/mock_storage_recipes/mock_storage_recipes.json"
+        ).provider
+        document_service = DocumentService(
+            recipe_provider=recipe_provider, repository_provider=None, blueprint_provider=mock_blueprint_provider
+        )
+        self.blueprint_provider = document_service.get_blueprint
 
+    def test_creation_of_array_simple(self):
+        default_array = create_default_array(Dimension("*", "integer"), self.blueprint_provider, CreateEntity)
         assert default_array == []
 
     def test_creation_of_array_simple_with_default_value(self):
+        integer_blueprint_attribute_with_default = BlueprintAttribute(
+            name="", attribute_type="integer", default=[22, 33, 44]
+        )
         default_array = create_default_array(
             Dimension("*", "integer"),
-            blueprint_provider,
+            self.blueprint_provider,
             CreateEntity,
             integer_blueprint_attribute_with_default.default,
         )
@@ -105,9 +54,11 @@ class DefaultArrayTestCase(unittest.TestCase):
         assert default_array == integer_blueprint_attribute_with_default.default
 
     def test_creation_of_default_array_complex_type(self):
+        empty_string_blueprint_attribute = BlueprintAttribute(name="", attribute_type="string")
+
         default_array = create_default_array(
             Dimension("1,1", "dmss://system/SIMOS/Package"),
-            blueprint_provider,
+            self.blueprint_provider,
             CreateEntity,
             empty_string_blueprint_attribute,
         )
@@ -115,12 +66,12 @@ class DefaultArrayTestCase(unittest.TestCase):
         assert default_array == [[{"name": "", "type": "dmss://system/SIMOS/Package", "isRoot": False, "content": []}]]
 
     def test_creation_of_default_array_unfixed_rank2(self):
-        default_array = create_default_array(Dimension("*,*", "integer"), blueprint_provider, CreateEntity)
+        default_array = create_default_array(Dimension("*,*", "integer"), self.blueprint_provider, CreateEntity)
 
         assert default_array == [[]]
 
     def test_creation_of_default_array_fixed_rank2(self):
-        default_array = create_default_array(Dimension("2,1", "integer"), blueprint_provider, CreateEntity)
+        default_array = create_default_array(Dimension("2,1", "integer"), self.blueprint_provider, CreateEntity)
         # fmt: off
         assert default_array == [
             [0],
@@ -129,7 +80,7 @@ class DefaultArrayTestCase(unittest.TestCase):
         # fmt: on
 
     def test_creation_of_default_array_mixed_rank_string(self):
-        default_array = create_default_array(Dimension("2,*,3", "string"), blueprint_provider, CreateEntity)
+        default_array = create_default_array(Dimension("2,*,3", "string"), self.blueprint_provider, CreateEntity)
         # fmt: off
         assert default_array == [
             [["", "", ""]],
@@ -138,13 +89,13 @@ class DefaultArrayTestCase(unittest.TestCase):
         # fmt: on
 
     def test_creation_of_default_array_mixed_rank3_int(self):
-        default_array = create_default_array(Dimension("2,2,*", "integer"), blueprint_provider, CreateEntity)
+        default_array = create_default_array(Dimension("2,2,*", "integer"), self.blueprint_provider, CreateEntity)
         expected = [[[], []], [[], []]]
 
         assert default_array == expected
 
     def test_creation_of_default_array_mixed_rank3_bool(self):
-        default_array = create_default_array(Dimension("1,2,1", "boolean"), blueprint_provider, CreateEntity)
+        default_array = create_default_array(Dimension("1,2,1", "boolean"), self.blueprint_provider, CreateEntity)
         expected = [[[False], [False]]]
 
         assert default_array == expected

--- a/src/tests/unit/use_cases/instantiate_entity_use_case/test_create_entity.py
+++ b/src/tests/unit/use_cases/instantiate_entity_use_case/test_create_entity.py
@@ -15,7 +15,7 @@ class CreateEntityTestCase(unittest.TestCase):
             "dmss://system/SIMOS/BlueprintAttribute",
             "dmss://system/SIMOS/NamedEntity",
         ]
-        mock_blueprint_folder = "src/tests/unit/mock_data/mock_blueprints"
+        mock_blueprint_folder = "src/tests/unit/use_cases/instantiate_entity_use_case/mock_data/"
         mock_blueprints_and_file_names = {
             "CarTest": "CarTest.blueprint.json",
             "WheelTest": "WheelTest.blueprint.json",


### PR DESCRIPTION
## What does this pull request change?

Rest of test that uses blueprint have their own mock_data folder to reference. No data coupling between tests anymore

## Why is this pull request needed?

## Issues related to this change:
