### PR TITLE
perf: cache on get_data_source

### DIFF
--- a/src/common/utils/package_import.py
+++ b/src/common/utils/package_import.py
@@ -13,7 +13,7 @@ from common.utils.logging import logger
 from common.utils.string_helpers import url_safe_name
 from enums import REFERENCE_TYPES, SIMOS
 from storage.data_source_interface import DataSource
-from storage.internal.data_source_repository import get_data_source
+from storage.internal.get_data_source_cached import get_data_source_cached
 
 
 def _add_documents(path, documents, data_source) -> list[dict]:
@@ -41,7 +41,7 @@ def _add_documents(path, documents, data_source) -> list[dict]:
 
 
 def import_package(path: str, user: User, data_source_name: str, is_root: bool = False) -> dict:
-    data_source: DataSource = get_data_source(data_source_id=data_source_name, user=user, get_blueprint=lambda: None)
+    data_source: DataSource = get_data_source_cached(data_source_id=data_source_name, user=user)
     package = {
         "name": os.path.basename(path),
         "type": SIMOS.PACKAGE.value,
@@ -50,7 +50,7 @@ def import_package(path: str, user: User, data_source_name: str, is_root: bool =
     try:
         resolved_address: ResolvedAddress = resolve_address(
             Address(package["name"], data_source.name),
-            lambda data_source_name: get_data_source(data_source_name, user, get_blueprint=lambda: None),
+            lambda data_source_name: get_data_source_cached(data_source_name, user),
         )
         if resolved_address.entity:
             raise BadRequestException(

--- a/src/features/access_control/access_control_feature.py
+++ b/src/features/access_control/access_control_feature.py
@@ -7,10 +7,7 @@ from common.address import Address
 from common.providers.storage_recipe_provider import storage_recipe_provider
 from common.responses import create_response, responses
 from services.document_service.document_service import DocumentService
-from storage.internal.data_source_repository import (
-    DataSourceRepository,
-    get_data_source,
-)
+from storage.internal.data_source_repository import DataSourceRepository
 
 from .use_cases.get_acl_use_case import get_acl_use_case
 from .use_cases.set_acl_use_case import set_acl_use_case
@@ -44,7 +41,6 @@ def set_acl(
     """
     address_obj = Address.from_absolute(address)
     document_service = DocumentService(
-        repository_provider=get_data_source,
         user=user,
         recipe_provider=storage_recipe_provider,
     )

--- a/src/features/attribute/use_cases/get_attribute_use_case.py
+++ b/src/features/attribute/use_cases/get_attribute_use_case.py
@@ -3,17 +3,15 @@ from common.address import Address
 from common.tree.tree_node import Node
 from enums import SIMOS
 from services.document_service.document_service import DocumentService
-from storage.internal.data_source_repository import get_data_source
 
 
 def get_attribute_use_case(
     address: str,
     resolve: bool,
     user: User,
-    repository_provider=get_data_source,
 ):
     """Get attribute by reference."""
-    document_service = DocumentService(repository_provider=repository_provider, user=user)
+    document_service = DocumentService(user=user)
     node: Node = document_service.get_document(Address.from_absolute(address))
     if resolve and node.attribute.attribute_type == SIMOS.REFERENCE.value:
         reference_address = Address.from_relative(node.entity["address"], None, node.get_data_source())

--- a/src/features/blob/use_cases/get_blob_use_case.py
+++ b/src/features/blob/use_cases/get_blob_use_case.py
@@ -1,9 +1,9 @@
 from authentication.models import User
-from storage.internal.data_source_repository import get_data_source
+from storage.internal.get_data_source_cached import get_data_source_cached
 
 
 def get_blob_use_case(user: User, data_source_id: str, blob_id: str):
-    data_source = get_data_source(data_source_id, user)
+    data_source = get_data_source_cached(data_source_id, user)
     if blob_id.startswith("$"):
         blob_id = blob_id[1:]
     blob = data_source.get_blob(blob_id)

--- a/src/features/blob/use_cases/upload_blob_use_case.py
+++ b/src/features/blob/use_cases/upload_blob_use_case.py
@@ -1,10 +1,10 @@
 from fastapi import UploadFile
 
 from authentication.models import User
-from storage.internal.data_source_repository import get_data_source
+from storage.internal.get_data_source_cached import get_data_source_cached
 
 
 def upload_blob_use_case(user: User, data_source_id: str, blob_id: str, file: UploadFile):
-    data_source = get_data_source(data_source_id, user)
+    data_source = get_data_source_cached(data_source_id, user)
     data_source.update_blob(blob_id, file.filename, file.content_type, file.file)
     return "OK"

--- a/src/features/blueprint/use_cases/resolve_blueprint_use_case.py
+++ b/src/features/blueprint/use_cases/resolve_blueprint_use_case.py
@@ -6,11 +6,11 @@ from common.exceptions import NotFoundException, ValidationException
 from common.providers.address_resolver.address_resolver import resolve_address
 from enums import SIMOS
 from storage.data_source_class import DataSource
-from storage.internal.data_source_repository import get_data_source
+from storage.internal.get_data_source_cached import get_data_source_cached
 
 
 def find_package_with_document(data_source: str, document_id: str, user) -> dict:
-    repository = get_data_source(data_source, user)
+    repository = get_data_source_cached(data_source, user)
     packages: list[dict] = repository.find(
         {"type": SIMOS.PACKAGE.value, "content": {"$elemMatch": {"address": document_id}}}
     )
@@ -20,11 +20,11 @@ def find_package_with_document(data_source: str, document_id: str, user) -> dict
 
 
 def resolve_references(values: list, data_source_id: str, user: User) -> list:
-    data_source: DataSource = get_data_source(data_source_id, user)
+    data_source: DataSource = get_data_source_cached(data_source_id, user)
     return [
         resolve_address(
             Address.from_relative(value["address"], None, data_source.name),
-            lambda data_source_name: get_data_source(data_source_name, user),
+            lambda data_source_name: get_data_source_cached(data_source_name, user),
         ).entity
         for value in values
     ]

--- a/src/features/document/document_feature.py
+++ b/src/features/document/document_feature.py
@@ -10,7 +10,6 @@ from common.address import Address
 from common.providers.storage_recipe_provider import storage_recipe_provider
 from common.responses import create_response, responses
 from services.document_service.document_service import DocumentService
-from storage.internal.data_source_repository import get_data_source
 
 from .use_cases.add_document_use_case import add_document_use_case
 from .use_cases.add_raw_use_case import add_raw_use_case
@@ -83,7 +82,6 @@ def update(
     """
 
     document_service = DocumentService(
-        repository_provider=get_data_source,
         user=user,
         recipe_provider=storage_recipe_provider,
     )
@@ -133,7 +131,6 @@ def add_document(
     #     TODO decide if we should support adding an empty list. That is currently not supported.
 
     document_service = DocumentService(
-        repository_provider=get_data_source,
         user=user,
         recipe_provider=storage_recipe_provider,
     )
@@ -202,5 +199,5 @@ def check_existence(address: str, user: User = Depends(auth_w_jwt_or_pat)):
     Returns:
     - bool: 'true' if the address points to an existing document, else 'false'.
     """
-    document_service = DocumentService(repository_provider=get_data_source, user=user)
+    document_service = DocumentService(user=user)
     return check_existence_use_case(address=Address.from_absolute(address), document_service=document_service)

--- a/src/features/document/use_cases/add_raw_use_case.py
+++ b/src/features/document/use_cases/add_raw_use_case.py
@@ -3,13 +3,13 @@ from uuid import uuid4
 from authentication.models import User
 from enums import SIMOS
 from services.document_service.document_service import DocumentService
-from storage.internal.data_source_repository import get_data_source
+from storage.internal.get_data_source_cached import get_data_source_cached
 
 
 def add_raw_use_case(user: User, document: dict, data_source_id: str):
     new_node_id = document.get("_id", str(uuid4()))
     document["_id"] = new_node_id
-    document_repository = get_data_source(data_source_id, user)
+    document_repository = get_data_source_cached(data_source_id, user)
     document_repository.update(document)
     if document["type"] == SIMOS.BLUEPRINT.value:
         DocumentService(user=user).invalidate_cache()

--- a/src/features/document/use_cases/get_document_use_case.py
+++ b/src/features/document/use_cases/get_document_use_case.py
@@ -3,14 +3,14 @@ from pydantic import conint
 from authentication.models import User
 from common.address import Address
 from services.document_service.document_service import DocumentService
-from storage.internal.data_source_repository import get_data_source
+from storage.internal.get_data_source_cached import get_data_source_cached
 
 
 def get_document_use_case(
     user: User,
     address: str,
     depth: conint(gt=-1, lt=1000),  # type: ignore
-    repository_provider=get_data_source,
+    repository_provider=get_data_source_cached,
 ):
     """Get document by reference."""
     document_service = DocumentService(repository_provider=repository_provider, user=user)

--- a/src/features/document/use_cases/remove_use_case.py
+++ b/src/features/document/use_cases/remove_use_case.py
@@ -1,11 +1,10 @@
 from authentication.models import User
 from common.address import Address
 from services.document_service.document_service import DocumentService
-from storage.internal.data_source_repository import get_data_source
 
 
-def remove_use_case(user: User, address: str, repository_provider=get_data_source) -> str:
-    document_service = DocumentService(repository_provider=repository_provider, user=user)
+def remove_use_case(user: User, address: str) -> str:
+    document_service = DocumentService(user=user)
     document_service.remove(Address.from_absolute(address))
     document_service.invalidate_cache()
     return "OK"

--- a/src/features/export/use_cases/export_meta_use_case.py
+++ b/src/features/export/use_cases/export_meta_use_case.py
@@ -7,7 +7,7 @@ from common.providers.address_resolver.address_resolver import (
     resolve_address,
 )
 from storage.data_source_class import DataSource
-from storage.internal.data_source_repository import get_data_source
+from storage.internal.get_data_source_cached import get_data_source_cached
 
 
 def concat_meta_data(meta: dict | None, new_meta: dict | None) -> dict:
@@ -31,7 +31,7 @@ def resolve_references(values: list, data_source: DataSource, user: User) -> lis
     return [
         resolve_address(
             Address.from_relative(value["address"], None, data_source.name),
-            lambda data_source_name: get_data_source(data_source_name, user),
+            lambda data_source_name: get_data_source_cached(data_source_name, user),
         ).entity
         for value in values
     ]
@@ -86,7 +86,7 @@ def export_meta_use_case(user: User, path_address: str) -> dict:
     """
     address_object = Address.from_absolute(path_address)
 
-    data_source = get_data_source(address_object.data_source, user)
+    data_source = get_data_source_cached(address_object.data_source, user)
     if not address_object.path:
         raise NotFoundException(f"Could not find a root package from reference '{path_address}'")
     path_items = path_to_path_items(address_object.path)
@@ -97,7 +97,7 @@ def export_meta_use_case(user: User, path_address: str) -> dict:
 
     root_package: dict = resolve_address(
         Address(root_package_name, address_object.data_source),
-        lambda data_source_name: get_data_source(data_source_name, user),
+        lambda data_source_name: get_data_source_cached(data_source_name, user),
     ).entity
 
     path_without_root_package: list[str] = address_object.path.strip("/").split("/")[1:]

--- a/src/features/file/use_cases/add_file_use_case.py
+++ b/src/features/file/use_cases/add_file_use_case.py
@@ -5,12 +5,12 @@ from fastapi import UploadFile
 
 from authentication.models import User
 from enums import REFERENCE_TYPES, SIMOS
-from storage.internal.data_source_repository import get_data_source
+from storage.internal.get_data_source_cached import get_data_source_cached
 
 
 async def add_file_use_case(data_source_id: str, file_id: str, file: UploadFile, user: User):
     blob_id = str(uuid4())
-    data_source = get_data_source(data_source_id, user)
+    data_source = get_data_source_cached(data_source_id, user)
     data_source.update_blob(blob_id, file.filename, file.content_type, file.file)
     await file.seek(0)
     content = await file.read()

--- a/src/features/lookup_table/use_cases/create_lookup_table.py
+++ b/src/features/lookup_table/use_cases/create_lookup_table.py
@@ -6,7 +6,6 @@ from domain_classes.storage_recipe import StorageAttribute, StorageRecipe
 from domain_classes.ui_recipe import Recipe
 from enums import SIMOS, StorageDataTypes
 from services.document_service.document_service import DocumentService
-from storage.internal.data_source_repository import get_data_source
 from storage.internal.lookup_tables import get_lookup, insert_lookup
 
 
@@ -14,14 +13,13 @@ def create_lookup_table_use_case(
     recipe_package_paths: list[str],
     name: str,
     user: User,
-    repository_provider=get_data_source,
 ) -> None:
     """
     Create lookup table. If the lookup table already exist, the lookup table will be updated.
     """
     assert_user_has_access(AccessControlList.default(), AccessLevel.WRITE, user)
 
-    document_service = DocumentService(repository_provider=repository_provider, user=user)
+    document_service = DocumentService(user=user)
     lookup_class_attributes = list(Lookup.__annotations__.keys())
     combined_lookup = Lookup().dict()
     for path in recipe_package_paths:

--- a/src/features/meta/use_cases/get_meta_use_case.py
+++ b/src/features/meta/use_cases/get_meta_use_case.py
@@ -1,9 +1,9 @@
 from authentication.models import User
-from storage.internal.data_source_repository import get_data_source
+from storage.internal.get_data_source_cached import get_data_source_cached
 
 
 def get_meta_use_case(user: User, data_source_id: str, document_id: str):
-    data_source = get_data_source(data_source_id, user)
+    data_source = get_data_source_cached(data_source_id, user)
     if document_id.startswith("$"):
         document_id = document_id[1:]
     lookup = data_source.get_lookup(document_id)

--- a/src/features/search/use_cases/search_use_case/search_use_case.py
+++ b/src/features/search/use_cases/search_use_case/search_use_case.py
@@ -13,10 +13,8 @@ from features.search.use_cases.search_use_case.sort_dtos_by_attribute import (
 )
 from restful.request_types.shared import DataSourceList
 from storage.data_source_class import DataSource
-from storage.internal.data_source_repository import (
-    DataSourceRepository,
-    get_data_source,
-)
+from storage.internal.data_source_repository import DataSourceRepository
+from storage.internal.get_data_source_cached import get_data_source_cached
 from storage.repositories.mongo import MongoDBClient
 
 
@@ -55,7 +53,7 @@ class SearchRequest(DataSourceList):
     dotted_attribute_path: str
 
 
-def search_use_case(user: User, request: SearchRequest, get_data_source=get_data_source) -> dict:
+def search_use_case(user: User, request: SearchRequest) -> dict:
     all_data_source_ids = [ds["id"] for ds in DataSourceRepository(user).list()]
     search_data_sources = all_data_source_ids
 
@@ -73,7 +71,7 @@ def search_use_case(user: User, request: SearchRequest, get_data_source=get_data
             search_data=deepcopy(request.data),
             dotted_attribute_path=request.dotted_attribute_path,
             user=user,
-            get_data_source=get_data_source,
+            get_data_source=get_data_source_cached,
         )
         search_results.update(results)
     return search_results

--- a/src/services/document_service/document_service.py
+++ b/src/services/document_service/document_service.py
@@ -37,7 +37,7 @@ from services.document_service.delete_documents import (
     delete_document,
 )
 from storage.data_source_class import DataSource
-from storage.internal.data_source_repository import get_data_source
+from storage.internal.get_data_source_cached import get_data_source_cached
 from storage.repositories.zip.zip_file_client import ZipFileClient
 
 pretty_printer = pprint.PrettyPrinter()
@@ -46,7 +46,7 @@ pretty_printer = pprint.PrettyPrinter()
 class DocumentService:
     def __init__(
         self,
-        repository_provider=get_data_source,
+        repository_provider=get_data_source_cached,
         blueprint_provider=None,
         user=User.default(),
         context: str | None = None,
@@ -57,9 +57,7 @@ class DocumentService:
         self.repository_provider = repository_provider
         self.user = user
         self.context = context
-        self.get_data_source = lambda data_source_id: self.repository_provider(
-            data_source_id, self.user, self.get_blueprint
-        )
+        self.get_data_source = lambda data_source_id: self.repository_provider(data_source_id, self.user)
 
     def get_blueprint(self, type: str) -> Blueprint:
         return self._blueprint_provider.get_blueprint_with_extended_attributes(type)

--- a/src/storage/internal/data_source_repository.py
+++ b/src/storage/internal/data_source_repository.py
@@ -99,5 +99,5 @@ class DataSourceRepository:
         data_source_collection.update_one(filter={"_id": data_source.name}, update={"$set": {"acl": acl.to_dict()}})
 
 
-def get_data_source(data_source_id: str, user: User, get_blueprint=None) -> DataSource:
+def get_data_source(data_source_id: str, user: User, get_blueprint) -> DataSource:
     return DataSourceRepository(user, get_blueprint).get(data_source_id)

--- a/src/storage/internal/get_data_source_cached.py
+++ b/src/storage/internal/get_data_source_cached.py
@@ -1,0 +1,19 @@
+from functools import lru_cache
+
+from authentication.models import User
+from common.providers.blueprint_provider import default_blueprint_provider
+from storage.data_source_interface import DataSource
+from storage.internal.data_source_repository import DataSourceRepository
+
+
+# This is needed to be able to cache 'get_data_source', as 'get_blueprint' is not hashable
+class GetDataSourceCached:
+    def __init__(self, blueprint_provider):
+        self.get_blueprint = blueprint_provider
+
+    @lru_cache(maxsize=128)  # noqa B019
+    def get(self, data_source_id: str, user: User) -> DataSource:
+        return DataSourceRepository(user, self.get_blueprint).get(data_source_id)
+
+
+get_data_source_cached = GetDataSourceCached(default_blueprint_provider).get

--- a/src/tests/bdd/steps/blobs.py
+++ b/src/tests/bdd/steps/blobs.py
@@ -3,12 +3,12 @@ import mimetypes
 from behave import given
 
 from storage.data_source_class import DataSource
-from storage.internal.data_source_repository import get_data_source
+from storage.internal.get_data_source_cached import get_data_source_cached
 
 
 @given('there exists a blob with id "{id}" in data source "{data_source}" loaded from "{path}"')
 def step_impl(context, id, data_source, path):
-    data_source: DataSource = get_data_source(data_source_id=data_source, user=context.user)
+    data_source: DataSource = get_data_source_cached(data_source_id=data_source, user=context.user)
     try:
         with open(path, "rb") as blob_file:
             guess = mimetypes.guess_type(blob_file.name)

--- a/src/tests/bdd/steps/data_source.py
+++ b/src/tests/bdd/steps/data_source.py
@@ -1,9 +1,11 @@
 from behave import given
 
+from common.providers.blueprint_provider import default_blueprint_provider
 from common.utils.encryption import encrypt
 from restful.request_types.create_data_source import DataSourceRequest
 from services.database import data_source_collection
 from storage.internal.data_source_repository import DataSourceRepository
+from storage.internal.get_data_source_cached import get_data_source_cached
 
 
 @given("there are data sources")
@@ -11,6 +13,9 @@ def create_data_sources(context):
     for row in context.table:
         document = {"_id": row["name"], "name": row["name"]}
         data_source_collection.insert_one(document)
+
+    get_data_source_cached.cache_clear()
+    default_blueprint_provider.get_data_source_cached.cache_clear()
 
 
 @given("there are repositories in the data sources")
@@ -32,6 +37,8 @@ def create_repositories(context):
             {"_id": row["data-source"]},
             {"$set": {f"repositories.{row['name']}": document}},
         )
+    get_data_source_cached.cache_clear()
+    default_blueprint_provider.get_data_source_cached.cache_clear()
 
 
 @given("there are basic data sources with repositories")
@@ -57,3 +64,6 @@ def create_basic_repositories(context):
         }
     document["repositories"] = repos
     DataSourceRepository(context.user).create(document["name"], DataSourceRequest(**document))
+
+    get_data_source_cached.cache_clear()
+    default_blueprint_provider.get_data_source_cached.cache_clear()

--- a/src/tests/bdd/steps/domain.py
+++ b/src/tests/bdd/steps/domain.py
@@ -7,15 +7,10 @@ from common.providers.storage_recipe_provider import storage_recipe_provider
 from common.tree.tree_node import ListNode, Node
 from domain_classes.blueprint_attribute import BlueprintAttribute
 from enums import SIMOS, BuiltinDataTypes
-from features.entity.use_cases.instantiate_entity_use_case.create_entity import (
-    CreateEntity,
-)
+from features.entity.use_cases.instantiate_entity_use_case.create_entity import CreateEntity
 from services.database import data_source_collection
 from services.document_service.document_service import DocumentService
-from storage.internal.data_source_repository import (
-    DataSourceRepository,
-    get_data_source,
-)
+from storage.internal.data_source_repository import DataSourceRepository
 
 
 def generate_tree_from_rows(node: Node, rows, document_service):
@@ -96,7 +91,7 @@ def generate_tree(data_source_id: str, table, document_service):
 @given('there are documents for the data source "{data_source_id}" in collection "{collection}"')
 def step_impl_documents(context, data_source_id: str, collection: str):
     context.documents = {}
-    document_service = DocumentService(get_data_source, user=context.user)
+    document_service = DocumentService(user=context.user)
     tree: Node = generate_tree(data_source_id, context.table, document_service)
     tree.show_tree()
     for node in tree.traverse():
@@ -106,7 +101,7 @@ def step_impl_documents(context, data_source_id: str, collection: str):
 
 @given('AccessControlList for document "{document_id}" in data-source "{data_source}" is')
 def step_ACL_for_docs_in_DS_is(context, document_id, data_source):
-    document_service = DocumentService(get_data_source, user=context.user)
+    document_service = DocumentService(user=context.user)
     acl = AccessControlList(**json.loads(context.text))
     document_service.repository_provider(data_source, context.user).update_access_control(document_id, acl)
 

--- a/src/tests/bdd/steps/schemas.py
+++ b/src/tests/bdd/steps/schemas.py
@@ -6,21 +6,17 @@ from authentication.models import User
 from common.utils.logging import logger
 from common.utils.package_import import import_package
 from config import config
-from features.lookup_table.use_cases.create_lookup_table import (
-    create_lookup_table_use_case,
-)
+from features.lookup_table.use_cases.create_lookup_table import create_lookup_table_use_case
 from restful.request_types.create_data_source import DataSourceRequest
-from storage.internal.data_source_repository import (
-    DataSourceRepository,
-    get_data_source,
-)
+from storage.internal.data_source_repository import DataSourceRepository
+from storage.internal.get_data_source_cached import get_data_source_cached
 
 
 @given('there exist document with id "{uid}" in data source "{data_source_id}"')
 def step_impl_2(context, uid: str, data_source_id: str):
     document: dict = json.loads(context.text)
     document["_id"] = uid
-    document_repository = get_data_source(data_source_id, context.user)
+    document_repository = get_data_source_cached(data_source_id, context.user)
     document_repository.update(document)
 
 


### PR DESCRIPTION
## What does this pull request change?
- DataSource caching has not been working for a while. This PR fixes this

- Reduces time for simple single document get in CosmosDB from ~1000ms to ~100ms. This is because on every request the MongoClient has to download meta data from the server before it can execute the request.


