### PR TITLE
build: remove publish pypi package

### DIFF
--- a/.github/workflows/on-master-push.yml
+++ b/.github/workflows/on-master-push.yml
@@ -32,11 +32,11 @@ jobs:
     secrets:
       DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
 
-  publish-new-pypi-package:
-    needs: release-please
-    if: ${{ needs.release-please.outputs.release_created }}
-    uses: ./.github/workflows/publish-to-pypi.yml
-    with:
-      version: ${{ needs.release-please.outputs.tag_name }}
-    secrets:
-      PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+#  publish-new-pypi-package:
+#    needs: release-please
+#    if: ${{ needs.release-please.outputs.release_created }}
+#    uses: ./.github/workflows/publish-to-pypi.yml
+#    with:
+#      version: ${{ needs.release-please.outputs.tag_name }}
+#    secrets:
+#      PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}


### PR DESCRIPTION
No need for it, and it fails to run.
closes #681 