### PR TITLE
fix: consistent envvar name

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -11,7 +11,7 @@ services:
       SECRET_KEY: sg9aeUM5i1JO4gNN8fQadokJa3_gXQMLBjSGGYcfscs= # Don't reuse this in production...
       ENVIRONMENT: local
       LOGGING_LEVEL: debug
-      # MONGO_URI: ${MONGO_URI}
+      MONGO_URI: ${MONGO_URI}
       AUTH_ENABLED: "False"
       #AUTH_ENABLED: "True"
       OAUTH_TOKEN_ENDPOINT: https://login.microsoftonline.com/3aa4a235-b6e2-48d5-9195-7fcf05b459b0/oauth2/v2.0/token #http://localhost:8080/auth/realms/dmss/protocol/openid-connect/token

--- a/src/config.py
+++ b/src/config.py
@@ -4,8 +4,8 @@ from enums import AuthProviderForRoleCheck
 
 
 class Config(BaseSettings):
-    MONGO_USERNAME: str = Field("maf", env="MONGO_INITDB_ROOT_USERNAME")
-    MONGO_PASSWORD: str = Field("maf", env="MONGO_INITDB_ROOT_PASSWORD")
+    MONGO_USERNAME: str = Field("maf", env="MONGO_USERNAME")
+    MONGO_PASSWORD: str = Field("maf", env="MONGO_PASSWORD")
     MONGO_URI: str = Field(None, env="MONGO_URI")
     ENVIRONMENT: str = Field("local", env="ENVIRONMENT")
     SECRET_KEY: str = Field(None, env="SECRET_KEY")


### PR DESCRIPTION
Env var used for internal mongoDB should have same name as variable in all other places.