### PR TITLE
refactor: skip create node tree when getting documents

### DIFF
--- a/src/features/document/use_cases/get_document_use_case.py
+++ b/src/features/document/use_cases/get_document_use_case.py
@@ -2,10 +2,20 @@ from pydantic import conint
 
 from authentication.models import User
 from common.address import Address
-from common.tree.tree_node import ListNode, Node
-from common.tree.tree_node_serializer import tree_node_to_dict
+from common.exceptions import BadRequestException
 from services.document_service.document_service import DocumentService
 from storage.internal.data_source_repository import get_data_source
+
+
+def get_nested_dict_attribute(entity: dict | list, path_list: list[str]) -> dict | list:
+    try:
+        if isinstance(entity, list):
+            path_list[0] = int(path_list[0].strip("[]"))  # type: ignore
+        if len(path_list) == 1:
+            return entity[path_list[0]]  # type: ignore
+        return get_nested_dict_attribute(entity[path_list[0]], path_list[1:])  # type: ignore
+    except (KeyError, IndexError) as e:
+        raise BadRequestException(f"Attribute/Item '{path_list[0]}' does not exists in '{entity}'") from e
 
 
 def get_document_use_case(
@@ -17,5 +27,7 @@ def get_document_use_case(
     """Get document by reference."""
     document_service = DocumentService(repository_provider=repository_provider, user=user)
     address_object = Address.from_absolute(address)
-    node: Node | ListNode = document_service.get_document(address_object, depth)
-    return tree_node_to_dict(node)
+    resolved_document, resolved_address = document_service.resolve_document(address_object, depth)
+    if len(resolved_address.attribute_path) > 0:
+        return get_nested_dict_attribute(resolved_document, resolved_address.attribute_path)
+    return resolved_document

--- a/src/services/document_service/document_service.py
+++ b/src/services/document_service/document_service.py
@@ -219,13 +219,16 @@ class DocumentService:
 
             data_source: DataSource = self.get_data_source(resolved_address.data_source_id)
             document: dict = data_source.get(resolved_address.document_id)
+            if depth == 0:
+                return document, resolved_address
 
+            attribute_depth = len(list(filter(lambda x: x[0] != "[", resolved_address.attribute_path)))
             resolved_document: dict = resolve_references_in_entity(
                 document,
                 data_source,
                 self.get_data_source,
                 resolved_address.document_id,
-                depth=depth + len(list(filter(lambda x: x[0] != "[", resolved_address.attribute_path))),
+                depth=depth + attribute_depth,
                 depth_count=1,
             )
         except (NotFoundException, ApplicationException) as e:


### PR DESCRIPTION
## What does this pull request change?

* Avoid create node tree when getting document that might speed up things a bit

## Why is this pull request needed?

## Issues related to this change:
