### PR TITLE
Fix: cache blueprint provider instead of one instance of it

### DIFF
--- a/src/common/providers/blueprint_provider.py
+++ b/src/common/providers/blueprint_provider.py
@@ -3,11 +3,12 @@ from collections.abc import Callable
 from functools import lru_cache
 
 from authentication.models import User
-from common.address import Address
-from common.exceptions import NotFoundException
 from common.providers.address_resolver.address_resolver import (
-    ResolvedAddress,
     resolve_address,
+)
+from common.providers.cached_blueprint_provider import (
+    cached_get_blueprint,
+    cached_get_blueprint_with_extended_attributes,
 )
 from common.utils.logging import logger
 from config import config
@@ -27,42 +28,20 @@ class BlueprintProvider:
         self.resolve_address = resolve_address
         self.id = uuid.uuid4()
 
-    @lru_cache(maxsize=config.CACHE_MAX_SIZE)  # noqa: B019
     def get_blueprint_with_extended_attributes(self, type: str) -> Blueprint:
-        blueprint: Blueprint = self.get_blueprint(type)
-        blueprint.realize_extends(self.get_blueprint)
-        logger.debug(f"Cache miss! Fetching extended blueprint '{type}' '{hash(self)} id: {self.id}'")
-        logger.debug(self.get_blueprint_with_extended_attributes.cache_info())
-        return blueprint
+        return cached_get_blueprint_with_extended_attributes(
+            type, self.get_data_source, self.resolve_address, self.user
+        )
 
     @lru_cache(maxsize=config.CACHE_MAX_SIZE)  # noqa: B019
     def get_blueprint(self, type: str) -> Blueprint:
-        logger.debug(f"Cache miss! Fetching blueprint '{type}' '{hash(self)}'")
-        try:
-            resolved_address: ResolvedAddress = self.resolve_address(
-                Address.from_absolute(type),
-                lambda data_source_name: self.get_data_source(data_source_name, self.user),
-            )
-        except NotFoundException as ex:
-            raise NotFoundException(
-                f"Blueprint referenced with '{type}' could not be found. Make sure the reference is correct.",
-                data=ex.dict(),
-            ) from ex
-        resolved_address = self.resolve_address(
-            Address.from_relative(
-                resolved_address.entity["address"],
-                resolved_address.document_id,
-                resolved_address.data_source_id,
-            ),
-            lambda data_source_name: self.get_data_source(data_source_name, self.user),
-        )
-        return Blueprint(resolved_address.entity, type)
+        return cached_get_blueprint(type, self.get_data_source, self.resolve_address, self.user)
 
     def invalidate_cache(self):
         try:
             logger.debug("invalidate cache")
-            self.get_blueprint.cache_clear()
-            self.get_blueprint_with_extended_attributes.cache_clear()
+            cached_get_blueprint_with_extended_attributes.cache_clear()
+            cached_get_blueprint.cache_clear()
         except Exception as error:
             logger.warning("function is not instance of lru cache.", error)
 
@@ -76,6 +55,3 @@ def get_blueprint_provider():
     return BlueprintProvider(
         User(**{"user_id": config.DMSS_ADMIN, "email": "mock_dmss_admin@example.com", "full_name": "Mock admin user"})
     )
-
-
-default_blueprint_provider = get_blueprint_provider()

--- a/src/common/providers/cached_blueprint_provider.py
+++ b/src/common/providers/cached_blueprint_provider.py
@@ -1,0 +1,51 @@
+from collections.abc import Callable
+from functools import lru_cache, partial
+
+from authentication.models import User
+from common.address import Address
+from common.exceptions import NotFoundException
+from common.providers.address_resolver.address_resolver import (
+    ResolvedAddress,
+)
+from common.utils.logging import logger
+from config import config
+from domain_classes.blueprint import Blueprint
+
+
+@lru_cache(maxsize=config.CACHE_MAX_SIZE)
+def cached_get_blueprint_with_extended_attributes(
+    type: str, get_data_source: Callable, resolve_address: Callable, user: User
+) -> Blueprint:
+    blueprint: Blueprint = cached_get_blueprint(type, get_data_source, resolve_address, user)
+
+    partial_get_blueprint = partial(
+        cached_get_blueprint, get_data_source=get_data_source, resolve_address=resolve_address, user=user
+    )
+    blueprint.realize_extends(partial_get_blueprint)
+    logger.debug(f"Standalone get_extended_blueprint - Cache miss! Fetching extended blueprint '{type}''")
+    logger.debug(cached_get_blueprint_with_extended_attributes.cache_info())
+    return blueprint
+
+
+@lru_cache(maxsize=config.CACHE_MAX_SIZE)
+def cached_get_blueprint(type: str, get_data_source: Callable, resolve_address: Callable, user: User) -> Blueprint:
+    logger.debug(f"Standalone get_blueprint - Cache miss! Fetching blueprint '{type}'")
+    try:
+        resolved_address: ResolvedAddress = resolve_address(
+            Address.from_absolute(type),
+            lambda data_source_name: get_data_source(data_source_name, user),
+        )
+    except NotFoundException as ex:
+        raise NotFoundException(
+            f"Blueprint referenced with '{type}' could not be found. Make sure the reference is correct.",
+            data=ex.dict(),
+        ) from ex
+    resolved_address = resolve_address(
+        Address.from_relative(
+            resolved_address.entity["address"],
+            resolved_address.document_id,
+            resolved_address.data_source_id,
+        ),
+        lambda data_source_name: get_data_source(data_source_name, user),
+    )
+    return Blueprint(resolved_address.entity, type)

--- a/src/services/document_service/document_service.py
+++ b/src/services/document_service/document_service.py
@@ -18,7 +18,7 @@ from common.providers.address_resolver.address_resolver import (
     resolve_address,
 )
 from common.providers.address_resolver.reference_resolver import resolve_references_in_entity
-from common.providers.blueprint_provider import default_blueprint_provider
+from common.providers.blueprint_provider import get_blueprint_provider
 from common.providers.storage_recipe_provider import (
     create_default_storage_recipe,
     storage_recipe_provider,
@@ -54,15 +54,15 @@ class DocumentService:
         context: str | None = None,
         recipe_provider=None,
     ):
-        self._blueprint_provider = blueprint_provider or default_blueprint_provider
         self._recipe_provider: Callable[..., list[StorageRecipe]] = recipe_provider or storage_recipe_provider
         self.repository_provider = repository_provider
+        self.blueprint_provider = blueprint_provider or get_blueprint_provider()
         self.user = user
         self.context = context
         self.get_data_source = lambda data_source_id: self.repository_provider(data_source_id, self.user)
 
     def get_blueprint(self, type: str) -> Blueprint:
-        return self._blueprint_provider.get_blueprint_with_extended_attributes(type)
+        return self.blueprint_provider.get_blueprint_with_extended_attributes(type)
 
     def get_storage_recipes(self, type: str, context: str | None = None) -> list[StorageRecipe]:
         if not context:

--- a/src/tests/bdd/environment.py
+++ b/src/tests/bdd/environment.py
@@ -1,5 +1,5 @@
 from authentication.models import User
-from common.providers.blueprint_provider import default_blueprint_provider
+from common.providers.blueprint_provider import get_blueprint_provider
 from config import config
 from tests.bdd.results import print_overview_errors, print_overview_features
 from tests.test_helpers.wipe_db import wipe_db
@@ -29,8 +29,8 @@ def after_feature(context, feature):
     if "skip" in feature.tags:
         feature.skip("Marked with @skip")
     context.features.append(feature)
-    default_blueprint_provider.get_blueprint.cache_clear()
-    default_blueprint_provider.get_blueprint_with_extended_attributes.cache_clear()
+    bp = get_blueprint_provider()
+    bp.invalidate_cache()
 
 
 def before_scenario(context, scenario):


### PR DESCRIPTION
## What does this pull request change?

Earlier we instantiated one. 


Think this is better to be able to reintroduce security measures. 
This is better because now we can have cache and userchecking inside the blueprint provider later I think

## Why is this pull request needed?

## Issues related to this change:
