### PR TITLE
feat: adding showRefreshButton?: bool to uiRecipe

### DIFF
--- a/src/home/system/SIMOS/UiRecipe.json
+++ b/src/home/system/SIMOS/UiRecipe.json
@@ -13,6 +13,13 @@
       "optional": false
     },
     {
+      "name": "refreshable",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "attributeType": "boolean",
+      "optional": true,
+      "default": true
+    },
+    {
       "name": "category",
       "type": "dmss://system/SIMOS/BlueprintAttribute",
       "attributeType": "string",

--- a/src/home/system/SIMOS/UiRecipe.json
+++ b/src/home/system/SIMOS/UiRecipe.json
@@ -13,7 +13,7 @@
       "optional": false
     },
     {
-      "name": "refreshable",
+      "name": "showRefreshButton",
       "type": "dmss://system/SIMOS/BlueprintAttribute",
       "attributeType": "boolean",
       "optional": true,


### PR DESCRIPTION
## What does this pull request change?

So in order to customise the refresh-button we add a showRefreshButton boolean to the uiRecipe. Default to true

## Why is this pull request needed?

## Issues related to this change:
