### PR TITLE
Test Blueprints now inherit from NamedEntity

### DIFF
--- a/src/tests/unit/common/entity/validators/mock_data/CarRental.blueprint.json
+++ b/src/tests/unit/common/entity/validators/mock_data/CarRental.blueprint.json
@@ -1,17 +1,10 @@
 {
   "name": "CarRental",
   "type": "system/SIMOS/Blueprint",
+  "extends": [
+    "dmss://system/SIMOS/NamedEntity"
+  ],
   "attributes": [
-    {
-      "name": "name",
-      "type": "system/SIMOS/BlueprintAttribute",
-      "attributeType": "string"
-    },
-    {
-      "name": "type",
-      "type": "system/SIMOS/BlueprintAttribute",
-      "attributeType": "string"
-    },
     {
       "name": "cars",
       "type": "system/SIMOS/BlueprintAttribute",

--- a/src/tests/unit/common/entity/validators/mock_data/CarTest.blueprint.json
+++ b/src/tests/unit/common/entity/validators/mock_data/CarTest.blueprint.json
@@ -1,19 +1,10 @@
 {
   "name": "CarTest",
   "type": "system/SIMOS/Blueprint",
+  "extends": [
+    "dmss://system/SIMOS/NamedEntity"
+  ],
   "attributes": [
-    {
-      "name": "name",
-      "type": "system/SIMOS/BlueprintAttribute",
-      "attributeType": "string",
-      "default": "CarTest"
-    },
-    {
-      "name": "type",
-      "type": "system/SIMOS/BlueprintAttribute",
-      "attributeType": "string",
-      "default": "CarTest"
-    },
     {
       "name": "plateNumber",
       "type": "system/SIMOS/BlueprintAttribute",

--- a/src/tests/unit/common/entity/validators/mock_data/EngineTest.blueprint.json
+++ b/src/tests/unit/common/entity/validators/mock_data/EngineTest.blueprint.json
@@ -2,22 +2,10 @@
   "name": "EngineTest",
   "type": "system/SIMOS/Blueprint",
   "description": "This describes an engine",
+  "extends": [
+    "dmss://system/SIMOS/NamedEntity"
+  ],
   "attributes": [
-    {
-      "name": "name",
-      "type": "system/SIMOS/BlueprintAttribute",
-      "attributeType": "string"
-    },
-    {
-      "name": "type",
-      "type": "system/SIMOS/BlueprintAttribute",
-      "attributeType": "string"
-    },
-    {
-      "name": "description",
-      "type": "system/SIMOS/BlueprintAttribute",
-      "attributeType": "string"
-    },
     {
       "name": "power",
       "type": "system/SIMOS/BlueprintAttribute",

--- a/src/tests/unit/common/entity/validators/mock_data/FuelPumpTest.blueprint.json
+++ b/src/tests/unit/common/entity/validators/mock_data/FuelPumpTest.blueprint.json
@@ -2,22 +2,7 @@
   "name": "FuelPumpTest",
   "type": "system/SIMOS/Blueprint",
   "description": "This describes a fuel pump",
-  "attributes": [
-    {
-      "name": "name",
-      "type": "system/SIMOS/BlueprintAttribute",
-      "attributeType": "string"
-    },
-    {
-      "name": "description",
-      "type": "system/SIMOS/BlueprintAttribute",
-      "attributeType": "string",
-      "default": "A standard fuel pump"
-    },
-    {
-      "name": "type",
-      "type": "system/SIMOS/BlueprintAttribute",
-      "attributeType": "string"
-    }
+  "extends": [
+    "dmss://system/SIMOS/NamedEntity"
   ]
 }

--- a/src/tests/unit/common/entity/validators/mock_data/RentalCar.blueprint.json
+++ b/src/tests/unit/common/entity/validators/mock_data/RentalCar.blueprint.json
@@ -1,19 +1,10 @@
 {
   "name": "RentalCar",
   "type": "system/SIMOS/Blueprint",
+  "extends": [
+    "dmss://system/SIMOS/NamedEntity"
+  ],
   "attributes": [
-    {
-      "name": "name",
-      "type": "system/SIMOS/BlueprintAttribute",
-      "attributeType": "string",
-      "default": "RentalCar"
-    },
-    {
-      "name": "type",
-      "type": "system/SIMOS/BlueprintAttribute",
-      "attributeType": "string",
-      "default": "RentalCar"
-    },
     {
       "name": "plateNumber",
       "type": "system/SIMOS/BlueprintAttribute",

--- a/src/tests/unit/common/entity/validators/mock_data/WheelTest.blueprint.json
+++ b/src/tests/unit/common/entity/validators/mock_data/WheelTest.blueprint.json
@@ -1,18 +1,10 @@
 {
   "name": "WheelTest",
   "type": "system/SIMOS/Blueprint",
+  "extends": [
+    "dmss://system/SIMOS/NamedEntity"
+  ],
   "attributes": [
-    {
-      "name": "name",
-      "type": "system/SIMOS/BlueprintAttribute",
-      "attributeType": "string",
-      "default": "Wheel"
-    },
-    {
-      "name": "type",
-      "type": "system/SIMOS/BlueprintAttribute",
-      "attributeType": "string"
-    },
     {
       "name": "power",
       "type": "system/SIMOS/BlueprintAttribute",

--- a/src/tests/unit/common/tree/mock_data/mock_blueprints/Blueprint4.blueprint.json
+++ b/src/tests/unit/common/tree/mock_data/mock_blueprints/Blueprint4.blueprint.json
@@ -2,23 +2,10 @@
   "name": "Blueprint4",
   "type": "system/SIMOS/Blueprint",
   "description": "Second blueprint",
+  "extends": [
+    "dmss://system/SIMOS/NamedEntity"
+  ],
   "attributes": [
-    {
-      "name": "name",
-      "type": "system/SIMOS/BlueprintAttribute",
-      "attributeType": "string"
-    },
-    {
-      "name": "type",
-      "type": "system/SIMOS/BlueprintAttribute",
-      "attributeType": "string"
-    },
-    {
-      "name": "description",
-      "type": "system/SIMOS/BlueprintAttribute",
-      "attributeType": "string",
-      "optional": true
-    },
     {
       "name": "a_list",
       "type": "system/SIMOS/BlueprintAttribute",

--- a/src/tests/unit/common/tree/mock_data/mock_blueprints/Box.blueprint.json
+++ b/src/tests/unit/common/tree/mock_data/mock_blueprints/Box.blueprint.json
@@ -2,22 +2,7 @@
   "name": "Box",
   "type": "system/SIMOS/Blueprint",
   "description": "Blueprint for a normal box. There is nothing interesting about this box.",
-  "attributes": [
-    {
-      "name": "name",
-      "type": "system/SIMOS/BlueprintAttribute",
-      "attributeType": "string"
-    },
-    {
-      "name": "type",
-      "type": "system/SIMOS/BlueprintAttribute",
-      "attributeType": "string"
-    },
-    {
-      "name": "description",
-      "type": "system/SIMOS/BlueprintAttribute",
-      "attributeType": "string",
-      "optional": true
-    }
+  "extends": [
+    "dmss://system/SIMOS/NamedEntity"
   ]
 }

--- a/src/tests/unit/common/tree/mock_data/mock_blueprints/Bush.blueprint.json
+++ b/src/tests/unit/common/tree/mock_data/mock_blueprints/Bush.blueprint.json
@@ -2,23 +2,10 @@
   "name": "Bush",
   "type": "system/SIMOS/Blueprint",
   "description": "Blueprint for a bush",
+  "extends": [
+    "dmss://system/SIMOS/NamedEntity"
+  ],
   "attributes": [
-    {
-      "name": "name",
-      "type": "system/SIMOS/BlueprintAttribute",
-      "attributeType": "string"
-    },
-    {
-      "name": "type",
-      "type": "system/SIMOS/BlueprintAttribute",
-      "attributeType": "string"
-    },
-    {
-      "name": "description",
-      "type": "system/SIMOS/BlueprintAttribute",
-      "attributeType": "string",
-      "optional": true
-    },
     {
       "name": "reference",
       "type": "system/SIMOS/BlueprintAttribute",

--- a/src/tests/unit/common/tree/mock_data/mock_blueprints/Case.blueprint.json
+++ b/src/tests/unit/common/tree/mock_data/mock_blueprints/Case.blueprint.json
@@ -2,7 +2,7 @@
   "name": "Case",
   "type": "system/SIMOS/Blueprint",
   "extends": [
-    "system/SIMOS/NamedEntity"
+    "dmss://system/SIMOS/NamedEntity"
   ],
   "attributes": [
     {

--- a/src/tests/unit/common/tree/mock_data/mock_blueprints/FormBlueprint.blueprint.json
+++ b/src/tests/unit/common/tree/mock_data/mock_blueprints/FormBlueprint.blueprint.json
@@ -1,12 +1,10 @@
 {
   "name": "FormBlueprint",
   "type": "system/SIMOS/Blueprint",
+  "extends": [
+    "dmss://system/SIMOS/NamedEntity"
+  ],
   "attributes": [
-    {
-      "name": "type",
-      "type": "system/SIMOS/BlueprintAttribute",
-      "attributeType": "string"
-    },
     {
       "name": "aNestedObject",
       "type": "system/SIMOS/BlueprintAttribute",

--- a/src/tests/unit/common/tree/mock_data/mock_blueprints/Garden.blueprint.json
+++ b/src/tests/unit/common/tree/mock_data/mock_blueprints/Garden.blueprint.json
@@ -2,23 +2,10 @@
   "name": "Garden",
   "type": "system/SIMOS/Blueprint",
   "description": "Blueprint for a nice garden.",
+  "extends": [
+    "dmss://system/SIMOS/NamedEntity"
+  ],
   "attributes": [
-    {
-      "name": "name",
-      "type": "system/SIMOS/BlueprintAttribute",
-      "attributeType": "string"
-    },
-    {
-      "name": "type",
-      "type": "system/SIMOS/BlueprintAttribute",
-      "attributeType": "string"
-    },
-    {
-      "name": "description",
-      "type": "system/SIMOS/BlueprintAttribute",
-      "attributeType": "string",
-      "optional": true
-    },
     {
       "name": "nested",
       "type": "system/SIMOS/BlueprintAttribute",

--- a/src/tests/unit/common/tree/mock_data/mock_blueprints/NestedField.blueprint.json
+++ b/src/tests/unit/common/tree/mock_data/mock_blueprints/NestedField.blueprint.json
@@ -1,12 +1,10 @@
 {
   "name": "NestedField",
   "type": "CORE:Blueprint",
+  "extends": [
+    "dmss://system/SIMOS/NamedEntity"
+  ],
   "attributes": [
-    {
-      "name": "type",
-      "type": "dmss://system/SIMOS/BlueprintAttribute",
-      "attributeType": "string"
-    },
     {
       "name": "foo",
       "type": "CORE:BlueprintAttribute",

--- a/src/tests/unit/common/tree/mock_data/mock_blueprints/Recursive.blueprint.json
+++ b/src/tests/unit/common/tree/mock_data/mock_blueprints/Recursive.blueprint.json
@@ -3,7 +3,7 @@
   "type": "system/SIMOS/Blueprint",
   "description": "Second blueprint",
   "extends": [
-    "system/SIMOS/NamedEntity"
+    "dmss://system/SIMOS/NamedEntity"
   ],
   "attributes": [
     {

--- a/src/tests/unit/common/tree/mock_data/mock_blueprints/Reference.blueprint.json
+++ b/src/tests/unit/common/tree/mock_data/mock_blueprints/Reference.blueprint.json
@@ -2,12 +2,10 @@
   "name": "Reference",
   "type": "dmss://system/SIMOS/Blueprint",
   "description": "Can be of type link, pointer or storage.",
+  "extends": [
+    "dmss://system/SIMOS/NamedEntity"
+  ],
   "attributes": [
-    {
-      "name": "type",
-      "type": "dmss://system/SIMOS/BlueprintAttribute",
-      "attributeType": "string"
-    },
     {
       "name": "referenceType",
       "type": "dmss://system/SIMOS/BlueprintAttribute",

--- a/src/tests/unit/common/tree/mock_data/mock_blueprints/SignalContainer.blueprint.json
+++ b/src/tests/unit/common/tree/mock_data/mock_blueprints/SignalContainer.blueprint.json
@@ -2,7 +2,7 @@
   "name": "SignalContainer",
   "type": "system/SIMOS/Blueprint",
   "extends": [
-    "system/SIMOS/NamedEntity"
+    "dmss://system/SIMOS/NamedEntity"
   ],
   "attributes": [
     {

--- a/src/tests/unit/common/tree/mock_data/mock_blueprints/all_contained_cases_blueprint.blueprint.json
+++ b/src/tests/unit/common/tree/mock_data/mock_blueprints/all_contained_cases_blueprint.blueprint.json
@@ -2,22 +2,10 @@
   "name": "all_contained_cases_blueprint",
   "type": "system/SIMOS/Blueprint",
   "description": "First blueprint",
+  "extends": [
+    "dmss://system/SIMOS/NamedEntity"
+  ],
   "attributes": [
-    {
-      "name": "name",
-      "type": "system/SIMOS/BlueprintAttribute",
-      "attributeType": "string"
-    },
-    {
-      "name": "type",
-      "type": "system/SIMOS/BlueprintAttribute",
-      "attributeType": "string"
-    },
-    {
-      "name": "description",
-      "type": "system/SIMOS/BlueprintAttribute",
-      "attributeType": "string"
-    },
     {
       "name": "nested",
       "type": "system/SIMOS/BlueprintAttribute",

--- a/src/tests/unit/common/tree/test_tree_node_delete.py
+++ b/src/tests/unit/common/tree/test_tree_node_delete.py
@@ -8,7 +8,7 @@ from tests.unit.mock_data.mock_blueprint_provider import MockBlueprintProvider
 
 class TreeNodeDeleteTest(unittest.TestCase):
     def setUp(self) -> None:
-        simos_blueprints = []
+        simos_blueprints = ["dmss://system/SIMOS/NamedEntity"]
         mock_blueprint_folder = "src/tests/unit/common/tree/mock_data/mock_blueprints"
         mock_blueprints_and_file_names = {
             "Blueprint4": "Blueprint4.blueprint.json",

--- a/src/tests/unit/common/tree/test_tree_node_from_dict.py
+++ b/src/tests/unit/common/tree/test_tree_node_from_dict.py
@@ -19,7 +19,7 @@ with open(FILE_PATH + "Bush.blueprint.json") as f:
 
 class TreeNodeFromDictTestCase(unittest.TestCase):
     def setUp(self) -> None:
-        simos_blueprints = ["dmss://system/SIMOS/Reference"]
+        simos_blueprints = ["dmss://system/SIMOS/Reference", "dmss://system/SIMOS/NamedEntity"]
         mock_blueprint_folder = "src/tests/unit/common/tree/mock_data/mock_blueprints"
         mock_blueprints_and_file_names = {
             "SignalContainer": "SignalContainer.blueprint.json",

--- a/src/tests/unit/common/tree/test_tree_node_helpers.py
+++ b/src/tests/unit/common/tree/test_tree_node_helpers.py
@@ -26,9 +26,7 @@ class TreeNodeHelpersTestCase(unittest.TestCase):
         self.recipe_provider = MockStorageRecipeProvider(
             "src/tests/unit/mock_data/mock_storage_recipes/mock_storage_recipes.json"
         ).provider
-        simos_blueprints = [
-            "dmss://system/SIMOS/Reference",
-        ]
+        simos_blueprints = ["dmss://system/SIMOS/Reference", "dmss://system/SIMOS/NamedEntity"]
         mock_blueprint_folder = "src/tests/unit/common/tree/mock_data/mock_blueprints"
         mock_blueprints_and_file_names = {
             "all_contained_cases_blueprint": "all_contained_cases_blueprint.blueprint.json",

--- a/src/tests/unit/common/tree/test_tree_node_to_dict.py
+++ b/src/tests/unit/common/tree/test_tree_node_to_dict.py
@@ -8,7 +8,7 @@ from tests.unit.mock_data.mock_blueprint_provider import MockBlueprintProvider
 
 class TreeNodeToDictTestCase(unittest.TestCase):
     def setUp(self) -> None:
-        simos_blueprints = []
+        simos_blueprints = ["dmss://system/SIMOS/NamedEntity"]
         mock_blueprint_folder = "src/tests/unit/common/tree/mock_data/mock_blueprints"
         mock_blueprints_and_file_names = {
             "all_contained_cases_blueprint": "all_contained_cases_blueprint.blueprint.json",

--- a/src/tests/unit/mock_data/mock_blueprint_provider.py
+++ b/src/tests/unit/mock_data/mock_blueprint_provider.py
@@ -25,9 +25,13 @@ class MockBlueprintProvider:
     def get_blueprint(self, type: str):
         if file_name := self.mock_blueprints_and_file_names.get(type):
             with open(f"{self.mock_blueprint_folder}/{file_name}") as f:
-                return Blueprint(json.load(f), type)
+                bp = Blueprint(json.load(f), type)
+                bp.realize_extends(self.get_blueprint)
+                return bp
         if type in self.simos_blueprints_available_for_test:
-            return Blueprint(file_repository_test.get(type), type)
+            bp = Blueprint(file_repository_test.get(type), type)
+            bp.realize_extends(self.get_blueprint)
+            return bp
         raise FileNotFoundError(
             f"Invalid type {type} asked for from the MockBlueprintProvider. No such blueprint were provided as available blueprints as parameters in the initialisation of the MockBlueprintProvider."
         )

--- a/src/tests/unit/services/document_service/mock_blueprints/car_rental_blueprints/CarRental.blueprint.json
+++ b/src/tests/unit/services/document_service/mock_blueprints/car_rental_blueprints/CarRental.blueprint.json
@@ -1,17 +1,10 @@
 {
   "name": "CarRental",
   "type": "system/SIMOS/Blueprint",
+  "extends": [
+    "dmss://system/SIMOS/NamedEntity"
+  ],
   "attributes": [
-    {
-      "name": "name",
-      "type": "system/SIMOS/BlueprintAttribute",
-      "attributeType": "string"
-    },
-    {
-      "name": "type",
-      "type": "system/SIMOS/BlueprintAttribute",
-      "attributeType": "string"
-    },
     {
       "name": "cars",
       "type": "system/SIMOS/BlueprintAttribute",

--- a/src/tests/unit/services/document_service/mock_blueprints/car_rental_blueprints/Customer.blueprint.json
+++ b/src/tests/unit/services/document_service/mock_blueprints/car_rental_blueprints/Customer.blueprint.json
@@ -1,12 +1,10 @@
 {
   "name": "Customer",
   "type": "system/SIMOS/Blueprint",
+  "extends": [
+    "dmss://system/SIMOS/NamedEntity"
+  ],
   "attributes": [
-    {
-      "name": "name",
-      "type": "system/SIMOS/BlueprintAttribute",
-      "attributeType": "string"
-    },
     {
       "name": "car",
       "type": "system/SIMOS/BlueprintAttribute",

--- a/src/tests/unit/services/document_service/mock_blueprints/car_rental_blueprints/EngineTest.blueprint.json
+++ b/src/tests/unit/services/document_service/mock_blueprints/car_rental_blueprints/EngineTest.blueprint.json
@@ -2,22 +2,10 @@
   "name": "EngineTest",
   "type": "system/SIMOS/Blueprint",
   "description": "This describes an engine",
+  "extends": [
+    "dmss://system/SIMOS/NamedEntity"
+  ],
   "attributes": [
-    {
-      "name": "name",
-      "type": "system/SIMOS/BlueprintAttribute",
-      "attributeType": "string"
-    },
-    {
-      "name": "type",
-      "type": "system/SIMOS/BlueprintAttribute",
-      "attributeType": "string"
-    },
-    {
-      "name": "description",
-      "type": "system/SIMOS/BlueprintAttribute",
-      "attributeType": "string"
-    },
     {
       "name": "power",
       "type": "system/SIMOS/BlueprintAttribute",

--- a/src/tests/unit/services/document_service/mock_blueprints/car_rental_blueprints/FuelPumpTest.blueprint.json
+++ b/src/tests/unit/services/document_service/mock_blueprints/car_rental_blueprints/FuelPumpTest.blueprint.json
@@ -2,22 +2,7 @@
   "name": "FuelPumpTest",
   "type": "system/SIMOS/Blueprint",
   "description": "This describes a fuel pump",
-  "attributes": [
-    {
-      "name": "name",
-      "type": "system/SIMOS/BlueprintAttribute",
-      "attributeType": "string"
-    },
-    {
-      "name": "description",
-      "type": "system/SIMOS/BlueprintAttribute",
-      "attributeType": "string",
-      "default": "A standard fuel pump"
-    },
-    {
-      "name": "type",
-      "type": "system/SIMOS/BlueprintAttribute",
-      "attributeType": "string"
-    }
+  "extends": [
+    "dmss://system/SIMOS/NamedEntity"
   ]
 }

--- a/src/tests/unit/services/document_service/mock_blueprints/car_rental_blueprints/RentalCar.blueprint.json
+++ b/src/tests/unit/services/document_service/mock_blueprints/car_rental_blueprints/RentalCar.blueprint.json
@@ -1,19 +1,10 @@
 {
   "name": "RentalCar",
   "type": "system/SIMOS/Blueprint",
+  "extends": [
+    "dmss://system/SIMOS/NamedEntity"
+  ],
   "attributes": [
-    {
-      "name": "name",
-      "type": "system/SIMOS/BlueprintAttribute",
-      "attributeType": "string",
-      "default": "RentalCar"
-    },
-    {
-      "name": "type",
-      "type": "system/SIMOS/BlueprintAttribute",
-      "attributeType": "string",
-      "default": "RentalCar"
-    },
     {
       "name": "plateNumber",
       "type": "system/SIMOS/BlueprintAttribute",

--- a/src/tests/unit/use_cases/add_document/mock_data/basic_blueprint.blueprint.json
+++ b/src/tests/unit/use_cases/add_document/mock_data/basic_blueprint.blueprint.json
@@ -1,9 +1,0 @@
-{
-  "name": "Blueprint 2",
-  "type": "dmss://system/SIMOS/Blueprint",
-  "description": "Second blueprint",
-  "extends": [
-    "dmss://system/SIMOS/NamedEntity"
-  ],
-  "attributes": []
-}

--- a/src/tests/unit/use_cases/add_document/mock_data/uncontained_blueprint.blueprint.json
+++ b/src/tests/unit/use_cases/add_document/mock_data/uncontained_blueprint.blueprint.json
@@ -9,7 +9,7 @@
     {
       "name": "uncontained_in_every_way",
       "type": "dmss://system/SIMOS/BlueprintAttribute",
-      "attributeType": "basic_blueprint",
+      "attributeType": "dmss://system/SIMOS/NamedEntity",
       "contained": false
     }
   ]

--- a/src/tests/unit/use_cases/add_document/mock_data/uncontained_list_blueprint.blueprint.json
+++ b/src/tests/unit/use_cases/add_document/mock_data/uncontained_list_blueprint.blueprint.json
@@ -9,7 +9,7 @@
     {
       "name": "uncontained_in_every_way",
       "type": "dmss://system/SIMOS/BlueprintAttribute",
-      "attributeType": "basic_blueprint",
+      "attributeType": "dmss://system/SIMOS/NamedEntity",
       "contained": false,
       "dimensions": "*"
     }

--- a/src/tests/unit/use_cases/add_document/test_add_reference.py
+++ b/src/tests/unit/use_cases/add_document/test_add_reference.py
@@ -18,7 +18,6 @@ class ReferenceTestCase(unittest.TestCase):
         simos_blueprints = ["dmss://system/SIMOS/NamedEntity", "dmss://system/SIMOS/Reference"]
         mock_blueprint_folder = "src/tests/unit/use_cases/add_document/mock_data"
         mock_blueprints_and_file_names = {
-            "basic_blueprint": "basic_blueprint.blueprint.json",
             "uncontained_blueprint": "uncontained_blueprint.blueprint.json",
             "blueprint_with_second_level_nested_uncontained_attribute": "blueprint_with_second_level_nested_uncontained_attribute.blueprint.json",
             "uncontained_list_blueprint": "uncontained_list_blueprint.blueprint.json",
@@ -49,7 +48,7 @@ class ReferenceTestCase(unittest.TestCase):
                 "_id": "2d7c3249-985d-43d2-83cf-a887e440825a",
                 "name": "something",
                 "description": "",
-                "type": "basic_blueprint",
+                "type": "dmss://system/SIMOS/NamedEntity",
             },
         }
 
@@ -91,7 +90,7 @@ class ReferenceTestCase(unittest.TestCase):
                 "_id": "2d7c3249-985d-43d2-83cf-a887e440825a",
                 "name": "something",
                 "description": "",
-                "type": "basic_blueprint",
+                "type": "dmss://system/SIMOS/NamedEntity",
             },
         }
 
@@ -170,14 +169,14 @@ class ReferenceTestCase(unittest.TestCase):
                     "_id": "something",
                     "name": "something",
                     "description": "",
-                    "type": "basic_blueprint",
+                    "type": "dmss://system/SIMOS/NamedEntity",
                 },
             },
             "something": {
                 "_id": "something",
                 "name": "something",
                 "description": "",
-                "type": "basic_blueprint",
+                "type": "dmss://system/SIMOS/NamedEntity",
             },
         }
 
@@ -210,7 +209,7 @@ class ReferenceTestCase(unittest.TestCase):
                         "_id": "something",
                         "name": "something",
                         "description": "",
-                        "type": "basic_blueprint",
+                        "type": "dmss://system/SIMOS/NamedEntity",
                     },
                 },
             },
@@ -218,7 +217,7 @@ class ReferenceTestCase(unittest.TestCase):
                 "_id": "something",
                 "name": "something",
                 "description": "",
-                "type": "basic_blueprint",
+                "type": "dmss://system/SIMOS/NamedEntity",
             },
         }
 
@@ -261,12 +260,12 @@ class ReferenceTestCase(unittest.TestCase):
             "2d7c3249-985d-43d2-83cf-a887e440825a": {
                 "_id": "2d7c3249-985d-43d2-83cf-a887e440825a",
                 "name": "something",
-                "type": "basic_blueprint",
+                "type": "dmss://system/SIMOS/NamedEntity",
             },
             "42dbe4a5-0eb0-4ee2-826c-695172c3c35a": {
                 "_id": "42dbe4a5-0eb0-4ee2-826c-695172c3c35a",
                 "name": "something",
-                "type": "basic_blueprint",
+                "type": "dmss://system/SIMOS/NamedEntity",
             },
         }
 
@@ -297,12 +296,12 @@ class ReferenceTestCase(unittest.TestCase):
             "2d7c3249-985d-43d2-83cf-a887e440825a": {
                 "_id": "2d7c3249-985d-43d2-83cf-a887e440825a",
                 "name": "something",
-                "type": "basic_blueprint",
+                "type": "dmss://system/SIMOS/NamedEntity",
             },
             "42dbe4a5-0eb0-4ee2-826c-695172c3c35a": {
                 "_id": "42dbe4a5-0eb0-4ee2-826c-695172c3c35a",
                 "name": "something",
-                "type": "basic_blueprint",
+                "type": "dmss://system/SIMOS/NamedEntity",
             },
         }
 


### PR DESCRIPTION
## What does this pull request change?

In very many cases the blueprints don't inherit from NamedEntity, and by doing this they can be reduced in size. 

This PR concludes the unit test refactor epic 

## Why is this pull request needed?

## Issues related to this change:
