### PR TITLE
build: use a data source template and subst envvars

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,10 @@ ENV PATH="/code/.venv/bin:$PATH"
 ENV PYTHONUNBUFFERED=1
 ENV PYTHONPATH=/code/src
 
+
+# gettext package is needed for envsubst command used in init.sh
+RUN apt-get update -y && apt-get upgrade -y && apt-get install -y gettext
+
 RUN pip install --upgrade pip && \
     pip install poetry && \
     poetry config virtualenvs.in-project true
@@ -19,11 +23,9 @@ FROM base as development
 RUN poetry install
 COPY /src/.behaverc ./src/.behaverc
 COPY src ./src
-RUN chown -R 1000:1000 /code/src/system_DS.json
 USER 1000
 
 FROM base as prod
 RUN poetry install --no-dev
 COPY src ./src
-RUN chown -R 1000:1000 /code/src/system_DS.json
 USER 1000

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -8,7 +8,6 @@ services:
       target: development
     environment:
       ENVIRONMENT: local
-      MONGO_INITDB_ROOT_PASSWORD: maf
       SECRET_KEY: sg9aeUM5i1JO4gNN8fQadokJa3_gXQMLBjSGGYcfscs= # Don't reuse this in production...
       AUTH_ENABLED: "False"
       OAUTH_CLIENT_SECRET: "None"

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -27,7 +27,6 @@ services:
       - "5000:5000"
 
   db:
-    image: mongo:3.4
     volumes:
       - ./data/db:/data/db
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,16 +8,16 @@ services:
     restart: unless-stopped
     environment:
       ENVIRONMENT: azure
-      MONGO_INITDB_ROOT_USERNAME: maf
-      MONGO_INITDB_ROOT_PASSWORD: maf
+      MONGO_USERNAME: maf
+      MONGO_PASSWORD: maf
       AUTH_ENABLED: "True"
       SECRET_KEY: ${SECRET_KEY}
       AUTH_PROVIDER_FOR_ROLE_CHECK: AAD
     depends_on:
       - db
   db:
-    image: mongo:5.0.9
-    command: mongod --quiet
+    image: bitnami/mongodb:6.0.9
     environment:
-      MONGO_INITDB_ROOT_USERNAME: maf
-      MONGO_INITDB_ROOT_PASSWORD: maf
+      MONGODB_ROOT_PASSWORD: maf
+      MONGODB_ROOT_USER: maf
+      MONGODB_EXTRA_FLAGS: "--quiet"

--- a/src/app.py
+++ b/src/app.py
@@ -215,7 +215,7 @@ def nuke_db():
 def reset_app(context):
     context.invoke(nuke_db)
     logger.info("CREATING SYSTEM DATA SOURCE")
-    context.invoke(import_data_source, file="/code/src/system_DS.json")
+    context.invoke(import_data_source, file="/tmp/DMSS_systemDS.json")  # noqa: S108
     logger.debug("DONE")
     context.invoke(init_application)
 

--- a/src/init.sh
+++ b/src/init.sh
@@ -1,5 +1,5 @@
 #! /bin/bash
-set -eu
+set -euo pipefail
 
 echo "########### VERSION ##########"
 if [[ -e "/code/src/version.txt" ]]; then
@@ -9,11 +9,10 @@ else
 fi
 echo -e "########### VERSION ##########\n"
 
-if [ "$1" = 'api' ]; then
-  if [ "${DATA_SOURCE_FILES:-""}" != "" ]; then
-    echo "$DATA_SOURCE_FILES" > /code/src/system_DS.json
-  fi
 
+envsubst < /code/src/system_DS_template.json > /tmp/DMSS_systemDS.json
+
+if [ "$1" = 'api' ]; then
   if [ "${RESET_DATA_SOURCE:-"on"}" == "on" ]; then
     python3 /code/src/app.py reset-app
   fi

--- a/src/system_DS_template.json
+++ b/src/system_DS_template.json
@@ -6,7 +6,7 @@
       "host": "db",
       "port": 27017,
       "username": "maf",
-      "password": "maf",
+      "password": "$MONGO_PASSWORD",
       "tls": false,
       "database": "DMSS-core",
       "collection": "DMSS-core"


### PR DESCRIPTION
## What does this pull request change?
- For the "system.json"-data_source-file, create a template, substitute it's variables with envvars.
- Replace local dev mongoDB image with `bitnami/mongodb:6.0.9`

## Why is this pull request needed?
Overall goal of making environment specific configuration simpler 