### PR TITLE
refactor: do not save non references recursively

### DIFF
--- a/src/features/document/use_cases/add_document_use_case.py
+++ b/src/features/document/use_cases/add_document_use_case.py
@@ -129,7 +129,7 @@ def _add_document_to_entity_or_list(
                     recipe_provider=document_service.get_storage_recipes,
                 )
                 list_node.add_child(new_node)
-            document_service.save(parent_node, address.data_source, initial=True)
+            document_service.save(parent_node.find_parent(), address.data_source)
             return {"uid": f"{list_node.node_id}"}
         else:
             new_node = tree_node_from_dict(
@@ -141,7 +141,7 @@ def _add_document_to_entity_or_list(
                 recipe_provider=document_service.get_storage_recipes,
             )
             parent_node.add_child(new_node)
-            document_service.save(parent_node, address.data_source, initial=True)
+            document_service.save(parent_node.find_parent(), address.data_source)
             return {"uid": f"{new_node.node_id}"}
 
     if target.type != SIMOS.PACKAGE.value and target.type != "object":

--- a/src/features/document/use_cases/add_document_use_case.py
+++ b/src/features/document/use_cases/add_document_use_case.py
@@ -129,7 +129,7 @@ def _add_document_to_entity_or_list(
                     recipe_provider=document_service.get_storage_recipes,
                 )
                 list_node.add_child(new_node)
-            document_service.save(parent_node.find_parent(), address.data_source)
+            document_service.save(parent_node, address.data_source)
             return {"uid": f"{list_node.node_id}"}
         else:
             new_node = tree_node_from_dict(
@@ -141,7 +141,7 @@ def _add_document_to_entity_or_list(
                 recipe_provider=document_service.get_storage_recipes,
             )
             parent_node.add_child(new_node)
-            document_service.save(parent_node.find_parent(), address.data_source)
+            document_service.save(parent_node, address.data_source)
             return {"uid": f"{new_node.node_id}"}
 
     if target.type != SIMOS.PACKAGE.value and target.type != "object":

--- a/src/features/document/use_cases/update_document_use_case.py
+++ b/src/features/document/use_cases/update_document_use_case.py
@@ -62,7 +62,7 @@ def _update_document(
     if files:
         merge_entity_and_files(node, files)
 
-    document_service.save(node.find_parent(), address.data_source)
+    document_service.save(node, address.data_source)
     logger.info(f"Updated entity '{address}'")
     return {"data": tree_node_to_dict(node)}
 

--- a/src/features/document/use_cases/update_document_use_case.py
+++ b/src/features/document/use_cases/update_document_use_case.py
@@ -62,7 +62,7 @@ def _update_document(
     if files:
         merge_entity_and_files(node, files)
 
-    document_service.save(node, address.data_source, initial=True)
+    document_service.save(node.find_parent(), address.data_source)
     logger.info(f"Updated entity '{address}'")
     return {"data": tree_node_to_dict(node)}
 

--- a/src/services/document_service/document_service.py
+++ b/src/services/document_service/document_service.py
@@ -107,7 +107,6 @@ class DocumentService:
         repository=None,
         path="",
         combined_document_meta: dict | None = None,
-        initial: bool = False,
     ) -> dict:
         """
         Saves a Node.
@@ -122,19 +121,8 @@ class DocumentService:
                         nodeC
             Here, combined_document_meta is the combined _meta_ information of node A, B and C.
             (this meta info can be found with _collect_entity_meta_by_path() util function).-
-        initial:  When true, the function will move up the tree until it finds a storage non-contained node, and start saving from there.
-            This allows us to call "save()" on any node, without having to find the "root node" (storage non-contained)
-
         """
-        if initial and node.storage_contained:
-            self.save(
-                node.parent,
-                data_source_id,
-                repository,
-                path,
-                combined_document_meta,
-                initial,
-            )
+
         if not node.entity:
             return {}
         # If not passed a custom repository to save into, use the DocumentService's storage

--- a/src/services/document_service/document_service.py
+++ b/src/services/document_service/document_service.py
@@ -146,15 +146,6 @@ class DocumentService:
         if node.type == SIMOS.PACKAGE.value:
             self.raise_for_duplicate_name(node, data_source_id)
 
-        for child in node.children:
-            if child.is_array():
-                [
-                    self.save(x, data_source_id, repository, path, combined_document_meta)
-                    for x in child.children
-                    if x.type != SIMOS.REFERENCE.value
-                ]
-            elif child.type != SIMOS.REFERENCE.value:
-                self.save(child, data_source_id, repository, path, combined_document_meta)
         if node.type == SIMOS.BLOB.value:
             node.entity = self.save_blob_data(node, repository)
 

--- a/src/services/document_service/document_service.py
+++ b/src/services/document_service/document_service.py
@@ -123,6 +123,12 @@ class DocumentService:
             (this meta info can be found with _collect_entity_meta_by_path() util function).-
         """
 
+        # Move up the tree until it finds a storage non-contained node, and start saving from there.
+        # This allows us to call "save()" on storage contained node,
+        # without having to find the "root node" (storage non-contained).
+        if node.storage_contained:
+            node = node.find_parent()
+
         if not node.entity:
             return {}
         # If not passed a custom repository to save into, use the DocumentService's storage

--- a/src/tests/unit/services/document_service/test_save.py
+++ b/src/tests/unit/services/document_service/test_save.py
@@ -152,7 +152,7 @@ class DocumentServiceTestCase(unittest.TestCase):
                 "type": "dmss://system/SIMOS/Entity",
             }
         )
-        self.mock_document_service.save(contained_node.find_parent(), "testing")
+        self.mock_document_service.save(contained_node, "testing")
 
         assert doc_storage["1"]["containedPersonInfo"]["description"] == "TEST_MODIFY"
 

--- a/src/tests/unit/services/document_service/test_save.py
+++ b/src/tests/unit/services/document_service/test_save.py
@@ -152,7 +152,7 @@ class DocumentServiceTestCase(unittest.TestCase):
                 "type": "dmss://system/SIMOS/Entity",
             }
         )
-        self.mock_document_service.save(contained_node, "testing", initial=True)
+        self.mock_document_service.save(contained_node.find_parent(), "testing")
 
         assert doc_storage["1"]["containedPersonInfo"]["description"] == "TEST_MODIFY"
 


### PR DESCRIPTION
## What does this pull request change?

* Upgrade to a newer `pymongo` version seems to give some performance gain
* Remove saving recursively in the save method (maybe add this later if we need it)
* Remove the `initial` flag from the save method, and let the save method find the parent if any contained node is passed in

> NOTES: needs mongo 3.6 or later (SIMPOS USE 3.4)

Performance before (see tests):

<img width="372" alt="image" src="https://github.com/equinor/data-modelling-storage-service/assets/1190419/f62337e2-a5c4-4869-8f28-03a1d52b3a14">

Performance after (see tests):

<img width="362" alt="image" src="https://github.com/equinor/data-modelling-storage-service/assets/1190419/0e88f02b-4c08-459b-a2b7-fe30f45c918a">


## Why is this pull request needed?

## Issues related to this change:
