### PR TITLE
fix: set depth to 1 as default for get document method

### DIFF
--- a/src/services/document_service/document_service.py
+++ b/src/services/document_service/document_service.py
@@ -185,7 +185,7 @@ class DocumentService:
         return ref_dict
 
     # TODO: Dont return Node. Doing this is ~33% slower
-    def get_document(self, address: Address, depth: int = 0) -> Node | ListNode:
+    def get_document(self, address: Address, depth: int = 1) -> Node | ListNode:
         """
         Get document by address.
 

--- a/src/tests/unit/services/document_service/test_remove.py
+++ b/src/tests/unit/services/document_service/test_remove.py
@@ -18,6 +18,12 @@ class DocumentServiceTestCase(unittest.TestCase):
         self.repository.delete = self.mock_delete
         self.repository.delete_blob = self.mock_delete
 
+        def mock_find(target: dict):
+            # Used when resolving reference using paths.
+            return [{"_id": "2", "name": "", "description": "", "type": "dmss://system/SIMOS/NamedEntity"}]
+
+        self.repository.find = mock_find
+
         simos_blueprints = [
             "dmss://system/SIMOS/NamedEntity",
             "dmss://system/SIMOS/Reference",

--- a/src/tests/unit/use_cases/add_document/test_add_reference.py
+++ b/src/tests/unit/use_cases/add_document/test_add_reference.py
@@ -44,7 +44,7 @@ class ReferenceTestCase(unittest.TestCase):
                 "description": "",
                 "type": "uncontained_blueprint",
                 "uncontained_in_every_way": {
-                    "address": "$123123123",
+                    "address": "$2d7c3249-985d-43d2-83cf-a887e440825a",
                     "type": SIMOS.REFERENCE.value,
                     "referenceType": REFERENCE_TYPES.LINK.value,
                 },


### PR DESCRIPTION
## What does this pull request change?

* Updating entities inside a package fails using an absolute address since the `get_document` method inside the `update_document_use_case` did not resolve the entity that the address is pointing to. If the address is `dmss://DemoDataSource/package/sub-package/entity`, the resolved `node` inside the `document_use_case` become the `sub-package`, but should have been the `entity`. This is solved by setting the depth=1, which means that if the address is pointing to a reference it will be resolved before returned. I just set the depth=1 as default to the `get_document` method, since I think this should be the default behavior. 

## Why is this pull request needed?

## Issues related to this change:
