### PR TITLE
perf: keep fetched blueprints. Custom blueprint 'get_document'

### DIFF
--- a/src/common/entity/validators.py
+++ b/src/common/entity/validators.py
@@ -1,8 +1,7 @@
 from collections.abc import Callable
 from typing import Any, Literal
 
-from common.exceptions import ApplicationException, ValidationException
-from common.utils.logging import logger
+from common.exceptions import ValidationException
 from domain_classes.blueprint import Blueprint
 from domain_classes.blueprint_attribute import BlueprintAttribute
 from enums import SIMOS, BuiltinDataTypes
@@ -27,17 +26,13 @@ def is_blueprint_instance_of(
                 the blueprint extends a blueprint that fulfills one of these three rules
             Otherwise it returns false.
     """
-    try:
-        if minimum_blueprint_type == BuiltinDataTypes.OBJECT.value:
+    if minimum_blueprint_type == BuiltinDataTypes.OBJECT.value:
+        return True
+    if minimum_blueprint_type == blueprint_type:
+        return True
+    for inherited_type in get_blueprint(blueprint_type).extends:
+        if is_blueprint_instance_of(minimum_blueprint_type, inherited_type, get_blueprint):
             return True
-        if minimum_blueprint_type == blueprint_type:
-            return True
-        for inherited_type in get_blueprint(blueprint_type).extends:
-            if is_blueprint_instance_of(minimum_blueprint_type, inherited_type, get_blueprint):
-                return True
-    except ApplicationException as ex:
-        logger.warn(ex)
-        return False
     return False
 
 

--- a/src/enums.py
+++ b/src/enums.py
@@ -41,6 +41,7 @@ class StorageDataTypes(str, Enum):
 
 
 class SIMOS(Enum):
+    ENUM = "dmss://system/SIMOS/Enum"
     BLUEPRINT = "dmss://system/SIMOS/Blueprint"
     STORAGE_RECIPE = "dmss://system/SIMOS/StorageRecipe"
     STORAGE_ATTRIBUTE = "dmss://system/SIMOS/StorageAttribute"

--- a/src/storage/repositories/mongo.py
+++ b/src/storage/repositories/mongo.py
@@ -2,7 +2,7 @@ from time import sleep
 
 import gridfs
 from pymongo import MongoClient
-from pymongo.errors import DuplicateKeyError, WriteError
+from pymongo.errors import DuplicateKeyError, OperationFailure, WriteError
 
 from common.exceptions import BadRequestException, NotFoundException
 from common.utils.encryption import decrypt
@@ -65,7 +65,7 @@ class MongoDBClient(RepositoryInterface):
                 attempts += 1
                 response = self.blob_handler.put(blob, _id=uid)
                 return response
-            except WriteError as error:  # Likely caused by MongoDB rate limiting.
+            except (WriteError, OperationFailure) as error:  # Likely caused by MongoDB rate limiting.
                 logger.warning(f"Failed to upload blob (attempt: {attempts}), will retry:\n\t{error}")
                 sleep(2)
                 if attempts > 2:

--- a/src/tests/bdd/document/add_attribute_to_document.feature
+++ b/src/tests/bdd/document/add_attribute_to_document.feature
@@ -188,7 +188,7 @@ Feature: Add attribute to document
       """
       {
         "name": "SignalGeneratorJob",
-        "type": "CORE:Blueprint",
+        "type": "dmss://system/SIMOS/Blueprint",
         "description": "",
         "extends": [
           "dmss://data-source-name/root_package/JobHandler"


### PR DESCRIPTION
## What does this pull request change?
- BlueprintProvider has a custom 'get_document' implementation. This allows for some big performance optimizations.

## Why is this pull request needed?
- Drastically improves performance on getting blueprints on a cold cache. Approx 90% faster

## Issues related to this change:
performance
