### PR TITLE
fix(node): Node.node_id() return invalid address to list elements

### DIFF
--- a/src/common/providers/address_resolver/path_items.py
+++ b/src/common/providers/address_resolver/path_items.py
@@ -130,6 +130,13 @@ class AttributeItem:
                     f"Invalid attribute '{self.path}'. Valid attributes are '{list(entity.keys())}'."
                 ) from ex
             else:
+                try:
+                    int(self.path)
+                    raise NotFoundException(
+                        "'myList.0' is an invalid syntax for accessing items in a list. Use 'myList[0]' instead"
+                    ) from ex
+                except ValueError:
+                    pass
                 raise NotFoundException(f"Invalid index '{self.path}'. Valid indices are < {len(entity)}.") from ex
 
         return result, self.path

--- a/src/common/tree/tree_node.py
+++ b/src/common/tree/tree_node.py
@@ -95,6 +95,8 @@ class NodeBase:
             return self.uid
         if not self.storage_contained and not self.is_array():
             return self.uid
+        if self.parent.is_array():
+            return f"{self.parent.node_id}[{self.key}]"
         return ".".join((self.parent.node_id, self.key))
 
     def path(self):

--- a/src/tests/bdd/document/add_contained.feature
+++ b/src/tests/bdd/document/add_contained.feature
@@ -89,5 +89,5 @@ Feature: Explorer - Add contained node
     Then the response status should be "OK"
     And the response should contain
     """
-    {"uid": "1.meAgain.1.meAgain.0"}
+    {"uid": "1.meAgain[1].meAgain[0]"}
     """

--- a/src/tests/bdd/document/add_document.feature
+++ b/src/tests/bdd/document/add_document.feature
@@ -386,6 +386,10 @@ Feature: Add document with document_service
     }
     """
     Then the response status should be "OK"
+    And the response should contain
+    """
+    {"uid": "11.phases[1]"}
+    """
     Given i access the resource url "/api/documents/data-source-name/root_package/EntityPackage/operation1?depth=3"
     When I make a "GET" request
     Then the response status should be "OK"
@@ -449,7 +453,7 @@ Feature: Add document with document_service
     And the response should contain
     """
       {
-        "uid": "11.phases.0.containedResults.0"
+        "uid": "11.phases[0].containedResults[0]"
       }
     """
 #     todo update document add use case such that id contains bracket notation for lists: 11.phases[0].containedResults[0]

--- a/src/tests/bdd/document/add_documentwith_optional_attributes.feature
+++ b/src/tests/bdd/document/add_documentwith_optional_attributes.feature
@@ -202,7 +202,7 @@ Feature: Add document with optional attributes
     And the response should contain
     """
       {
-        "uid": "workComputerId.letterKeys.0"
+        "uid": "workComputerId.letterKeys[0]"
       }
     """
     Given i access the resource url "/api/documents/data-source-name/$workComputerId.letterKeys"

--- a/src/tests/bdd/document/update_list.feature
+++ b/src/tests/bdd/document/update_list.feature
@@ -139,7 +139,7 @@ Feature: Add document with optional attributes
     And the response should contain
     """
       {
-        "uid": "workComputerId.letterKeys.0"
+        "uid": "workComputerId.letterKeys[0]"
       }
     """
     Given i access the resource url "/api/documents/data-source-name/$workComputerId.letterKeys"

--- a/src/tests/unit/common/tree/test_tree_node_helpers.py
+++ b/src/tests/unit/common/tree/test_tree_node_helpers.py
@@ -288,7 +288,7 @@ class TreeNodeHelpersTestCase(unittest.TestCase):
         self.assertEqual(nested_2.node_id, "1.nested.nested")
         self.assertEqual(reference.node_id, "1.nested.nested.reference")
         self.assertEqual(list_node.node_id, "1.list")
-        self.assertEqual(item_1.node_id, "1.list.0")
+        self.assertEqual(item_1.node_id, "1.list[0]")
 
     def test_search(self):
         document_1 = {


### PR DESCRIPTION
## What does this pull request change?
- Have Node.node_id() return a valid address for items in a list

## Why is this pull request needed?
When using add_document(), I expect to be able to use the returned address to fetch the newly created entity.


## Issues related to this change:
blocking "recurring job handler"