### PR TITLE
feat: get_attribute able to resolve references

### DIFF
--- a/src/features/attribute/attribute_feature.py
+++ b/src/features/attribute/attribute_feature.py
@@ -1,5 +1,6 @@
 from fastapi import APIRouter, Depends
 from fastapi.responses import JSONResponse
+from pydantic import BaseModel
 
 from authentication.authentication import auth_w_jwt_or_pat
 from authentication.models import User
@@ -10,14 +11,19 @@ from .use_cases.get_attribute_use_case import get_attribute_use_case
 router = APIRouter(tags=["default", "attribute"], prefix="/attribute")
 
 
+class GetAttributeResponse(BaseModel):
+    attribute: dict
+    address: str
+
+
 @router.get(
     "/{address:path}",
     operation_id="attribute_get",
-    response_model=dict,
+    response_model=GetAttributeResponse,
     responses=responses,
 )
 @create_response(JSONResponse)
-def get_attribute(address: str, user: User = Depends(auth_w_jwt_or_pat)):
+def get_attribute(address: str, resolve: bool = True, user: User = Depends(auth_w_jwt_or_pat)):
     """Fetch the BlueprintAttribute which is the container for the addressed object.
 
     This endpoint is used for fetching a BlueprintAttribute in which the addressed entity is contained.
@@ -29,4 +35,4 @@ def get_attribute(address: str, user: User = Depends(auth_w_jwt_or_pat)):
     Returns:
     - dict: The blueprint-attribute object.
     """
-    return get_attribute_use_case(user=user, address=address)
+    return get_attribute_use_case(user=user, address=address, resolve=resolve)

--- a/src/features/attribute/use_cases/get_attribute_use_case.py
+++ b/src/features/attribute/use_cases/get_attribute_use_case.py
@@ -1,16 +1,22 @@
 from authentication.models import User
 from common.address import Address
 from common.tree.tree_node import Node
+from enums import SIMOS
 from services.document_service.document_service import DocumentService
 from storage.internal.data_source_repository import get_data_source
 
 
 def get_attribute_use_case(
     address: str,
+    resolve: bool,
     user: User,
     repository_provider=get_data_source,
 ):
     """Get attribute by reference."""
     document_service = DocumentService(repository_provider=repository_provider, user=user)
     node: Node = document_service.get_document(Address.from_absolute(address))
-    return node.attribute.to_dict()
+    direct_address = address
+    if resolve and node.attribute.attribute_type == SIMOS.REFERENCE.value:
+        direct_address = node.entity["address"]
+        node: Node = document_service.get_document(Address.from_absolute(direct_address), 2)  # type: ignore
+    return {"attribute": node.attribute.to_dict(), "address": direct_address}

--- a/src/home/system/SIMOS/ViewConfig.json
+++ b/src/home/system/SIMOS/ViewConfig.json
@@ -15,6 +15,13 @@
       "default": "self"
     },
     {
+      "name": "resolve",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "attributeType": "boolean",
+      "optional": true,
+      "default": "true"
+    },
+    {
       "name": "label",
       "type": "dmss://system/SIMOS/BlueprintAttribute",
       "attributeType": "string",


### PR DESCRIPTION
## What does this pull request change?

- GetAttribute endpoint will now resolve references by default, and return "direct address"

## Why is this pull request needed?
Some plugins create views of children that are references. Should be possible to see the actual content.

