### PR TITLE
fix(export): add proper error response on export ++ minor issues

### DIFF
--- a/src/features/export/use_cases/export_use_case.py
+++ b/src/features/export/use_cases/export_use_case.py
@@ -29,7 +29,7 @@ def save_node_to_zipfile(
         path = ""  # Path here is used to get the proper file structure in the zip file
         for node in document_node.traverse():
             if not node.storage_contained and not node.is_array():
-                path = f"{path}/{node.entity['name']}/" if path else f"{node.entity['name']}"
+                path = f"{path}/{node.entity.get('name', 'noname')}/" if path else node.entity.get("name", "noname")
                 document_service.save(
                     node=node,
                     data_source_id=data_source_id,

--- a/src/home/system/SIMOS/StorageAttribute.json
+++ b/src/home/system/SIMOS/StorageAttribute.json
@@ -28,7 +28,7 @@
       "attributeType": "string",
       "default": "default",
       "enumType": "dmss://system/SIMOS/enums/StorageTypes",
-      "optional": "true"
+      "optional": true
     },
     {
       "name": "label",

--- a/src/home/system/SIMOS/recipe_links/entity.json
+++ b/src/home/system/SIMOS/recipe_links/entity.json
@@ -6,6 +6,7 @@
       "name": "DEFAULT_CREATE",
       "type": "dmss://system/SIMOS/UiRecipe",
       "description": "",
+      "plugin": "@development-framework/dm-core-plugins/form",
       "attributes": [
         {
           "name": "type",

--- a/src/home/system/SIMOS/recipe_links/package.json
+++ b/src/home/system/SIMOS/recipe_links/package.json
@@ -9,7 +9,7 @@
       "attributes": [
         {
           "name": "content",
-          "type": "object",
+          "type": "dmss://system/SIMOS/StorageAttribute",
           "contained": false
         }
       ]
@@ -20,7 +20,7 @@
       "name": "DEFAULT_CREATE",
       "type": "dmss://system/SIMOS/UiRecipe",
       "description": "",
-      "plugin": "DEFAULT_CREATE",
+      "plugin": "@development-framework/dm-core-plugins/form",
       "attributes": [
         {
           "name": "isRoot",


### PR DESCRIPTION
Trying to export "system/SIMOS" revealed some missing error responses.
When that was added, some invalid blueprints and entities where discovered.

These has now been fixed.