### PR TITLE
Fix/attribute resolve

### DIFF
--- a/src/common/tree/tree_node.py
+++ b/src/common/tree/tree_node.py
@@ -234,6 +234,7 @@ class Node(NodeBase):
         parent=None,
         blueprint_provider=None,
         recipe_provider: Callable[..., list[StorageRecipe]] | None = None,
+        data_source: str | None = None,
     ):
         super().__init__(
             key,
@@ -244,6 +245,7 @@ class Node(NodeBase):
             entity=entity,
             recipe_provider=recipe_provider,
         )
+        self.data_source = data_source
         self.entity: dict = entity if entity else {}
 
     # Replace the entire data of the node with the input dict. If it matches the blueprint...
@@ -343,6 +345,11 @@ class Node(NodeBase):
             self.entity["_id"] = new_id
         else:
             self.entity.pop("_id", None)
+
+    def get_data_source(self) -> str:
+        if self.data_source:
+            return self.data_source
+        return self.find_parent().get_data_source()
 
 
 class ListNode(NodeBase):

--- a/src/common/tree/tree_node_serializer.py
+++ b/src/common/tree/tree_node_serializer.py
@@ -124,6 +124,7 @@ def tree_node_from_dict(
     recipe_provider: Callable[..., list[StorageRecipe]] | None = None,
     uid: str | None = None,
     key: str | None = None,
+    data_source: str | None = None,
 ) -> Node:
     if recursion_depth >= config.MAX_ENTITY_RECURSION_DEPTH:
         message = (
@@ -150,6 +151,7 @@ def tree_node_from_dict(
         key=key,
         uid=uid,
         entity=entity,
+        data_source=data_source,
         blueprint_provider=blueprint_provider,
         attribute=node_attribute,
         recipe_provider=recipe_provider,

--- a/src/features/attribute/use_cases/get_attribute_use_case.py
+++ b/src/features/attribute/use_cases/get_attribute_use_case.py
@@ -15,12 +15,9 @@ def get_attribute_use_case(
     """Get attribute by reference."""
     document_service = DocumentService(repository_provider=repository_provider, user=user)
     node: Node = document_service.get_document(Address.from_absolute(address))
-    direct_address = address
     if resolve and node.attribute.attribute_type == SIMOS.REFERENCE.value:
-        direct_address = node.entity["address"]
-        # type: ignore
-        reference_node: Node = document_service.get_document(
-            Address.from_relative(direct_address, None, Address.from_absolute(address).data_source), 2
-        )
-        return {"attribute": reference_node.attribute.to_dict(), "address": direct_address}
-    return {"attribute": node.attribute.to_dict(), "address": direct_address}
+        reference_address = Address.from_relative(node.entity["address"], None, node.get_data_source())
+        # Resolve the reference
+        reference_node: Node = document_service.get_document(reference_address, 1)
+        return {"attribute": reference_node.attribute.to_dict(), "address": str(reference_address)}
+    return {"attribute": node.attribute.to_dict(), "address": address}

--- a/src/services/document_service/document_service.py
+++ b/src/services/document_service/document_service.py
@@ -234,6 +234,7 @@ class DocumentService:
                 uid=resolved_address.document_id,
                 blueprint_provider=self.get_blueprint,
                 recipe_provider=self.get_storage_recipes,
+                data_source=resolved_address.data_source_id,
             )
 
             if resolved_address.attribute_path:


### PR DESCRIPTION
## What does this pull request change?

When resolving a reference (resolve=true and pointing to a reference) in `get_attribute_use_case`. 

The fix is to use this: 

```
Address.from_relative(node.entity["address"], None, node.get_data_source())
```

It will do this:

1) If the reference does not contain a data source in the address, only the ID, use the data source found in getting the reference. 
2) If the reference contains the absolute address (dmss://DS/$1234.something), it will use that directly. 

> **NOTE**: Needed to add data source to the node class so that the node remembers what it's data source is.

## Why is this pull request needed?

## Issues related to this change:
