### PR TITLE
perf: blueprint cache shared between users

### DIFF
--- a/src/features/access_control/access_control_feature.py
+++ b/src/features/access_control/access_control_feature.py
@@ -47,7 +47,7 @@ def set_acl(
     document_service = DocumentService(
         repository_provider=get_data_source,
         user=user,
-        blueprint_provider=get_blueprint_provider(user),
+        blueprint_provider=get_blueprint_provider(),
         recipe_provider=storage_recipe_provider,
     )
 

--- a/src/features/document/document_feature.py
+++ b/src/features/document/document_feature.py
@@ -84,7 +84,7 @@ def update(
     document_service = DocumentService(
         repository_provider=get_data_source,
         user=user,
-        blueprint_provider=get_blueprint_provider(user),
+        blueprint_provider=get_blueprint_provider(),
         recipe_provider=storage_recipe_provider,
     )
 
@@ -135,7 +135,7 @@ def add_document(
     document_service = DocumentService(
         repository_provider=get_data_source,
         user=user,
-        blueprint_provider=get_blueprint_provider(user),
+        blueprint_provider=get_blueprint_provider(),
         recipe_provider=storage_recipe_provider,
     )
 

--- a/src/features/lookup_table/use_cases/create_lookup_table.py
+++ b/src/features/lookup_table/use_cases/create_lookup_table.py
@@ -69,5 +69,4 @@ def create_lookup_table_use_case(
 
     insert_lookup(name, combined_lookup)
 
-    document_service.get_storage_recipes.cache_clear()
     get_lookup.cache_clear()

--- a/src/tests/bdd/environment.py
+++ b/src/tests/bdd/environment.py
@@ -1,4 +1,5 @@
 from authentication.models import User
+from common.providers.blueprint_provider import get_blueprint_provider
 from config import config
 from tests.bdd.results import print_overview_errors, print_overview_features
 from tests.test_helpers.wipe_db import wipe_db
@@ -28,6 +29,10 @@ def after_feature(context, feature):
     if "skip" in feature.tags:
         feature.skip("Marked with @skip")
     context.features.append(feature)
+    blueprint_provider = get_blueprint_provider()
+    blueprint_provider.get_blueprint.cache_clear()
+    blueprint_provider.get_blueprint_with_extended_attributes.cache_clear()
+    get_blueprint_provider.cache_clear()
 
 
 def before_scenario(context, scenario):

--- a/src/tests/unit/mocks/mock_blueprint_provider.py
+++ b/src/tests/unit/mocks/mock_blueprint_provider.py
@@ -35,3 +35,6 @@ class MockBlueprintProvider:
             f"Invalid type {type} asked for from the MockBlueprintProvider. No such blueprint were provided as"
             + " available blueprints as parameters in the initialisation of the MockBlueprintProvider."
         )
+
+    def get_blueprint_with_extended_attributes(self, type: str):
+        return self.get_blueprint(type)


### PR DESCRIPTION
## What does this pull request change?
- All users now share the same blueprint cache

## Why is this pull request needed?
- Caching was not working as intended. With a new cache for each user and each instance of the DocumentService() (which is created on each request)

## Issues related to this change:
related to #770 