### PR TITLE
feat: option to enforce uid on all complex children

### DIFF
--- a/src/SIMOS/BlueprintAttribute.json
+++ b/src/SIMOS/BlueprintAttribute.json
@@ -29,6 +29,14 @@
       "default": ""
     },
     {
+      "name": "ensureUID",
+      "type": "dmss://system/SIMOS/BlueprintAttribute",
+      "description": "If true, DMSS will ensure every complex child governed by this attribute, has a UUID",
+      "attributeType": "boolean",
+      "optional": true,
+      "default": false
+    },
+    {
       "name": "label",
       "type": "dmss://system/SIMOS/BlueprintAttribute",
       "attributeType": "string",

--- a/src/common/entity/validators.py
+++ b/src/common/entity/validators.py
@@ -90,7 +90,7 @@ def validate_entity(
     entity: dict | list,
     get_blueprint: Callable[..., Blueprint],
     blueprint: Blueprint,
-    implementation_mode: Literal["extend", "minimum"],
+    implementation_mode: Literal["extend", "minimum", "exact"],
     key: str = "^",
 ) -> None:
     """Takes a complex entity (dict) or a list of entities and validates them against an arbitrary blueprint.
@@ -126,6 +126,7 @@ def _validate_entity(
             debug=_get_debug_message(key),
             data=entity,
         )
+
     if implementation_mode == "extend":
         if entity["type"] != SIMOS.REFERENCE.value:
             if not is_blueprint_instance_of(blueprint.path, entity["type"], get_blueprint):
@@ -240,6 +241,14 @@ def _validate_complex_attribute(
     if attributeDefinition.attribute_type == BuiltinDataTypes.OBJECT.value:
         validate_entity_against_self(entity=attribute, get_blueprint=get_blueprint, key=key)
         return
+
+    if attributeDefinition.ensure_uid and not attribute.get("_id"):
+        raise ValidationException(
+            f"The attribute '{attributeDefinition.name}', requires "
+            + "the entity to have a UUID. Make sure the entity has a valid UUIDv4 at the key '_id'",
+            debug=_get_debug_message(key),
+            data=attribute,
+        )
     _validate_entity(
         attribute,
         get_blueprint,

--- a/src/common/tree/tree_node.py
+++ b/src/common/tree/tree_node.py
@@ -96,6 +96,9 @@ class NodeBase:
         if not self.storage_contained and not self.is_array():
             return self.uid
         if self.parent.is_array():
+            if self.attribute.ensure_uid:
+                return f'{self.parent.node_id}(_id="{self.uid}")'
+
             return f"{self.parent.node_id}[{self.key}]"
         return ".".join((self.parent.node_id, self.key))
 
@@ -215,6 +218,8 @@ class NodeBase:
             return True
 
     def should_have_id(self):
+        if self.attribute.ensure_uid:
+            return True
         if isinstance(self, ListNode):
             return False
         if self.type == SIMOS.REFERENCE.value:

--- a/src/domain_classes/blueprint_attribute.py
+++ b/src/domain_classes/blueprint_attribute.py
@@ -20,6 +20,7 @@ class BlueprintAttribute(BaseModel):
     label: str = ""
     default: StrictStr | StrictInt | StrictFloat | StrictBool | list | dict | None = None
     dimensions: Dimension | None = None
+    ensure_uid: bool = Field(False, alias="ensureUID")
     optional: bool = False
     contained: bool = True
     enum_type: str = Field("", alias="enumType")

--- a/src/features/document/use_cases/add_document_use_case.py
+++ b/src/features/document/use_cases/add_document_use_case.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 from typing import BinaryIO
 
 from fastapi import UploadFile
@@ -151,10 +152,12 @@ def _add_document_to_entity_or_list(
             "extend",
         )
 
+    new_attribute = deepcopy(target.attribute)
+    new_attribute.type = document["type"]
     new_node = tree_node_from_dict(
         {**document},
         blueprint_provider=document_service.get_blueprint,
-        node_attribute=BlueprintAttribute(name=target.attribute.name, attribute_type=Entity(**document).type),
+        node_attribute=new_attribute,
         recipe_provider=document_service.get_storage_recipes,
     )
 

--- a/src/tests/bdd/document/add_document.feature
+++ b/src/tests/bdd/document/add_document.feature
@@ -241,7 +241,7 @@ Feature: Add document with document_service
 
   Scenario: Add document to EntityPackage using path as reference
     Given i access the resource url "/api/documents/data-source-name/root_package/EntityPackage"
-    When i make a "POST" request with "1" files
+    When i make a form-data "POST" request
     """
     {
       "document":
@@ -269,7 +269,7 @@ Feature: Add document with document_service
 
   Scenario: Add document to EntityPackage using id as reference
     Given i access the resource url "/api/documents/data-source-name/root_package.content[6]"
-    When i make a "POST" request with "1" files
+    When i make a form-data "POST" request
     """
     {
       "document":
@@ -300,7 +300,7 @@ Feature: Add document with document_service
 
   Scenario: Add document to root package using path as reference
     Given i access the resource url "/api/documents/data-source-name/root_package"
-    When i make a "POST" request with "1" files
+    When i make a form-data "POST" request
     """
     {
       "document":
@@ -329,7 +329,7 @@ Feature: Add document with document_service
 
   Scenario: Add document to root package using id as reference
     Given i access the resource url "/api/documents/data-source-name/$100"
-    When i make a "POST" request with "1" files
+    When i make a form-data "POST" request
     """
     {
       "document":

--- a/src/tests/bdd/document/add_file.feature
+++ b/src/tests/bdd/document/add_file.feature
@@ -461,9 +461,9 @@ Feature: Explorer - Add file
     }
     """
 
-  Scenario: Add file with duplicate name
+  Scenario: Add document with duplicate name
     Given i access the resource url "/api/documents/test-DS/root_package"
-    When i make a "POST" request with "1" files
+    When i make a form-data "POST" request
     """
       {
         "document": {
@@ -501,7 +501,7 @@ Feature: Explorer - Add file
 
   Scenario: Add Parent entity without a name attribute with -by-path endpoint
     Given i access the resource url "/api/documents/test-DS/root_package"
-    When i make a "POST" request with "1" files
+    When i make a form-data "POST" request
     """
     {
       "document": {
@@ -521,9 +521,9 @@ Feature: Explorer - Add file
     }
     """
 
-  Scenario: Adding file with id set to empty string should generate new uid
+  Scenario: Adding document with id set to empty string should generate new uid
     Given I access the resource url "/api/documents/test-DS/root_package"
-    When i make a "POST" request with "1" files
+    When i make a form-data "POST" request
     """
     {
       "document": {
@@ -537,9 +537,9 @@ Feature: Explorer - Add file
     Then the response status should be "OK"
     And the response should have valid uid
 
-  Scenario: Adding file with id
+  Scenario: Adding document with id
     Given I access the resource url "/api/documents/test-DS/root_package"
-    When i make a "POST" request with "1" files
+    When i make a form-data "POST" request
     """
     {
       "document": {
@@ -555,7 +555,7 @@ Feature: Explorer - Add file
 
   Scenario: Add Comment entity without a name attribute with -by-path endpoint
     Given i access the resource url "/api/documents/test-DS/root_package"
-    When i make a "POST" request with "1" files
+    When i make a form-data "POST" request
     """
     {
       "document":
@@ -570,7 +570,7 @@ Feature: Explorer - Add file
 
   Scenario: Add blueprint without a name attribute with -by-path endpoint should fail
     Given i access the resource url "/api/documents/test-DS/root_package"
-    When i make a "POST" request with "1" files
+    When i make a form-data "POST" request
     """
     {
       "document":
@@ -593,7 +593,7 @@ Feature: Explorer - Add file
 
   Scenario: Add package without a name attribute with -by-path endpoint should fail
     Given i access the resource url "/api/documents/test-DS/root_package"
-    When i make a "POST" request with "1" files
+    When i make a form-data "POST" request
     """
     {
       "document":

--- a/src/tests/bdd/document/update_list.feature
+++ b/src/tests/bdd/document/update_list.feature
@@ -82,6 +82,7 @@ Feature: Add document with optional attributes
             "type": "dmss://system/SIMOS/BlueprintAttribute",
             "attributeType": "data-source-name/root_package/KeyboardKey",
             "optional": true,
+            "ensureUID": true,
             "dimensions": "*"
           },
           {
@@ -125,37 +126,7 @@ Feature: Add document with optional attributes
 
   Scenario: add to list that exist
     Given i access the resource url "/api/documents/data-source-name/$workComputerId.letterKeys"
-    When I make a "POST" request with "1" files
-    """
-    {
-      "document":
-       {
-        "name": "T",
-        "type": "data-source-name/root_package/KeyboardKey"
-      }
-    }
-    """
-    Then the response status should be "OK"
-    And the response should contain
-    """
-      {
-        "uid": "workComputerId.letterKeys[0]"
-      }
-    """
-    Given i access the resource url "/api/documents/data-source-name/$workComputerId.letterKeys"
-    When I make a "GET" request
-    Then the response status should be "OK"
-    And the response should contain
-    """
-    [
-     {
-       "name": "T",
-       "type": "data-source-name/root_package/KeyboardKey"
-     }
-    ]
-    """
-    Given i access the resource url "/api/documents/data-source-name/$workComputerId.letterKeys"
-    When I make a "POST" request with "1" files
+    When i make a form-data "POST" request
     """
     {
       "document":
@@ -166,6 +137,66 @@ Feature: Add document with optional attributes
     }
     """
     Then the response status should be "OK"
+    Given i access the resource url "/api/documents/data-source-name/$workComputerId.letterKeys[0]"
+    When I make a "GET" request
+    Then the response status should be "OK"
+    And the response should contain and have an id
+    """
+     {
+       "name": "X",
+       "type": "data-source-name/root_package/KeyboardKey"
+     }
+    """
+
+    Given i access the resource url "/api/documents/data-source-name/$workComputerId.letterKeys"
+    When i make a form-data "POST" request
+    """
+    {
+      "document":
+       {
+        "name": "T",
+        "type": "data-source-name/root_package/KeyboardKey",
+        "_id": "a2039c8d-54ca-4b5c-bd86-b7918410a4c5"
+      }
+    }
+    """
+    Then the response status should be "OK"
+
+    Given i access the resource url "/api/documents/data-source-name/$workComputerId.letterKeys[1]"
+    When I make a "GET" request
+    Then the response status should be "OK"
+    And the response should be
+    """
+     {
+       "name": "T",
+       "type": "data-source-name/root_package/KeyboardKey",
+       "_id": "a2039c8d-54ca-4b5c-bd86-b7918410a4c5"
+     }
+    """
+    Given i access the resource url "/api/documents/data-source-name/$workComputerId.letterKeys(_id=a2039c8d-54ca-4b5c-bd86-b7918410a4c5)"
+    When I make a "GET" request
+    Then the response status should be "OK"
+    And the response should be
+    """
+     {
+       "name": "T",
+       "type": "data-source-name/root_package/KeyboardKey",
+       "_id": "a2039c8d-54ca-4b5c-bd86-b7918410a4c5"
+     }
+    """
+
+    Given i access the resource url "/api/documents/data-source-name/$workComputerId.letterKeys"
+    When i make a form-data "POST" request
+    """
+    {
+      "document":
+       {
+        "name": "C",
+        "type": "data-source-name/root_package/KeyboardKey"
+      }
+    }
+    """
+    Then the response status should be "OK"
     Given i access the resource url "/api/documents/data-source-name/$workComputerId.letterKeys"
     When I make a "GET" request
     Then the response status should be "OK"
@@ -173,11 +204,15 @@ Feature: Add document with optional attributes
     """
     [
      {
+       "name": "X",
+       "type": "data-source-name/root_package/KeyboardKey"
+     },
+     {
        "name": "T",
        "type": "data-source-name/root_package/KeyboardKey"
      },
      {
-       "name": "X",
+       "name": "C",
        "type": "data-source-name/root_package/KeyboardKey"
      }
     ]
@@ -186,7 +221,7 @@ Feature: Add document with optional attributes
 
   Scenario: change list that exist
     Given i access the resource url "/api/documents/data-source-name/$workComputerId.letterKeys"
-    When I make a "POST" request with "1" files
+    When i make a form-data "POST" request
     """
     {
       "document":
@@ -230,7 +265,7 @@ Feature: Add document with optional attributes
     Given i access the resource url "/api/documents/data-source-name/$workComputerId.letterKeys"
     When i make a "GET" request
     Then the response status should be "OK"
-    And the response should be
+    And the response should contain
     """
        [{
         "name": "XXX",

--- a/src/tests/bdd/steps/handle_response.py
+++ b/src/tests/bdd/steps/handle_response.py
@@ -97,6 +97,17 @@ def step_impl_contain(context):
     pretty_print_should_contain_diff(expected, actual)
 
 
+@then("the response should contain and have an id")
+def step_impl_contain_id(context):
+    actual = context.response.json()
+    data = context.text or context.data
+    expected = json.loads(data)
+    if "_id" not in actual.keys():
+        raise ValueError("The response does not have a '_id' key")
+    del actual["_id"]
+    pretty_print_should_contain_diff(expected, actual)
+
+
 @then("the response should have valid uid")
 def step_impl_valid_uid(context):
     response = context.response.json()

--- a/src/tests/unit/common/entity/validators/mock_data/CarRental.blueprint.json
+++ b/src/tests/unit/common/entity/validators/mock_data/CarRental.blueprint.json
@@ -9,7 +9,8 @@
       "name": "cars",
       "type": "system/SIMOS/BlueprintAttribute",
       "dimensions": "*",
-      "attributeType": "RentalCar"
+      "attributeType": "RentalCar",
+      "ensureUID": true
     },
     {
       "name": "customers",

--- a/src/tests/unit/common/entity/validators/test_validate_entity.py
+++ b/src/tests/unit/common/entity/validators/test_validate_entity.py
@@ -293,6 +293,83 @@ class ValidateEntityTestCase(unittest.TestCase):
         assert error.exception.message == "Missing required attribute 'name'"
         assert error.exception.debug == "Location: Entity in key '^.engine.fuelPump'"
 
+    def test_array_with_missing_required_uid(self):
+        test_entity = {
+            "_id": "2",
+            "type": "CarRental",
+            "name": "myCarRental",
+            "cars": [
+                {
+                    "type": "RentalCar",
+                    "name": "Volvo 240",
+                    "plateNumber": "123",
+                    "engine": {
+                        "name": "myEngine",
+                        "description": "Some description",
+                        "fuelPump": {
+                            "name": "fuelPump",
+                            "description": "A standard fuel pump",
+                            "type": "FuelPumpTest",
+                        },
+                        "power": 120,
+                        "type": "EngineTest",
+                    },
+                },
+            ],
+            "customers": [],
+        }
+
+        blueprint = self.mock_document_service.get_blueprint("CarRental")
+
+        with self.assertRaises(ValidationException) as error:
+            validate_entity(
+                test_entity,
+                self.mock_document_service.get_blueprint,
+                blueprint,
+                implementation_mode="exact",
+            )
+        assert (
+            error.exception.message
+            == "The attribute 'cars', requires the entity to have a UUID. Make sure the entity has a valid UUIDv4 at the key '_id'"
+        )
+        assert error.exception.debug == "Location: Entity in key '^.cars.0'"
+
+    def test_array_with_required_uid(self):
+        test_entity = {
+            "_id": "2",
+            "type": "CarRental",
+            "name": "myCarRental",
+            "cars": [
+                {
+                    "_id": "7eaf3777-7c79-4a94-9dc3-1430d2e4625e",
+                    "type": "RentalCar",
+                    "name": "Volvo 240",
+                    "plateNumber": "123",
+                    "engine": {
+                        "name": "myEngine",
+                        "description": "Some description",
+                        "fuelPump": {
+                            "name": "fuelPump",
+                            "description": "A standard fuel pump",
+                            "type": "FuelPumpTest",
+                        },
+                        "power": 120,
+                        "type": "EngineTest",
+                    },
+                },
+            ],
+            "customers": [],
+        }
+
+        blueprint = self.mock_document_service.get_blueprint("CarRental")
+
+        validate_entity(
+            test_entity,
+            self.mock_document_service.get_blueprint,
+            blueprint,
+            implementation_mode="exact",
+        )
+
     def test_array_with_complex_child_getting_array_type_from_parent_node(self):
         test_entity = {
             "_id": "2",


### PR DESCRIPTION
## What does this pull request change?
- New BlueprintAttribute - attribute "ensureUID"
  - This means that any complex attribute, where the attribute definition has this set to "TRUE", MUST have an "_id" key.
  - The "add_document" endpoint will inject this id if missing
- Fix some bdd tests to not use the "post file" fixture when not posting a file (should speed up tests)

## Why is this pull request needed?
- An experiment to get static identification for elements in a list

## Issues related to this change:
closes #785 