### PR TITLE
perf: cache documents in 'resolve_document'

### DIFF
--- a/src/common/providers/address_resolver/address_resolver.py
+++ b/src/common/providers/address_resolver/address_resolver.py
@@ -17,22 +17,23 @@ def _resolve_path_items(
     data_source: DataSource,
     path_items: list[AttributeItem | QueryItem | IdItem],
     get_data_source: Callable,
+    cache: dict | None = None,
 ) -> tuple[list | dict, list[str], str]:
     if len(path_items) == 0 or isinstance(path_items[0], AttributeItem):
         raise NotFoundException(f"Invalid path_items {path_items}.")
-    entity, id = path_items[0].get_entry_point(data_source)
+    entity, id = path_items[0].get_entry_point(data_source, cache)
     path = [id]
     data_source_name = data_source.name
     for index, ref_item in enumerate(path_items[1:]):
         if isinstance(ref_item, IdItem):
             raise NotFoundException(f"Invalid path_items {path_items}.")
         entity, attribute = ref_item.get_child(
-            entity, path[0], data_source, get_data_source, resolve_address=resolve_address
+            entity, path[0], data_source, get_data_source, resolve_address=resolve_address, cache=cache
         )
         if is_reference(entity) and index < len(path_items) - 2:
             # Found a new document, use that as new starting point for the attribute path
             address = Address.from_relative(entity["address"], path[0], data_source.name)
-            resolved_reference = resolve_address(address, get_data_source)
+            resolved_reference = resolve_address(address, get_data_source, cache)
             path = [resolved_reference.document_id, *resolved_reference.attribute_path]
             data_source_name = resolved_reference.data_source_id
         else:
@@ -50,7 +51,7 @@ class ResolvedAddress:
     entity: dict | list
 
 
-def resolve_address(address: Address, get_data_source: Callable) -> ResolvedAddress:
+def resolve_address(address: Address, get_data_source: Callable, cache: dict | None = None) -> ResolvedAddress:
     """Resolve the address into a document.
 
     We extract data_source, document_id, attribute_path from the address and also find the document the
@@ -63,7 +64,7 @@ def resolve_address(address: Address, get_data_source: Callable) -> ResolvedAddr
 
     # The first reference item should always be a DataSourceItem
     data_source = get_data_source(address.data_source)
-    document, path, data_source = _resolve_path_items(data_source, path_items, get_data_source)
+    document, path, data_source = _resolve_path_items(data_source, path_items, get_data_source, cache)
 
     return ResolvedAddress(
         entity=document,

--- a/src/features/entity/use_cases/validate_existing_entity_use_case.py
+++ b/src/features/entity/use_cases/validate_existing_entity_use_case.py
@@ -2,15 +2,14 @@ from authentication.models import User
 from common.address import Address
 from common.entity.validators import validate_entity_against_self
 from common.exceptions import NotFoundException, ValidationException
-from common.tree.tree_node import Node
 from services.document_service.document_service import DocumentService
 
 
 def validate_existing_entity_use_case(address: str, user: User) -> str:
     document_service = DocumentService(user=user)
     try:
-        document_as_node: Node = document_service.get_document(Address.from_absolute(address), depth=500)
+        document, _ = document_service.resolve_document(Address.from_absolute(address), depth=500)
     except NotFoundException as ex:
         raise ValidationException(message=ex.message, debug=ex.debug, data=ex.data) from ex
-    validate_entity_against_self(document_as_node.entity, document_service.get_blueprint)
+    validate_entity_against_self(document, document_service.get_blueprint)
     return "OK"

--- a/src/services/document_service/document_service.py
+++ b/src/services/document_service/document_service.py
@@ -209,6 +209,8 @@ class DocumentService:
                     self.get_data_source,
                 )
 
+            document_cache: dict[str, dict] = {}
+
             # start resolving any references if depth > 1
             resolved_document: dict = resolve_references_in_entity(
                 resolved_address.entity,
@@ -218,6 +220,7 @@ class DocumentService:
                 depth=depth,
                 depth_count=1,
                 path=resolved_address.attribute_path,
+                cache=document_cache,
             )
             return resolved_document, resolved_address
         except (NotFoundException, ApplicationException) as e:
@@ -260,7 +263,8 @@ class DocumentService:
             raise ValidationException("Tried to remove a required attribute")
 
         data_source = self.repository_provider(address.data_source, self.user)
-        resolved_reference: ResolvedAddress = resolve_address(address, self.get_data_source)
+        document_cache: dict[str, dict] = {}
+        resolved_reference: ResolvedAddress = resolve_address(address, self.get_data_source, document_cache)
         # If the reference goes through a parent, get the parent document
         if resolved_reference.attribute_path:
             document = data_source.get(resolved_reference.document_id)


### PR DESCRIPTION
## What does this pull request change?
- When calling DocumentService.resolve_document(), a cache for documents are created. The cache lives for this request only.

## Why is this pull request needed?
- The cache stops DMSS fetching the same document from the data_source multiple times.
  This improved performance on some request from 82 seconds --> 18,7 seconds

## Issues related to this change:
perf
