### PR TITLE
fix: don't explicitly set admin role for service principal

### DIFF
--- a/src/authentication/authentication.py
+++ b/src/authentication/authentication.py
@@ -58,9 +58,6 @@ def auth_with_jwt(jwt_token: str = Security(oauth2_scheme)) -> User:
     try:
         payload = jwt.decode(jwt_token, key, algorithms=["RS256"], audience=config.AUTH_AUDIENCE)
         if config.MICROSOFT_AUTH_PROVIDER in payload["iss"]:
-            # To support app registration with a Federated Credential to login
-            if config.AAD_ENTERPRISE_APP_OID == payload["sub"]:
-                return User(user_id=payload["sub"], roles=[config.DMSS_ADMIN_ROLE], **payload)
             # Azure AD uses an oid string to uniquely identify users. Each user has a unique oid value.
             user = User(user_id=payload["oid"], **payload)
         else:


### PR DESCRIPTION
## What does this pull request change?

- Remove workaround for assigning role to service principal


## Why is this pull request needed?
- If payload and kwargs contain "roles" we get an exception

## Issues related to this change:
none

