### PR TITLE
fix: smarter validate attributes of type any

### DIFF
--- a/src/common/entity/validators.py
+++ b/src/common/entity/validators.py
@@ -37,6 +37,8 @@ def is_blueprint_instance_of(
 
 
 def _validate_primitive_attribute(attribute: BlueprintAttribute, value: bool | int | float | str, key: str):
+    if attribute.attribute_type == BuiltinDataTypes.ANY.value:
+        return  # If type is "any", no need to validate further
     python_type = BuiltinDataTypes(attribute.attribute_type).to_py_type()
     if attribute.attribute_type == "number" and isinstance(value, int):  # float is considered a superset containing int
         return
@@ -143,12 +145,6 @@ def _validate_entity(
                 len(attributeDefinition.dimensions.dimensions) if attributeDefinition.dimensions else 0,
                 implementation_mode,
             )
-        elif attributeDefinition.is_primitive:
-            _validate_primitive_attribute(
-                attributeDefinition,
-                entity[attributeDefinition.name],
-                f"{key}.{attributeDefinition.name}",
-            )
         elif attributeDefinition.attribute_type == "any" and attributeDefinition.name == "default":
             default_attribute_definition = BlueprintAttribute(
                 name=attributeDefinition.name,
@@ -178,6 +174,12 @@ def _validate_entity(
                     f"{key}.{default_attribute_definition.name}",
                     "extend",
                 )
+        elif attributeDefinition.is_primitive:
+            _validate_primitive_attribute(
+                attributeDefinition,
+                entity[attributeDefinition.name],
+                f"{key}.{attributeDefinition.name}",
+            )
         else:
             _validate_complex_attribute(
                 attributeDefinition,

--- a/src/domain_classes/dimension.py
+++ b/src/domain_classes/dimension.py
@@ -1,4 +1,6 @@
 # Convert dmt attribute_types to python types. If complex, return type as string.
+from typing import Any
+
 from enums import BuiltinDataTypes
 
 
@@ -27,7 +29,9 @@ class Dimension:
         a string value is stored.
         """
         self.dimensions: list[str] = dimensions.split(",")
-        self.type: type[bool] | type[int] | type[float] | type[str] | str = _get_data_type_from_dmt_type(attribute_type)
+        self.type: type[bool] | type[int] | type[float] | type[str] | str | Any = _get_data_type_from_dmt_type(
+            attribute_type
+        )
         self.value = None
 
     def is_array(self) -> bool:

--- a/src/enums.py
+++ b/src/enums.py
@@ -1,6 +1,7 @@
 from enum import Enum
+from typing import Any
 
-PRIMITIVES = {"string", "number", "integer", "boolean"}
+PRIMITIVES = {"string", "number", "integer", "boolean", "any"}
 
 
 class Protocols(Enum):
@@ -14,6 +15,7 @@ class BuiltinDataTypes(Enum):
     BOOL = "boolean"
     OBJECT = "object"  # Any complex type (i.e. any blueprint type)
     BINARY = "binary"
+    ANY = "any"
 
     def to_py_type(self):
         if self is BuiltinDataTypes.BOOL:
@@ -26,6 +28,8 @@ class BuiltinDataTypes(Enum):
             return str
         elif self is BuiltinDataTypes.OBJECT:
             return dict
+        elif self is BuiltinDataTypes.ANY:
+            return Any
 
 
 class RepositoryType(Enum):

--- a/src/tests/bdd/entity/validate_default_entity.feature
+++ b/src/tests/bdd/entity/validate_default_entity.feature
@@ -36,6 +36,11 @@ Feature: Validate Default Entity
           "address": "$AnimalBlueprint",
           "type": "dmss://system/SIMOS/Reference",
           "referenceType": "storage"
+        },
+        {
+          "address": "$SomeBlueprint",
+          "type": "dmss://system/SIMOS/Reference",
+          "referenceType": "storage"
         }
       ]
     }
@@ -189,6 +194,24 @@ Feature: Validate Default Entity
     }
     """
 
+    Given there exist document with id "SomeBlueprint" in data source "data-source-name"
+    """
+    {
+      "name": "SomeBlueprint",
+      "type": "dmss://system/SIMOS/Blueprint",
+      "attributes": [
+        {
+          "name": "pets",
+          "type": "dmss://system/SIMOS/BlueprintAttribute",
+          "attributeType": "number",
+          "label": "Number of pets",
+          "optional": false,
+          "default": "five"
+        }
+      ]
+    }
+    """
+
   Scenario: Validate existing simple example
 
     Given i access the resource url "/api/entity/validate-existing-entity/data-source-name/root_package/PersonBlueprint"
@@ -204,6 +227,20 @@ Feature: Validate Default Entity
       "status": 400,
       "type": "ValidationException",
       "message": "Entity should be of type 'dmss://data-source-name/root_package/AnimalBlueprint' (or extending from it). Got 'dmss://data-source-name/root_package/NorwegianBlueprint'",
+      "debug": "Location: Entity in key '^.attributes.0.default'",
+      "data": null
+    }
+    """
+
+    Given i access the resource url "/api/entity/validate-existing-entity/data-source-name/root_package/SomeBlueprint"
+    When i make a "POST" request
+    Then the response status should be "Bad Request"
+    And the response should contain
+    """
+    {
+      "status": 400,
+      "type": "ValidationException",
+      "message": "Attribute 'default' should be type 'float'. Got 'str'. Value: five",
       "debug": "Location: Entity in key '^.attributes.0.default'",
       "data": null
     }


### PR DESCRIPTION
## What does this pull request change?
- A bit more robust handling of "any" type and validation
- "any" is now considered a primitive type, which was needed for being able to update primitive values
- Reorder a list of "if/elif" in validators.py, so that the special case of BlueprintAttributes get's picked out before "any" is picked as a primitive
 
## Why is this pull request needed?
- The validator did not allow users to update the "default" attribute in BlueprintAttribute with a primitive value

## Issues related to this change:
none
