### PR TITLE
Fix/get attribute relative address

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -4,7 +4,7 @@ services:
   dmss:
     build:
       target: development
-    image: datamodelingtool.azurecr.io/dmss:dev
+    image: datamodelingtool.azurecr.io/dmss:latest
     volumes:
       - ./src:/code/src
     environment:

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -4,7 +4,7 @@ services:
   dmss:
     build:
       target: development
-    image: datamodelingtool.azurecr.io/dmss:latest
+    image: datamodelingtool.azurecr.io/dmss:dev
     volumes:
       - ./src:/code/src
     environment:
@@ -27,6 +27,10 @@ services:
       - "5000:5000"
 
   db:
+    image: mongo:3.4
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: maf
+      MONGO_INITDB_ROOT_PASSWORD: maf
     volumes:
       - ./data/db:/data/db
 

--- a/src/features/attribute/use_cases/get_attribute_use_case.py
+++ b/src/features/attribute/use_cases/get_attribute_use_case.py
@@ -18,7 +18,7 @@ def get_attribute_use_case(
     node: Node = document_service.get_document(address_from_abs)
     if resolve and node.attribute.attribute_type == SIMOS.REFERENCE.value:
         reference_address = Address.from_relative(
-            node.entity["address"], address_from_abs.path.split(".").pop(0).strip("$"), node.get_data_source()
+            node.entity["address"], node.find_parent().node_id, node.get_data_source()
         )
         # Resolve the reference
         reference_node: Node = document_service.get_document(reference_address, 1)

--- a/src/features/attribute/use_cases/get_attribute_use_case.py
+++ b/src/features/attribute/use_cases/get_attribute_use_case.py
@@ -14,8 +14,7 @@ def get_attribute_use_case(
 ):
     """Get attribute by reference."""
     document_service = DocumentService(repository_provider=repository_provider, user=user)
-    address_from_abs = Address.from_absolute(address)
-    node: Node = document_service.get_document(address_from_abs)
+    node: Node = document_service.get_document(Address.from_absolute(address))
     if resolve and node.attribute.attribute_type == SIMOS.REFERENCE.value:
         reference_address = Address.from_relative(
             node.entity["address"], node.find_parent().node_id, node.get_data_source()

--- a/src/features/attribute/use_cases/get_attribute_use_case.py
+++ b/src/features/attribute/use_cases/get_attribute_use_case.py
@@ -14,9 +14,12 @@ def get_attribute_use_case(
 ):
     """Get attribute by reference."""
     document_service = DocumentService(repository_provider=repository_provider, user=user)
-    node: Node = document_service.get_document(Address.from_absolute(address))
+    address_from_abs = Address.from_absolute(address)
+    node: Node = document_service.get_document(address_from_abs)
     if resolve and node.attribute.attribute_type == SIMOS.REFERENCE.value:
-        reference_address = Address.from_relative(node.entity["address"], None, node.get_data_source())
+        reference_address = Address.from_relative(
+            node.entity["address"], address_from_abs.path.split(".").pop(0).strip("$"), node.get_data_source()
+        )
         # Resolve the reference
         reference_node: Node = document_service.get_document(reference_address, 1)
         return {"attribute": reference_node.attribute.to_dict(), "address": str(reference_address)}

--- a/src/tests/bdd/document/get_attribute.feature
+++ b/src/tests/bdd/document/get_attribute.feature
@@ -35,6 +35,11 @@ Feature: Get an attribute
                 "address": "$4",
                 "type": "dmss://system/SIMOS/Reference",
                 "referenceType": "link"
+            },
+            {
+                "address": "$5",
+                "type": "dmss://system/SIMOS/Reference",
+                "referenceType": "link"
             }
         ]
     }
@@ -114,10 +119,16 @@ Feature: Get an attribute
           "attributeType": "string",
           "contained": true,
           "optional": true
+        },
+        {
+          "name": "middleManager",
+          "type": "dmss://system/SIMOS/BlueprintAttribute",
+          "attributeType": "dmss://test-DS/root_package/Manager",
+          "contained": true,
+          "optional": true
         }
       ]
-      }
-
+    }
     """
 
     Given there exist document with id "3" in data source "test-DS"
@@ -153,6 +164,16 @@ Feature: Get an attribute
         "type":"dmss://system/SIMOS/Reference",
         "referenceType":"link",
         "address":"dmss://test-DS/$3.accountant"
+      },
+      "middleManager": {
+        "type":"dmss://test-DS/root_package/Manager",
+        "name":"Karen",
+        "phoneNumber":1337,
+        "worker": {
+          "type":"dmss://system/SIMOS/Reference",
+          "referenceType":"link",
+          "address":"^.employees[1]"
+        }
       }
     }
     """
@@ -181,6 +202,43 @@ Feature: Get an attribute
           "attributeType": "number",
           "label": "Phone Number",
           "optional": true
+        }
+      ]
+    }
+    """
+  Given there exist document with id "5" in data source "test-DS"
+    """
+    {
+      "name": "Manager",
+      "type": "dmss://system/SIMOS/Blueprint",
+      "attributes": [
+        {
+          "name": "type",
+          "type": "dmss://system/SIMOS/BlueprintAttribute",
+          "attributeType": "string",
+          "optional": false
+        },
+        {
+          "name": "name",
+          "type": "dmss://system/SIMOS/BlueprintAttribute",
+          "attributeType": "string",
+          "label": "Name",
+          "optional": false
+        },
+        {
+          "name": "phoneNumber",
+          "type": "dmss://system/SIMOS/BlueprintAttribute",
+          "attributeType": "number",
+          "label": "Phone Number",
+          "optional": true
+        },
+        {
+          "name": "worker",
+          "type": "dmss://system/SIMOS/BlueprintAttribute",
+          "attributeType": "dmss://test-DS/root_package/Person",
+          "label": "Worker",
+          "optional": true,
+          "contained": false
         }
       ]
     }
@@ -271,5 +329,27 @@ Feature: Get an attribute
           "enumType": ""
         },
         "address": "test-DS/$3.ceo"
+      }
+    """
+  Scenario: Get nested uncontained attribute without resolve
+    Given I access the resource url "/api/attribute/test-DS/$3.middleManager.worker?resolve=true"
+    When I make a "GET" request
+    Then the response status should be "OK"
+    And the response should contain
+    """
+      {
+        "attribute": {
+          "name": "employees",
+          "attributeType": "dmss://test-DS/root_package/Person",
+          "type": "dmss://system/SIMOS/BlueprintAttribute",
+          "description": "",
+          "label": "Employees",
+          "default": null,
+          "dimensions": "",
+          "optional": false,
+          "contained": true,
+          "enumType": ""
+        },
+        "address": "dmss://test-DS/$3.employees[1]"
       }
     """

--- a/src/tests/bdd/document/get_attribute.feature
+++ b/src/tests/bdd/document/get_attribute.feature
@@ -123,7 +123,7 @@ Feature: Get an attribute
     Given there exist document with id "3" in data source "test-DS"
     """
     {
-      "type":"dmss://DemoDataSource/plugins/form/uncontained_object/blueprints/Company",
+      "type":"dmss://test-DS/root_package/Company",
       "_id":"UncontainedObject",
       "name":"UncontainedObject",
       "numberOfEmployees":10,
@@ -131,12 +131,12 @@ Feature: Get an attribute
       "description":"It's a super nice place to work. The people are happy and they love to create great applications for use in the moorling line simulations.",
       "employees":[
         {
-          "type":"dmss://DemoDataSource/plugins/form/uncontained_object/blueprints/Person",
+          "type":"dmss://test-DS/root_package/Person",
           "name":"Miranda",
           "phoneNumber":1337
         },
         {
-          "type":"dmss://DemoDataSource/plugins/form/uncontained_object/blueprints/Person",
+          "type":"dmss://test-DS/root_package/Person",
           "name":"John","phoneNumber":1234
       }],
       "ceo":{
@@ -152,7 +152,7 @@ Feature: Get an attribute
       "assistant":{
         "type":"dmss://system/SIMOS/Reference",
         "referenceType":"link",
-        "address":"dmss://DemoDataSource/$UncontainedObject.accountant"
+        "address":"dmss://test-DS/$3.accountant"
       }
     }
     """
@@ -185,7 +185,91 @@ Feature: Get an attribute
       ]
     }
     """
-  Scenario: Get uncontained attribute
-    Given I access the resource url "/api/attribute_get/test-DS/$3.ceo"
+  Scenario: Get contained attribute with resolve
+    Given I access the resource url "/api/attribute/test-DS/$3.employees?resolve=true"
     When I make a "GET" request
     Then the response status should be "OK"
+    And the response should contain
+    """
+      {
+        "attribute": {
+          "name": "employees",
+          "attributeType": "dmss://test-DS/root_package/Person",
+          "type": "dmss://system/SIMOS/BlueprintAttribute",
+          "description": "",
+          "label": "Employees",
+          "default": null,
+          "dimensions": "*",
+          "optional": false,
+          "contained": true,
+          "enumType": ""
+        },
+        "address": "test-DS/$3.employees"
+      }
+    """
+  Scenario: Get contained attribute without resolve
+    Given I access the resource url "/api/attribute/test-DS/$3.employees?resolve=false"
+    When I make a "GET" request
+    Then the response status should be "OK"
+    And the response should contain
+    """
+      {
+        "attribute": {
+          "name": "employees",
+          "attributeType": "dmss://test-DS/root_package/Person",
+          "type": "dmss://system/SIMOS/BlueprintAttribute",
+          "description": "",
+          "label": "Employees",
+          "default": null,
+          "dimensions": "*",
+          "optional": false,
+          "contained": true,
+          "enumType": ""
+        },
+        "address": "test-DS/$3.employees"
+      }
+    """
+  Scenario: Get uncontained attribute with resolve
+    Given I access the resource url "/api/attribute/test-DS/$3.ceo?resolve=true"
+    When I make a "GET" request
+    Then the response status should be "OK"
+    And the response should contain
+    """
+      {
+        "attribute":{
+          "name": "employees",
+          "attributeType": "dmss://test-DS/root_package/Person",
+          "type": "dmss://system/SIMOS/BlueprintAttribute",
+          "description": "",
+          "label": "Employees",
+          "default": null,
+          "dimensions": "",
+          "optional": false,
+          "contained": true,
+          "enumType": ""
+        },
+        "address": "dmss://test-DS/$3.employees[0]"
+      }
+    """
+  Scenario: Get uncontained attribute without resolve
+    Given I access the resource url "/api/attribute/test-DS/$3.ceo?resolve=false"
+    When I make a "GET" request
+    Then the response status should be "OK"
+    And the response should contain
+    """
+      {
+        "attribute": {
+          "name": "ceo",
+          "attributeType": "dmss://system/SIMOS/Reference",
+          "type": "dmss://system/SIMOS/BlueprintAttribute",
+          "description": "",
+          "label": "CEO",
+          "default": null,
+          "dimensions": "",
+          "optional": false,
+          "contained": false,
+          "enumType": ""
+        },
+        "address": "test-DS/$3.ceo"
+      }
+    """

--- a/src/tests/bdd/document/get_attribute.feature
+++ b/src/tests/bdd/document/get_attribute.feature
@@ -1,0 +1,191 @@
+# Created by CHCL at 09/01/2024
+Feature: Get an attribute
+  # Enter feature description here
+  Background: The core package is uploaded to the system
+    Given the system data source and SIMOS core package are available
+#    Given the DMSS-lookup has been created
+    Given there are basic data sources with repositories
+      | name    |
+      | test-DS |
+
+    Given there are repositories in the data sources
+      | data-source | host | port  | username | password | tls   | name  | database | collection | type     | dataTypes |
+      | test-DS     | db   | 27017 | maf      | maf      | false | blobs | bdd-test | blobs      | mongo-db | blob      |
+
+
+
+    Given there exist document with id "1" in data source "test-DS"
+    """
+    {
+        "name": "root_package",
+        "type": "dmss://system/SIMOS/Package",
+        "isRoot": true,
+        "content": [
+            {
+                "address": "$2",
+                "type": "dmss://system/SIMOS/Reference",
+                "referenceType": "link"
+            },
+            {
+                "address": "$3",
+                "type": "dmss://system/SIMOS/Reference",
+                "referenceType": "link"
+            },
+            {
+                "address": "$4",
+                "type": "dmss://system/SIMOS/Reference",
+                "referenceType": "link"
+            }
+        ]
+    }
+    """
+    Given there exist document with id "2" in data source "test-DS"
+    """
+    {
+      "name": "Company",
+      "type": "dmss://system/SIMOS/Blueprint",
+      "attributes": [
+        {
+          "name": "type",
+          "type": "dmss://system/SIMOS/BlueprintAttribute",
+          "attributeType": "string"
+        },
+        {
+          "name": "name",
+          "type": "dmss://system/SIMOS/BlueprintAttribute",
+          "attributeType": "string"
+        },
+        {
+          "name": "employees",
+          "type": "dmss://system/SIMOS/BlueprintAttribute",
+          "attributeType": "dmss://test-DS/root_package/Person",
+          "dimensions": "*",
+          "label": "Employees"
+        },
+        {
+          "name": "ceo",
+          "type": "dmss://system/SIMOS/BlueprintAttribute",
+          "attributeType": "dmss://test-DS/root_package/Person",
+          "label": "CEO",
+          "contained": false,
+          "optional": false
+        },
+        {
+          "name": "numberOfEmployees",
+          "type": "dmss://system/SIMOS/BlueprintAttribute",
+          "attributeType": "number",
+          "contained": true,
+          "optional": true
+        },
+        {
+          "name": "accountant",
+          "type": "dmss://system/SIMOS/BlueprintAttribute",
+          "attributeType": "dmss://test-DS/root_package/Person",
+          "label": "Accountant",
+          "contained": false,
+          "optional": false
+        },
+        {
+          "name": "averageSalary",
+          "type": "dmss://system/SIMOS/BlueprintAttribute",
+          "attributeType": "number",
+          "contained": true,
+          "optional": true
+        },
+        {
+          "name": "assistant",
+          "type": "dmss://system/SIMOS/BlueprintAttribute",
+          "attributeType": "dmss://test-DS/root_package/Person",
+          "label": "Assistant",
+          "contained": false,
+          "optional": true
+        },
+        {
+          "name": "trainee",
+          "type": "dmss://system/SIMOS/BlueprintAttribute",
+          "attributeType": "dmss://test-DS/root_package/Person",
+          "label": "Trainee",
+          "contained": false,
+          "optional": true
+        },
+        {
+          "name": "description",
+          "type": "dmss://system/SIMOS/BlueprintAttribute",
+          "attributeType": "string",
+          "contained": true,
+          "optional": true
+        }
+      ]
+      }
+
+    """
+
+    Given there exist document with id "3" in data source "test-DS"
+    """
+    {
+      "type":"dmss://DemoDataSource/plugins/form/uncontained_object/blueprints/Company",
+      "_id":"UncontainedObject",
+      "name":"UncontainedObject",
+      "numberOfEmployees":10,
+      "averageSalary":800000,
+      "description":"It's a super nice place to work. The people are happy and they love to create great applications for use in the moorling line simulations.",
+      "employees":[
+        {
+          "type":"dmss://DemoDataSource/plugins/form/uncontained_object/blueprints/Person",
+          "name":"Miranda",
+          "phoneNumber":1337
+        },
+        {
+          "type":"dmss://DemoDataSource/plugins/form/uncontained_object/blueprints/Person",
+          "name":"John","phoneNumber":1234
+      }],
+      "ceo":{
+        "type":"dmss://system/SIMOS/Reference",
+        "referenceType":"link",
+        "address":"^.employees[0]"
+      },
+      "accountant":{
+        "type":"dmss://system/SIMOS/Reference",
+        "referenceType":"link",
+        "address":"^.employees[0]"
+      },
+      "assistant":{
+        "type":"dmss://system/SIMOS/Reference",
+        "referenceType":"link",
+        "address":"dmss://DemoDataSource/$UncontainedObject.accountant"
+      }
+    }
+    """
+    Given there exist document with id "4" in data source "test-DS"
+    """
+    {
+      "name": "Person",
+      "type": "dmss://system/SIMOS/Blueprint",
+      "attributes": [
+        {
+          "name": "type",
+          "type": "dmss://system/SIMOS/BlueprintAttribute",
+          "attributeType": "string",
+          "optional": false
+        },
+        {
+          "name": "name",
+          "type": "dmss://system/SIMOS/BlueprintAttribute",
+          "attributeType": "string",
+          "label": "Name",
+          "optional": false
+        },
+        {
+          "name": "phoneNumber",
+          "type": "dmss://system/SIMOS/BlueprintAttribute",
+          "attributeType": "number",
+          "label": "Phone Number",
+          "optional": true
+        }
+      ]
+    }
+    """
+  Scenario: Get uncontained attribute
+    Given I access the resource url "/api/attribute_get/test-DS/$3.ceo"
+    When I make a "GET" request
+    Then the response status should be "OK"


### PR DESCRIPTION
## What does this pull request change?
Pass document ID down so it can be used to repolace ^

## Why is this pull request needed?@
Unable to open uncontained attributes that use ^ in link reference

## Issues related to this change: