### PR TITLE
feat: addDocument() return full address to the new entity

### DIFF
--- a/src/common/tree/tree_node.py
+++ b/src/common/tree/tree_node.py
@@ -97,7 +97,7 @@ class NodeBase:
             return self.uid
         if self.parent.is_array():
             if self.attribute.ensure_uid:
-                return f'{self.parent.node_id}(_id="{self.uid}")'
+                return f"{self.parent.node_id}(_id={self.uid})"
 
             return f"{self.parent.node_id}[{self.key}]"
         return ".".join((self.parent.node_id, self.key))
@@ -218,10 +218,10 @@ class NodeBase:
             return True
 
     def should_have_id(self):
-        if self.attribute.ensure_uid:
-            return True
         if isinstance(self, ListNode):
             return False
+        if self.attribute.ensure_uid:
+            return True
         if self.type == SIMOS.REFERENCE.value:
             return False
         if self.storage_contained and self.contained:

--- a/src/features/entity/use_cases/validate_existing_entity_use_case.py
+++ b/src/features/entity/use_cases/validate_existing_entity_use_case.py
@@ -1,13 +1,16 @@
 from authentication.models import User
 from common.address import Address
 from common.entity.validators import validate_entity_against_self
+from common.exceptions import NotFoundException, ValidationException
 from common.tree.tree_node import Node
 from services.document_service.document_service import DocumentService
 
 
 def validate_existing_entity_use_case(address: str, user: User) -> str:
     document_service = DocumentService(user=user)
-    document_as_node: Node = document_service.get_document(Address.from_absolute(address), depth=500)
-    # TODO resolving fails in above line. for some reason the address dmss://DemoDataSource/plugins/DemoDataSource/plugins/grid/blueprints/Dashboard
+    try:
+        document_as_node: Node = document_service.get_document(Address.from_absolute(address), depth=500)
+    except NotFoundException as ex:
+        raise ValidationException(message=ex.message, debug=ex.debug) from ex
     validate_entity_against_self(document_as_node.entity, document_service.get_blueprint)
     return "OK"

--- a/src/services/document_service/document_service.py
+++ b/src/services/document_service/document_service.py
@@ -6,7 +6,6 @@ from uuid import uuid4
 from authentication.models import User
 from common.address import Address
 from common.entity.is_reference import is_reference
-from common.entity.validators import validate_entity_against_self
 from common.exceptions import (
     ApplicationException,
     BadRequestException,
@@ -26,7 +25,6 @@ from common.providers.storage_recipe_provider import (
 from common.tree.tree_node import ListNode, Node
 from common.tree.tree_node_serializer import (
     tree_node_from_dict,
-    tree_node_to_dict,
     tree_node_to_ref_dict,
 )
 from common.utils.logging import logger
@@ -154,7 +152,6 @@ class DocumentService:
                 ref_dict["__path__"] = path
                 ref_dict["__combined_document_meta__"] = combined_document_meta
             parent_uid = node.parent.node_id if node.parent else None
-            validate_entity_against_self(tree_node_to_dict(node), self.get_blueprint)
             repository.update(
                 ref_dict,
                 node.get_context_storage_attribute(),

--- a/src/tests/bdd/document/add_contained.feature
+++ b/src/tests/bdd/document/add_contained.feature
@@ -89,5 +89,5 @@ Feature: Explorer - Add contained node
     Then the response status should be "OK"
     And the response should contain
     """
-    {"uid": "1.meAgain[1].meAgain[0]"}
+    {"uid": "dmss://entities/$1.meAgain[1].meAgain[0]"}
     """

--- a/src/tests/bdd/document/add_document.feature
+++ b/src/tests/bdd/document/add_document.feature
@@ -297,7 +297,6 @@ Feature: Add document with document_service
     }
     """
 
-
   Scenario: Add document to root package using path as reference
     Given i access the resource url "/api/documents/data-source-name/root_package"
     When i make a form-data "POST" request
@@ -326,7 +325,6 @@ Feature: Add document with document_service
       }
     """
 
-
   Scenario: Add document to root package using id as reference
     Given i access the resource url "/api/documents/data-source-name/$100"
     When i make a form-data "POST" request
@@ -354,7 +352,6 @@ Feature: Add document with document_service
         "phases": []
       }
     """
-
 
   Scenario: Add root package
     Given i access the resource url "/api/documents/data-source-name"
@@ -388,7 +385,7 @@ Feature: Add document with document_service
     Then the response status should be "OK"
     And the response should contain
     """
-    {"uid": "11.phases[1]"}
+    {"uid": "dmss://data-source-name/$11.phases[1]"}
     """
     Given i access the resource url "/api/documents/data-source-name/root_package/EntityPackage/operation1?depth=3"
     When I make a "GET" request
@@ -453,7 +450,7 @@ Feature: Add document with document_service
     And the response should contain
     """
       {
-        "uid": "11.phases[0].containedResults[0]"
+        "uid": "dmss://data-source-name/$11.phases[0].containedResults[0]"
       }
     """
 #     todo update document add use case such that id contains bracket notation for lists: 11.phases[0].containedResults[0]

--- a/src/tests/bdd/document/add_documentwith_optional_attributes.feature
+++ b/src/tests/bdd/document/add_documentwith_optional_attributes.feature
@@ -170,7 +170,7 @@ Feature: Add document with optional attributes
     And the response should contain
     """
       {
-        "uid": "workComputerId.keyboard"
+        "uid": "dmss://data-source-name/$workComputerId.keyboard"
       }
     """
     Given i access the resource url "/api/documents/data-source-name/$workComputerId.keyboard"
@@ -201,7 +201,7 @@ Feature: Add document with optional attributes
     And the response should contain
     """
       {
-        "uid": "workComputerId.letterKeys[0]"
+        "uid": "dmss://data-source-name/$workComputerId.letterKeys[0]"
       }
     """
     Given i access the resource url "/api/documents/data-source-name/$workComputerId.letterKeys"
@@ -233,7 +233,7 @@ Feature: Add document with optional attributes
     And the response should contain
     """
       {
-        "uid": "workComputerId.numberKeys"
+        "uid": "dmss://data-source-name/$workComputerId.numberKeys[3]"
       }
     """
     Given i access the resource url "/api/documents/data-source-name/$workComputerId.numberKeys[0]"
@@ -273,6 +273,6 @@ Feature: Add document with optional attributes
     And the response should contain
     """
       {
-        "uid": "workComputerId.monitors"
+        "uid": "dmss://data-source-name/$workComputerId.monitors"
       }
     """

--- a/src/tests/bdd/document/add_file.feature
+++ b/src/tests/bdd/document/add_file.feature
@@ -535,7 +535,6 @@ Feature: Explorer - Add file
     }
     """
     Then the response status should be "OK"
-    And the response should have valid uid
 
   Scenario: Adding document with id
     Given I access the resource url "/api/documents/test-DS/root_package"
@@ -551,7 +550,10 @@ Feature: Explorer - Add file
     }
     """
     Then the response status should be "OK"
-    And the response should have valid uid
+    And the response should be
+    """
+    {"uid": "dmss://test-DS/$2283c9b0-d509-46c9-a153-94c79f4d7b7b"}
+    """
 
   Scenario: Add Comment entity without a name attribute with -by-path endpoint
     Given i access the resource url "/api/documents/test-DS/root_package"

--- a/src/tests/bdd/steps/handle_response.py
+++ b/src/tests/bdd/steps/handle_response.py
@@ -1,6 +1,5 @@
 import json
 import pprint
-import uuid
 
 from behave import then
 from deepdiff import DeepDiff
@@ -106,12 +105,6 @@ def step_impl_contain_id(context):
         raise ValueError("The response does not have a '_id' key")
     del actual["_id"]
     pretty_print_should_contain_diff(expected, actual)
-
-
-@then("the response should have valid uid")
-def step_impl_valid_uid(context):
-    response = context.response.json()
-    uuid.UUID(str(response["uid"]))
 
 
 @then("the array at {dot_path} should be of length {length}")


### PR DESCRIPTION
## What does this pull request change?
- "addDocument()" now return the full address to the new entity
- Make sure all branches of the "addDocument" use-case sets UID's
- Failing to get a document during validation should raise ValidationError, not 404.

## Issues related to this change:
needed for https://github.com/equinor/dm-core-packages/issues/1308