### PR TITLE
fix: resolve tilde correct

### DIFF
--- a/src/common/address.py
+++ b/src/common/address.py
@@ -50,9 +50,17 @@ class Address:
             go_up = address.count("~")
             path = relative_path.copy()
             while go_up != 0:
-                path.pop(0)
+                if len(path) == 0:
+                    raise ApplicationException(
+                        "Invalid relative reference. Traversing outside a contained document with '~' is not supported"
+                    )
+                path.pop()
                 go_up -= 1
-            new_address = f"${document_id}{".".join(path)}{address.rsplit("~", 1)[1]}"
+            rest = address.rsplit("~", 1)[1]
+            if path:
+                new_address = f"${document_id}.{".".join(path)}{rest}"
+            else:
+                new_address = f"${document_id}{rest}"
             return cls(new_address, data_source)
         elif address.startswith("^"):
             if not document_id:

--- a/src/common/providers/address_resolver/reference_resolver.py
+++ b/src/common/providers/address_resolver/reference_resolver.py
@@ -39,12 +39,19 @@ def _resolve_reference_list(
         ]
 
     if isinstance(value_sample, dict):
-        return [
-            resolve_references_in_entity(
-                value, document_repository, get_data_source, current_id, depth, depth_count, path
-            )
-            for value in values
-        ]
+        if path:
+            return [
+                resolve_references_in_entity(
+                    value,
+                    document_repository,
+                    get_data_source,
+                    current_id,
+                    depth,
+                    depth_count,
+                    path[:-1] + [f"{path[-1]}[{index}]"],
+                )
+                for index, value in enumerate(values)
+            ]
 
     # Values are primitive, return as is.
     return values

--- a/src/tests/bdd/document/relative_references.feature
+++ b/src/tests/bdd/document/relative_references.feature
@@ -31,6 +31,19 @@ Feature: Relative references
           "type": "dmss://system/SIMOS/BlueprintAttribute",
           "name": "job",
           "optional": true
+        },
+        {
+          "attributeType": "dmss://test-source-name/TestData/Task",
+          "type": "CORE:BlueprintAttribute",
+          "name": "task",
+          "optional": true
+        },
+        {
+          "attributeType": "dmss://test-source-name/TestData/Task",
+          "type": "CORE:BlueprintAttribute",
+          "name": "tasks",
+          "optional": true,
+          "dimensions": "*"
         }
       ]
     }
@@ -129,7 +142,60 @@ Feature: Relative references
           "type": "dmss://system/SIMOS/Reference",
           "referenceType": "link"
         }
-      }
+      },
+      "task": {
+        "type": "dmss://test-source-name/TestData/Task",
+        "name": "ChildTask",
+        "data": {
+          "type": "dmss://test-source-name/TestData/Data",
+          "aNumber": 200
+        },
+        "job": {
+          "type": "dmss://test-source-name/TestData/Job",
+          "name": "Sub Job",
+          "input": {
+            "address": "~.~.data",
+            "type": "dmss://system/SIMOS/Reference",
+            "referenceType": "link"
+          }
+        }
+      },
+      "tasks": [
+        {
+          "type": "dmss://test-source-name/TestData/Task",
+          "name": "ChildTask1",
+          "data": {
+            "type": "dmss://test-source-name/TestData/Data",
+            "aNumber": 300
+          },
+          "job": {
+            "type": "dmss://test-source-name/TestData/Job",
+            "name": "Task 1",
+            "input": {
+              "address": "~.~.data",
+              "type": "dmss://system/SIMOS/Reference",
+              "referenceType": "link"
+            }
+          }
+        },
+        {
+          "type": "dmss://test-source-name/TestData/Task",
+          "name": "ChildTask2",
+          "data": {
+            "type": "dmss://test-source-name/TestData/Data",
+            "aNumber": 400
+          },
+          "job": {
+            "type": "dmss://test-source-name/TestData/Job",
+            "name": "Task 2",
+            "input": {
+              "address": "~.~.~.data",
+              "type": "dmss://system/SIMOS/Reference",
+              "referenceType": "link"
+            }
+          }
+        }
+      ]
     }
     """
 
@@ -160,6 +226,42 @@ Feature: Relative references
 
   Scenario: Resolve relative references
     Given I access the resource url "/api/documents/test-source-name/$5.job.input?depth=1"
+    When I make a "GET" request
+    Then the response status should be "OK"
+    And the response should contain
+    """
+    {
+      "type": "dmss://test-source-name/TestData/Data",
+      "aNumber": 100
+    }
+    """
+
+  Scenario: Resolve relative references of nested attribute
+    Given I access the resource url "/api/documents/test-source-name/$5.task.job.input?depth=1"
+    When I make a "GET" request
+    Then the response status should be "OK"
+    And the response should contain
+    """
+    {
+      "type": "dmss://test-source-name/TestData/Data",
+      "aNumber": 200
+    }
+    """
+
+  Scenario: Resolve relative references of document in list
+    Given I access the resource url "/api/documents/test-source-name/$5.tasks[0].job.input?depth=1"
+    When I make a "GET" request
+    Then the response status should be "OK"
+    And the response should contain
+    """
+    {
+      "type": "dmss://test-source-name/TestData/Data",
+      "aNumber": 300
+    }
+    """
+
+  Scenario: Resolve relative references of document in list and has an address points outside list
+    Given I access the resource url "/api/documents/test-source-name/$5.tasks[1].job.input?depth=1"
     When I make a "GET" request
     Then the response status should be "OK"
     And the response should contain

--- a/src/tests/unit/common/test_address.py
+++ b/src/tests/unit/common/test_address.py
@@ -66,3 +66,32 @@ class AddressTestCase(unittest.TestCase):
 
         with self.assertRaises(ApplicationException):
             Address.from_relative(path, None, data_source="ds")
+
+    def test_one_attribute_up_from_current_document_with_relative_path(self):
+        address = "~.data"
+        relative_path = ["attribute[1]", "attribute_b"]
+        document_id = "doc_id"
+        addr = Address.from_relative(address, document_id, data_source="ds", relative_path=relative_path)
+
+        self.assertEqual(addr.path, "$doc_id.attribute[1].data")
+
+    def test_two_attributes_up_from_current_document_with_relative_path(self):
+        address = "~.~.data"
+        relative_path = ["attribute_a", "attribute_b"]
+        document_id = "doc_id"
+        addr = Address.from_relative(address, document_id, data_source="ds", relative_path=relative_path)
+
+        self.assertEqual(addr.path, "$doc_id.data")
+
+    def test_two_attributes_up_from_current_document_without_relative_path_throws_ApplicationException(self):
+        address = "~.~.data"
+        document_id = "doc_id"
+        with self.assertRaises(ApplicationException):
+            Address.from_relative(address, document_id, data_source="ds")
+
+    def test_go_up_from_current_document_more_than_possible_throws_ApplicationException(self):
+        address = "~.~.~.~.data"
+        relative_path = ["attribute_a", "attribute_b"]
+        document_id = "doc_id"
+        with self.assertRaises(ApplicationException):
+            Address.from_relative(address, document_id, data_source="ds", relative_path=relative_path)


### PR DESCRIPTION
## What does this pull request change?

* Bug in how the resolve tilde ~ (the fix is to remove the last element in the path, not the first)
* Include the index to the relative path if used inside a list
* Raise exception if going outside document

## Why is this pull request needed?

## Issues related to this change:
