### PR TITLE
fix: fallback recursive limit should be bigger than common used depth

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -10,7 +10,7 @@ class Config(BaseSettings):
     ENVIRONMENT: str = Field("local", env="ENVIRONMENT")
     SECRET_KEY: str = Field(None, env="SECRET_KEY")
     LOGGER_LEVEL: str = Field("DEBUG", env="LOGGING_LEVEL", to_lower=True)
-    MAX_ENTITY_RECURSION_DEPTH: int = Field(50, env="MAX_ENTITY_RECURSION_DEPTH")
+    MAX_ENTITY_RECURSION_DEPTH: int = Field(5000, env="MAX_ENTITY_RECURSION_DEPTH")
     CORE_DATA_SOURCE: str = "system"
     CACHE_MAX_SIZE: int = 200
     # Access Control

--- a/src/domain_classes/dimension.py
+++ b/src/domain_classes/dimension.py
@@ -12,8 +12,6 @@ def _get_data_type_from_dmt_type(
         return type_enum.to_py_type()
     except ValueError:
         return attribute_type
-    except Exception as ex:
-        raise Exception(f"Something went wrong trying to fetch data type: {ex}") from ex
 
 
 class Dimension:

--- a/src/features/entity/use_cases/validate_existing_entity_use_case.py
+++ b/src/features/entity/use_cases/validate_existing_entity_use_case.py
@@ -7,7 +7,7 @@ from services.document_service.document_service import DocumentService
 
 def validate_existing_entity_use_case(address: str, user: User) -> str:
     document_service = DocumentService(user=user)
-    document_as_node: Node = document_service.get_document(Address.from_absolute(address), depth=999)
+    document_as_node: Node = document_service.get_document(Address.from_absolute(address), depth=500)
     # TODO resolving fails in above line. for some reason the address dmss://DemoDataSource/plugins/DemoDataSource/plugins/grid/blueprints/Dashboard
     validate_entity_against_self(document_as_node.entity, document_service.get_blueprint)
     return "OK"


### PR DESCRIPTION
- The fallback recursive limit number (config.MAX_ENTITY_RECURSION_DEPTH) should be bigger than common depth values. If not we get a recursion error on even small depths
