### PR TITLE
feat: cache documents in redis

### DIFF
--- a/src/services/database.py
+++ b/src/services/database.py
@@ -4,3 +4,5 @@ data_source_db = RedisClient(0)
 personal_access_token_db = RedisClient(1)
 lookup_table_db = RedisClient(2)
 acl_lookup_db = RedisClient(3)
+document_cache = RedisClient(8)  # 5-6 are used by dm-job
+blob_cache = RedisClient(9)

--- a/src/storage/internal/redis_client.py
+++ b/src/storage/internal/redis_client.py
@@ -28,9 +28,9 @@ class RedisClient:
             return json.loads(value)
         return None
 
-    def set(self, key: str, value: dict) -> None:
+    def set(self, key: str, value: dict, ttl: int | None = None) -> None:
         try:
-            self.client.set(key, json.dumps(value))
+            self.client.set(key, json.dumps(value), ex=ttl)
         except DataError as e:
             raise ValueError(f"Failed to set key '{key}' with value '{value}'") from e
 

--- a/src/tests/unit/services/document_service/test_data_source_and_repositories.py
+++ b/src/tests/unit/services/document_service/test_data_source_and_repositories.py
@@ -89,6 +89,7 @@ class DataSourceTestCase(unittest.TestCase):
             user=test_user,
             repositories={"default": default_repo, "blob": blob_repo},
             acl_lookup_db=acl_lookup_db_mock,
+            document_cache=mock.Mock(),
         )
 
         self.mock_document_service.repository_provider = lambda *args: data_source
@@ -158,6 +159,7 @@ class DataSourceTestCase(unittest.TestCase):
             user=test_user,
             repositories={"default": default_repo, "blob": blob_repo},
             acl_lookup_db=acl_lookup_db_mock,
+            document_cache=mock.Mock(),
         )
 
         self.mock_document_service.repository_provider = lambda *args: data_source
@@ -230,6 +232,7 @@ class DataSourceTestCase(unittest.TestCase):
             user=test_user,
             repositories={"default": default_repo, "blob": blob_repo},
             acl_lookup_db=acl_lookup_db_mock,
+            document_cache=mock.Mock(),
         )
         self.mock_document_service.repository_provider = lambda *args: data_source
         self.mock_document_service.user = test_user


### PR DESCRIPTION
## What does this pull request change?
- Cache documents in redis (implemented in DataSource)

## Why is this pull request needed?

Loading of a analysis (ULS) goes from 15sec to ~600ms


## Issues related to this change:
perf