### PR TITLE
fix: gunicorn times out on some slow requests

### DIFF
--- a/src/common/utils/timeit.py
+++ b/src/common/utils/timeit.py
@@ -1,0 +1,15 @@
+import time
+from functools import wraps
+
+
+def timeit(func):
+    @wraps(func)
+    def timeit_wrapper(*args, **kwargs):
+        start_time = time.perf_counter()
+        result = func(*args, **kwargs)
+        end_time = time.perf_counter()
+        total_time = end_time - start_time
+        print(f"Function {func.__name__}{args} {kwargs} Took {total_time} seconds")
+        return result
+
+    return timeit_wrapper

--- a/src/features/search/use_cases/search_use_case/search_use_case.py
+++ b/src/features/search/use_cases/search_use_case/search_use_case.py
@@ -3,7 +3,7 @@ from copy import deepcopy
 
 from authentication.models import User
 from common.exceptions import ApplicationException, BadRequestException
-from common.providers.blueprint_provider import BlueprintProvider
+from common.providers.blueprint_provider import default_blueprint_provider
 from common.utils.logging import logger
 from features.search.use_cases.search_use_case.build_complex_search import (
     build_mongo_query,
@@ -35,8 +35,9 @@ def _search(
         )
 
     try:
-        blueprint_provider = BlueprintProvider(user)
-        process_search_data = build_mongo_query(blueprint_provider.get_blueprint_with_extended_attributes, search_data)
+        process_search_data = build_mongo_query(
+            default_blueprint_provider.get_blueprint_with_extended_attributes, search_data
+        )
     except ValueError as ex:
         logger.warning(f"Failed to build mongo query; {ex}")
         raise BadRequestException("Failed to build mongo query") from ex

--- a/src/init.sh
+++ b/src/init.sh
@@ -19,7 +19,7 @@ if [ "$1" = 'api' ]; then
 
   if [ "${ENVIRONMENT:-'local'}" != "local" ]; then
     cat version.txt || true
-    gunicorn app:create_app --workers 4 --disable-redirect-access-to-syslog --worker-class uvicorn.workers.UvicornWorker --bind 0.0.0.0:5000
+    gunicorn app:create_app --workers 4 --disable-redirect-access-to-syslog --worker-class uvicorn.workers.UvicornWorker --bind 0.0.0.0:5000 --graceful-timeout 60 --timeout 60
   else
     python3 /code/src/app.py run
   fi


### PR DESCRIPTION
## What does this pull request change?
- Added timit decorator for performance testing
- Increase default timout of gunicorn
- Search endpoint use the same "default_blueprint_provider"

## Why is this pull request needed?
- When running gunicorn with dm-core-packages example data, the validate request times out


## Issues related to this change:
related to https://github.com/equinor/dm-core-packages/issues/1307
