### PR TITLE
fix: skip empty storage references while deleting package

### DIFF
--- a/src/services/document_service/delete_documents.py
+++ b/src/services/document_service/delete_documents.py
@@ -1,4 +1,6 @@
 from common.entity.find import find
+from common.exceptions import NotFoundException
+from common.utils.logging import logger
 from enums import REFERENCE_TYPES, SIMOS, StorageDataTypes
 from storage.data_source_class import DataSource
 
@@ -39,7 +41,11 @@ def _delete_dict_recursive(in_dict: dict, data_source: DataSource):
     if (
         in_dict.get("type") == SIMOS.REFERENCE.value and in_dict.get("referenceType") == REFERENCE_TYPES.STORAGE.value
     ):  # It's a model contained reference
-        delete_document(data_source, in_dict["address"])
+        try:
+            delete_document(data_source, in_dict["address"])
+        except NotFoundException:  # storage address was empty so there is nothing to delete
+            logger.warning(f"STOARGE ADDRESS {in_dict['address']} NOT FOUND: SKIPPING")
+
     elif in_dict.get("type") == SIMOS.BLOB.value:
         data_source.delete_blob(in_dict["_blob_id"])
     else:


### PR DESCRIPTION
## What does this pull request change?
Ignore empty storage addresses during delete

## Why is this pull request needed?
While deleting packages, it is possible that model contained / storage uncontained content (sub folders) has not yet been uploaded. Trying to delete the sub-folders will throw a NotFoundException. This we should ignore because it means that the subfolders do not exist, and it is safe to delete the parent folder.

## Issues related to this change:
Closes https://github.com/equinor/dm-core-packages/issues/858