### PR TITLE
Fix/one blueprint provider to rule them all

### DIFF
--- a/src/common/providers/blueprint_provider.py
+++ b/src/common/providers/blueprint_provider.py
@@ -65,12 +65,15 @@ class BlueprintProvider:
             logger.warning("function is not instance of lru cache.", error)
 
 
-@lru_cache(maxsize=config.CACHE_MAX_SIZE)
 def get_blueprint_provider():
     # TODO: Hard coding the admin user here is a short term performance hack.
     # This hack leads to any authenticated user can read any document if it's accessed as a blueprint
     # The proper fix would be to either "compile" all blueprint at startup, or implement a repository/access control
     # system that lends itself to cache better than what we have now (6.2.2024)
+    logger.debug("Cache miss! Creating new blueprint provider!")
     return BlueprintProvider(
         User(**{"user_id": config.DMSS_ADMIN, "email": "mock_dmss_admin@example.com", "full_name": "Mock admin user"})
     )
+
+
+default_blueprint_provider = get_blueprint_provider()

--- a/src/common/providers/blueprint_provider.py
+++ b/src/common/providers/blueprint_provider.py
@@ -1,3 +1,4 @@
+import uuid
 from collections.abc import Callable
 from functools import lru_cache
 
@@ -24,12 +25,13 @@ class BlueprintProvider:
         self.user = user
         self.get_data_source = get_data_source
         self.resolve_address = resolve_address
+        self.id = uuid.uuid4()
 
     @lru_cache(maxsize=config.CACHE_MAX_SIZE)  # noqa: B019
     def get_blueprint_with_extended_attributes(self, type: str) -> Blueprint:
         blueprint: Blueprint = self.get_blueprint(type)
         blueprint.realize_extends(self.get_blueprint)
-        logger.debug(f"Cache miss! Fetching extended blueprint '{type}' '{hash(self)}'")
+        logger.debug(f"Cache miss! Fetching extended blueprint '{type}' '{hash(self)} id: {self.id}'")
         logger.debug(self.get_blueprint_with_extended_attributes.cache_info())
         return blueprint
 

--- a/src/features/access_control/access_control_feature.py
+++ b/src/features/access_control/access_control_feature.py
@@ -4,7 +4,6 @@ from fastapi.responses import JSONResponse, PlainTextResponse
 from authentication.authentication import auth_w_jwt_or_pat
 from authentication.models import AccessControlList, User
 from common.address import Address
-from common.providers.blueprint_provider import get_blueprint_provider
 from common.providers.storage_recipe_provider import storage_recipe_provider
 from common.responses import create_response, responses
 from services.document_service.document_service import DocumentService
@@ -47,7 +46,6 @@ def set_acl(
     document_service = DocumentService(
         repository_provider=get_data_source,
         user=user,
-        blueprint_provider=get_blueprint_provider(),
         recipe_provider=storage_recipe_provider,
     )
 

--- a/src/features/document/document_feature.py
+++ b/src/features/document/document_feature.py
@@ -5,7 +5,6 @@ from pydantic import Json, conint
 from authentication.authentication import auth_w_jwt_or_pat
 from authentication.models import User
 from common.address import Address
-from common.providers.blueprint_provider import get_blueprint_provider
 from common.providers.storage_recipe_provider import storage_recipe_provider
 from common.responses import create_response, responses
 from services.document_service.document_service import DocumentService
@@ -84,7 +83,6 @@ def update(
     document_service = DocumentService(
         repository_provider=get_data_source,
         user=user,
-        blueprint_provider=get_blueprint_provider(),
         recipe_provider=storage_recipe_provider,
     )
 
@@ -135,7 +133,6 @@ def add_document(
     document_service = DocumentService(
         repository_provider=get_data_source,
         user=user,
-        blueprint_provider=get_blueprint_provider(),
         recipe_provider=storage_recipe_provider,
     )
 

--- a/src/services/document_service/document_service.py
+++ b/src/services/document_service/document_service.py
@@ -54,9 +54,7 @@ class DocumentService:
         context: str | None = None,
         recipe_provider=None,
     ):
-        logger.debug("New document service")
         self._blueprint_provider = blueprint_provider or default_blueprint_provider
-        logger.debug(f"Got blueprint provider: {hash(self._blueprint_provider)}")
         self._recipe_provider: Callable[..., list[StorageRecipe]] = recipe_provider or storage_recipe_provider
         self.repository_provider = repository_provider
         self.user = user
@@ -64,7 +62,6 @@ class DocumentService:
         self.get_data_source = lambda data_source_id: self.repository_provider(data_source_id, self.user)
 
     def get_blueprint(self, type: str) -> Blueprint:
-        logger.debug(f"Getting blueprint from document service: {type}")
         return self._blueprint_provider.get_blueprint_with_extended_attributes(type)
 
     def get_storage_recipes(self, type: str, context: str | None = None) -> list[StorageRecipe]:

--- a/src/services/document_service/document_service.py
+++ b/src/services/document_service/document_service.py
@@ -18,7 +18,7 @@ from common.providers.address_resolver.address_resolver import (
     resolve_address,
 )
 from common.providers.address_resolver.reference_resolver import resolve_references_in_entity
-from common.providers.blueprint_provider import get_blueprint_provider
+from common.providers.blueprint_provider import default_blueprint_provider
 from common.providers.storage_recipe_provider import (
     create_default_storage_recipe,
     storage_recipe_provider,
@@ -54,7 +54,9 @@ class DocumentService:
         context: str | None = None,
         recipe_provider=None,
     ):
-        self._blueprint_provider = blueprint_provider or get_blueprint_provider()
+        logger.debug("New document service")
+        self._blueprint_provider = blueprint_provider or default_blueprint_provider
+        logger.debug(f"Got blueprint provider: {hash(self._blueprint_provider)}")
         self._recipe_provider: Callable[..., list[StorageRecipe]] = recipe_provider or storage_recipe_provider
         self.repository_provider = repository_provider
         self.user = user
@@ -62,6 +64,7 @@ class DocumentService:
         self.get_data_source = lambda data_source_id: self.repository_provider(data_source_id, self.user)
 
     def get_blueprint(self, type: str) -> Blueprint:
+        logger.debug(f"Getting blueprint from document service: {type}")
         return self._blueprint_provider.get_blueprint_with_extended_attributes(type)
 
     def get_storage_recipes(self, type: str, context: str | None = None) -> list[StorageRecipe]:

--- a/src/tests/bdd/environment.py
+++ b/src/tests/bdd/environment.py
@@ -1,5 +1,5 @@
 from authentication.models import User
-from common.providers.blueprint_provider import get_blueprint_provider
+from common.providers.blueprint_provider import default_blueprint_provider
 from config import config
 from tests.bdd.results import print_overview_errors, print_overview_features
 from tests.test_helpers.wipe_db import wipe_db
@@ -29,10 +29,8 @@ def after_feature(context, feature):
     if "skip" in feature.tags:
         feature.skip("Marked with @skip")
     context.features.append(feature)
-    blueprint_provider = get_blueprint_provider()
-    blueprint_provider.get_blueprint.cache_clear()
-    blueprint_provider.get_blueprint_with_extended_attributes.cache_clear()
-    get_blueprint_provider.cache_clear()
+    default_blueprint_provider.get_blueprint.cache_clear()
+    default_blueprint_provider.get_blueprint_with_extended_attributes.cache_clear()
 
 
 def before_scenario(context, scenario):


### PR DESCRIPTION
## What does this pull request change?

So no cache on blueprint provider classes, instead instantiate one and use that FOREVER: 

## Why is this pull request needed?

## Issues related to this change:
