### PR TITLE
fix: change to depth 0 as default

### DIFF
--- a/src/common/address.py
+++ b/src/common/address.py
@@ -1,3 +1,5 @@
+import re
+
 from common.exceptions import ApplicationException
 from enums import Protocols
 
@@ -46,3 +48,10 @@ class Address:
             return cls(address.replace("^", f"${document_id}"), data_source)
         else:
             return cls(address, data_source)
+
+    def is_by_package(self) -> bool:
+        if not self.path:
+            return False
+        # This checks if the path is by package path format,
+        # then the last part of that part points directly to an entity.
+        return len(re.findall("/([A-Za-z0-9_-]*)$", self.path)) > 0

--- a/src/common/providers/address_resolver/address_resolver.py
+++ b/src/common/providers/address_resolver/address_resolver.py
@@ -62,6 +62,7 @@ def resolve_address(address: Address, get_data_source: Callable) -> ResolvedAddr
     # The first reference item should always be a DataSourceItem
     data_source = get_data_source(address.data_source)
     document, path = _resolve_path_items(data_source, path_items, get_data_source)
+
     return ResolvedAddress(
         entity=document,
         data_source_id=address.data_source,

--- a/src/features/document/document_feature.py
+++ b/src/features/document/document_feature.py
@@ -27,7 +27,7 @@ router = APIRouter(tags=["default", "document"], prefix="/documents")
 @create_response(JSONResponse)
 def get(
     address: str,
-    depth: conint(gt=-1, lt=1000) = 1,  # type: ignore
+    depth: conint(gt=-1, lt=1000) = 0,  # type: ignore
     user: User = Depends(auth_w_jwt_or_pat),
 ):
     """Get a Document as JSON String

--- a/src/features/document/use_cases/update_document_use_case.py
+++ b/src/features/document/use_cases/update_document_use_case.py
@@ -30,11 +30,22 @@ def _update_document(
         raise Exception(f"Could not find the node on '{address}'")
 
     try:
-        node: Node = document_service.get_document(address)  # type: ignore
+        node: Node = document_service.get_document(address)
     except NotFoundException:
         raise ValidationException(
             f"Can not update document with address {address}, since that document does not exist. If the goal is to add a document, use the document add use instead"
         )
+
+    if isinstance(data, dict):
+        if node.attribute.attribute_type == SIMOS.REFERENCE.value and data["type"] != SIMOS.REFERENCE.value:
+            raise ValidationException(
+                f"Can not update the document with address {address}, since the the address is pointing to a reference, but the data is not a reference."
+            )
+
+        if node.attribute.attribute_type != SIMOS.REFERENCE.value and data["type"] == SIMOS.REFERENCE.value:
+            raise ValidationException(
+                f"Can not update the document with address {address}, since the address is not pointing to a reference, but the data is a reference."
+            )
 
     if node.attribute.attribute_type != BuiltinDataTypes.OBJECT.value:
         validate_entity(

--- a/src/tests/bdd/document/get.feature
+++ b/src/tests/bdd/document/get.feature
@@ -211,7 +211,7 @@ Feature: Get document
     """
 
   Scenario: Get resolved entity
-    Given I access the resource url "/api/documents/test-source-name/$1.content[0]"
+    Given I access the resource url "/api/documents/test-source-name/$1.content[0]?depth=1"
     When I make a "GET" request
     Then the response status should be "OK"
     And the response should contain
@@ -223,7 +223,7 @@ Feature: Get document
     """
 
   Scenario: Get reference
-    Given I access the resource url "/api/documents/test-source-name/$1.content[0]?depth=0"
+    Given I access the resource url "/api/documents/test-source-name/$1.content[0]"
     When I make a "GET" request
     Then the response status should be "OK"
     And the response should contain

--- a/src/tests/bdd/document/reference.feature
+++ b/src/tests/bdd/document/reference.feature
@@ -261,3 +261,212 @@ Feature: Add and remove references
       "description": "This is a wind turbine demoing uncontained relationships"
     }
     """
+
+    Scenario: Replace reference in entity
+    Given there exist document with id "10" in data source "test-DS"
+    """
+    {
+      "name": "TestReplace",
+      "description": "",
+      "type": "dmss://system/SIMOS/Package",
+      "content": [
+        {
+          "address": "$Company",
+          "type": "dmss://system/SIMOS/Reference",
+          "referenceType": "link"
+        },
+        {
+          "address": "$Person",
+          "type": "dmss://system/SIMOS/Reference",
+          "referenceType": "link"
+        },
+        {
+          "address": "$companyEntity",
+          "type": "dmss://system/SIMOS/Reference",
+          "referenceType": "link"
+        }
+      ],
+      "isRoot": true
+    }
+    """
+
+    Given there exist document with id "Company" in data source "test-DS"
+    """
+    {
+      "name": "Company",
+      "type": "dmss://system/SIMOS/Blueprint",
+      "attributes": [
+        {
+          "name": "type",
+          "type": "dmss://system/SIMOS/BlueprintAttribute",
+          "attributeType": "string"
+        },
+        {
+          "name": "name",
+          "type": "dmss://system/SIMOS/BlueprintAttribute",
+          "attributeType": "string"
+        },
+        {
+          "name": "employees",
+          "type": "dmss://system/SIMOS/BlueprintAttribute",
+          "attributeType": "dmss://test-DS/TestReplace/Person",
+          "dimensions": "*",
+          "label": "Employees"
+        },
+        {
+          "name": "ceo",
+          "type": "CORE:BlueprintAttribute",
+          "attributeType": "dmss://test-DS/TestReplace/Person",
+          "label": "CEO",
+          "contained": false,
+          "optional": false
+        },
+        {
+          "name": "accountant",
+          "type": "dmss://system/SIMOS/BlueprintAttribute",
+          "attributeType": "dmss://test-DS/TestReplace/Person",
+          "label": "Accountant",
+          "contained": false,
+          "optional": false
+        }
+      ]
+    }
+    """
+
+    Given there exist document with id "Person" in data source "test-DS"
+    """
+    {
+      "name": "Person",
+      "type": "dmss://system/SIMOS/Blueprint",
+      "attributes": [
+        {
+          "name": "type",
+          "type": "dmss://system/SIMOS/BlueprintAttribute",
+          "attributeType": "string",
+          "optional": false
+        },
+        {
+          "name": "name",
+          "type": "dmss://system/SIMOS/BlueprintAttribute",
+          "attributeType": "string",
+          "label": "Name",
+          "optional": false
+        },
+        {
+          "name": "phoneNumber",
+          "type": "dmss://system/SIMOS/BlueprintAttribute",
+          "attributeType": "number",
+          "label": "Phone Number",
+          "optional": true
+        }
+      ]
+    }
+    """
+
+    Given there exist document with id "companyEntity" in data source "test-DS"
+    """
+    {
+      "name": "myCompany",
+      "type": "dmss://test-DS/TestReplace/Company",
+      "employees": [
+        {
+          "name": "Miranda",
+          "type": "dmss://test-DS/TestReplace/Person",
+          "phoneNumber": 1337
+        },
+        {
+          "name": "John",
+          "type": "dmss://test-DS/TestReplace/Person",
+          "phoneNumber": 1234
+        }
+      ],
+      "ceo": {
+        "type": "dmss://system/SIMOS/Reference",
+        "address": "^.employees[0]",
+        "referenceType": "link"
+      },
+      "accountant": {
+        "type": "dmss://system/SIMOS/Reference",
+        "address": "^.employees[0]",
+        "referenceType": "link"
+      }
+    }
+    """
+
+    Given there exist document with id "personEntity1" in data source "test-DS"
+    """
+    {
+      "name": "personEntity1",
+      "type": "dmss://test-DS/TestReplace/Person",
+      "phoneNumber": 1337
+    }
+    """
+
+    Given i access the resource url "/api/documents/test-DS/$companyEntity"
+    When i make a "GET" request
+    Then the response status should be "OK"
+    And the response should contain
+    """
+    {
+      "name": "myCompany",
+      "type": "dmss://test-DS/TestReplace/Company",
+      "employees": [
+        {
+          "name": "Miranda",
+          "type": "dmss://test-DS/TestReplace/Person",
+          "phoneNumber": 1337
+        },
+        {
+          "name": "John",
+          "type": "dmss://test-DS/TestReplace/Person",
+          "phoneNumber": 1234
+        }
+      ],
+      "accountant": {
+        "type": "dmss://system/SIMOS/Reference",
+        "address": "^.employees[0]",
+        "referenceType": "link"
+      }
+    }
+    """
+
+    Given i access the resource url "/api/documents/test-DS/$companyEntity.accountant"
+    When i make a form-data "PUT" request
+    """
+    {
+      "data": {
+        "address": "$companyEntity.employees[1]",
+        "type": "dmss://system/SIMOS/Reference",
+        "referenceType": "link"
+      }
+    }
+    """
+    Then the response status should be "OK"
+
+    Given i access the resource url "/api/documents/test-DS/$companyEntity"
+    When i make a "GET" request
+    Then the response status should be "OK"
+    And the response should contain
+    """
+    {
+      "name": "myCompany",
+      "type": "dmss://test-DS/TestReplace/Company",
+      "employees": [
+        {
+          "name": "Miranda",
+          "type": "dmss://test-DS/TestReplace/Person",
+          "phoneNumber": 1337
+        },
+        {
+          "name": "John",
+          "type": "dmss://test-DS/TestReplace/Person",
+          "phoneNumber": 1234
+        }
+      ],
+      "accountant": {
+        "type": "dmss://system/SIMOS/Reference",
+        "address": "$companyEntity.employees[1]",
+        "referenceType": "link"
+      }
+    }
+    """


### PR DESCRIPTION
## What does this pull request change?

* refactor: `document_service.get_document` to have depth=0 by default 
* refactor: the GET documents endpoint to have depth=0 by default 
* fix: return resolved entity if the address is by path (package/sub-package/entity)
* feat: add validation exceptions to the `update_document_use_case` that throws validation exception if
   * 1) try to update a reference with data 
   * 2) try to update data with reference
  
The overall update document rules after this PR is:
```
REFERENCE -> REFERENCE (OK) 
DATA -> DATA  (OK)
DATA -> REFERENCE (ERROR)
REFERENCE -> DATA  (ERROR) 
```

## Why is this pull request needed?

## Issues related to this change:
