### PR TITLE
perf: never invalidate blueprint cache

### DIFF
--- a/src/features/document/use_cases/add_raw_use_case.py
+++ b/src/features/document/use_cases/add_raw_use_case.py
@@ -1,8 +1,6 @@
 from uuid import uuid4
 
 from authentication.models import User
-from enums import SIMOS
-from services.document_service.document_service import DocumentService
 from storage.internal.data_source_repository import get_data_source
 
 
@@ -11,6 +9,4 @@ def add_raw_use_case(user: User, document: dict, data_source_id: str):
     document["_id"] = new_node_id
     document_repository = get_data_source(data_source_id, user)
     document_repository.update(document)
-    if document["type"] == SIMOS.BLUEPRINT.value:
-        DocumentService(user=user).invalidate_cache()
     return new_node_id

--- a/src/features/document/use_cases/remove_use_case.py
+++ b/src/features/document/use_cases/remove_use_case.py
@@ -7,5 +7,4 @@ from storage.internal.data_source_repository import get_data_source
 def remove_use_case(user: User, address: str, repository_provider=get_data_source) -> str:
     document_service = DocumentService(repository_provider=repository_provider, user=user)
     document_service.remove(Address.from_absolute(address))
-    document_service.invalidate_cache()
     return "OK"

--- a/src/features/document/use_cases/update_document_use_case.py
+++ b/src/features/document/use_cases/update_document_use_case.py
@@ -93,7 +93,4 @@ def update_document_use_case(
         files={f.filename: f.file for f in files} if files else None,
         partial_update=partial_update,
     )
-    # Do not invalidate the blueprint cache if it was not a blueprint that was changed
-    if "type" in document["data"] and document["data"]["type"] == SIMOS.BLUEPRINT.value:
-        document_service.invalidate_cache()
     return document


### PR DESCRIPTION
## What does this pull request change?
Never invalidate blueprint cache.

## Why is this pull request needed?
Performance boost

## Issues related to this change:
part of https://github.com/equinor/dm-core-packages/issues/1173
