### PR TITLE
fix: transform entities into references when storage uncontained

### DIFF
--- a/src/features/document/use_cases/add_document_use_case.py
+++ b/src/features/document/use_cases/add_document_use_case.py
@@ -74,7 +74,7 @@ def _add_document_to_entity_or_list(
     entity: Entity = Entity(**document)
 
     try:
-        target: Node = document_service.get_document(address, depth=2)
+        target: Node = document_service.get_document(address)
     except NotFoundException:
         target = None
 
@@ -97,7 +97,7 @@ def _add_document_to_entity_or_list(
         parent_address: Address = Address(
             protocol=address.protocol, path=parent_address_as_string, data_source=address.data_source
         )
-        parent_node: Node = document_service.get_document(parent_address, depth=1)
+        parent_node: Node = document_service.get_document(parent_address)
 
         attribute_to_update: BlueprintAttribute = parent_node.blueprint.get_attribute_by_name(
             last_attribute_in_address

--- a/src/tests/bdd/document/add_document.feature
+++ b/src/tests/bdd/document/add_document.feature
@@ -281,18 +281,15 @@ Feature: Add document with document_service
       }
     }
     """
-    Then the response status should be "OK"
-    Given i access the resource url "/api/documents/data-source-name/root_package/EntityPackage/operation3?depth=2"
-    When I make a "GET" request
-    Then the response status should be "OK"
+    Then the response status should be "Bad Request"
     And the response should contain
     """
-      {
-        "type": "dmss://data-source-name/root_package/Operation",
-        "name": "operation3",
-        "description": "",
-        "phases": []
-      }
+    {
+      "status": 400, "type": "ValidationException",
+      "message": "Entity should be of type 'dmss://system/SIMOS/Reference' (or extending from it). Got 'dmss://data-source-name/root_package/Operation'",
+      "debug": "Location: Entity in key '^'",
+      "data": null
+    }
     """
 
 

--- a/src/tests/unit/common/tree/mock_data/get_mock_nodes.py
+++ b/src/tests/unit/common/tree/mock_data/get_mock_nodes.py
@@ -90,7 +90,7 @@ def get_form_example_node(
         "referenceType": "link",
         "address": "dmss://DemoDataSource/$product1",
     }
-    a_nested_object = ({"type": "system/SIMOS/NamedEntity", "name": "nested obj", "description": "a description"},)
+    a_nested_object = {"type": "system/SIMOS/NamedEntity", "name": "nested obj", "description": "a description"}
     form_example_entity = {
         "_id": "formExample",
         "type": "FormBlueprint",

--- a/src/tests/unit/services/document_service/mock_blueprints/blob_blueprints/uncontained_blueprint.blueprint.json
+++ b/src/tests/unit/services/document_service/mock_blueprints/blob_blueprints/uncontained_blueprint.blueprint.json
@@ -10,7 +10,7 @@
       "name": "uncontained_in_every_way",
       "type": "dmss://system/SIMOS/BlueprintAttribute",
       "attributeType": "dmss://system/SIMOS/NamedEntity",
-      "contained": false
+      "contained": true
     }
   ]
 }

--- a/src/tests/unit/services/document_service/test_save.py
+++ b/src/tests/unit/services/document_service/test_save.py
@@ -180,9 +180,9 @@ class DocumentServiceTestCase(unittest.TestCase):
                 "type": "Person",
                 "containedPersonInfo": {"name": "Nested", "type": "dmss://system/SIMOS/NamedEntity"},
                 "storageUncontainedBestFriend": {
-                    "_id": "2",
-                    "name": "Mary",
-                    "type": "dmss://system/SIMOS/NamedEntity",
+                    "address": "$5",
+                    "type": SIMOS.REFERENCE.value,
+                    "referenceType": REFERENCE_TYPES.STORAGE.value,
                 },
                 "storageUncontainedListOfFriends": [
                     {
@@ -218,6 +218,11 @@ class DocumentServiceTestCase(unittest.TestCase):
                 "_id": "4",
                 "name": "Patricia",
                 "description": "Index 3",
+                "type": "dmss://system/SIMOS/NamedEntity",
+            },
+            "5": {
+                "_id": "5",
+                "name": "Mary",
                 "type": "dmss://system/SIMOS/NamedEntity",
             },
         }
@@ -300,7 +305,13 @@ class DocumentServiceTestCase(unittest.TestCase):
         # Testing updating the reference
         node: Node = self.mock_document_service.get_document(Address("$1", "testing"))
         target_node = node.get_by_path(["cat", "owner"])
-        target_node.update(doc_storage["3"])
+        target_node.update(
+            {
+                "address": "$3",
+                "type": SIMOS.REFERENCE.value,
+                "referenceType": REFERENCE_TYPES.LINK.value,
+            }
+        )
         self.mock_document_service.save(node, "testing")
         assert doc_storage["1"]["cat"]["owner"] == {
             "address": "$3",
@@ -413,5 +424,6 @@ class DocumentServiceTestCase(unittest.TestCase):
         )
 
         assert doc_storage["1"]["a"]["description"] == "SOME DESCRIPTION"
-        assert doc_storage["1"]["a"]["storageUncontainedBestFriend"]["description"] == "A NEW DESCRIPTION HERE"
+        assert doc_storage["1"]["a"]["storageUncontainedBestFriend"].get("referenceType") == "storage"
+        assert doc_storage["1"]["a"]["storageUncontainedBestFriend"].get("description") is None
         assert doc_storage["1"]["b"] == {}


### PR DESCRIPTION
## What does this pull request change?
Changes the behaviour of document save by creating a (storage) reference to entities only if the entity is storage uncontained. 

## Why is this pull request needed?


## Issues related to this change:
