### PR TITLE
feat: url blueprint in core

### DIFF
--- a/src/home/system/SIMOS/Url.json
+++ b/src/home/system/SIMOS/Url.json
@@ -1,0 +1,22 @@
+{
+  "name": "Url",
+  "type": "dmss://system/SIMOS/Blueprint",
+  "description": "This an object containing a url, ie. 'https://example.com'.",
+  "extends": [
+    "dmss://system/SIMOS/Entity"
+  ],
+  "attributes": [
+    {
+      "name": "value",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "description": "This is the url string, ie. 'https://example.com'.",
+      "attributeType": "string"
+    },
+    {
+      "name": "label",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "description": "The label for the url, will often be what is seen by the user instead of the url string itself.",
+      "attributeType": "string"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this pull request change?

Adding a url blueprint according to specification 

## Why is this pull request needed?

## Issues related to this change:
