### PR TITLE
fix: validation endpoint properly returns a ValidationException

### DIFF
--- a/src/common/tree/tree_node_serializer.py
+++ b/src/common/tree/tree_node_serializer.py
@@ -5,6 +5,7 @@ from common.exceptions import (
     ApplicationException,
     BadRequestException,
     NotFoundException,
+    ValidationException,
 )
 from common.tree.tree_node import ListNode, Node
 from common.utils.logging import logger
@@ -235,7 +236,7 @@ def tree_node_from_dict(
         else:
             attribute_data = entity.get(child_attribute.name, {})
             if not isinstance(attribute_data, dict):
-                raise ValueError(
+                raise ValidationException(
                     f"The attribute '{child_attribute.name}' on blueprint '{node.type}' "
                     + f"should be a dict, but was '{str(type(attribute_data))}'"
                 )


### PR DESCRIPTION
## What does this pull request change?
Validation checks should return a Validation error. Not a "ValueError" which results in a 500 status code.

## Why is this pull request needed?
API should return helpful errors

## Issues related to this change:
none