### PR TITLE
feat: refresh existing application lookup

### DIFF
--- a/src/domain_classes/lookup.py
+++ b/src/domain_classes/lookup.py
@@ -32,6 +32,7 @@ class Lookup(BaseModel):
     )
     initial_ui_recipes: dict[str, Recipe | None] = Field(default_factory=lambda: {}, alias="initialUiRecipes")
     extends: dict[str, list[str]] = {}
+    paths: list[str] | None = None
 
     def realize_extends(self):
         new_ui_recipes = {}

--- a/src/features/lookup_table/lookup_table_feature.py
+++ b/src/features/lookup_table/lookup_table_feature.py
@@ -9,6 +9,7 @@ from features.lookup_table.use_cases.create_lookup_table import (
     create_lookup_table_use_case,
 )
 from features.lookup_table.use_cases.get_lookup_table import get_lookup_table_use_case
+from features.lookup_table.use_cases.refresh_lookup_table import refresh_lookup_table_use_case
 
 router = APIRouter(tags=["default", "lookup-table"])
 
@@ -46,7 +47,7 @@ def create_lookup(
 @router.get(
     "/application/{application}",
     operation_id="get_lookup",
-    response_model=Lookup,
+    response_model=None,
     responses={**responses},
 )
 @create_response(JSONResponse)
@@ -64,3 +65,23 @@ def get_lookup(application: str, user: User = Depends(auth_w_jwt_or_pat)):
     - dict: The recipe lookup table for the provided application.
     """
     return get_lookup_table_use_case(application, user)
+
+
+@router.post(
+    "/application/{application}/refresh",
+    operation_id="refresh_lookup",
+    response_model=Lookup,
+    responses={**responses},
+)
+@create_response(JSONResponse)
+def refresh_lookup(application: str, user: User = Depends(auth_w_jwt_or_pat)):
+    """Recreate an existing Recipe Lookup Table for an Application. For example, after updating the recipe links.
+
+    Args:
+    - application (str): The name of the application to recreate.
+    - user (User): The authenticated user accessing the endpoint, automatically generated from provided bearer token or Access-Key.
+
+    Returns:
+    - void
+    """
+    return refresh_lookup_table_use_case(application, user)

--- a/src/features/lookup_table/use_cases/create_lookup_table.py
+++ b/src/features/lookup_table/use_cases/create_lookup_table.py
@@ -20,7 +20,6 @@ def create_lookup_table_use_case(
     assert_user_has_access(AccessControlList.default(), AccessLevel.WRITE, user)
 
     document_service = DocumentService(user=user)
-    lookup_class_attributes = list(Lookup.__annotations__.keys())
     combined_lookup = Lookup().dict()
     for path in recipe_package_paths:
         recipe_package = document_service.get_document(Address(*path.split("/", 1)[::-1]), depth=999)
@@ -62,9 +61,10 @@ def create_lookup_table_use_case(
         lookup.realize_extends()
 
         lookup_as_dict = lookup.dict()
-        for attribute in lookup_class_attributes:
+        for attribute in ["ui_recipes", "storage_recipes", "initial_ui_recipes", "extends"]:
             combined_lookup[attribute].update(lookup_as_dict[attribute])
 
+    combined_lookup["paths"] = recipe_package_paths
     insert_lookup(name, combined_lookup)
 
     get_lookup.cache_clear()

--- a/src/features/lookup_table/use_cases/refresh_lookup_table.py
+++ b/src/features/lookup_table/use_cases/refresh_lookup_table.py
@@ -1,0 +1,10 @@
+from authentication.access_control import AccessControlList, assert_user_has_access
+from authentication.models import AccessLevel, User
+from features.lookup_table.use_cases.create_lookup_table import create_lookup_table_use_case
+from storage.internal.lookup_tables import get_lookup
+
+
+def refresh_lookup_table_use_case(lookup_id: str, user: User) -> None:
+    assert_user_has_access(AccessControlList.default(), AccessLevel.WRITE, user)
+    paths = get_lookup(lookup_id).paths
+    return create_lookup_table_use_case(paths, lookup_id, user)

--- a/src/tests/bdd/create_lookup.feature
+++ b/src/tests/bdd/create_lookup.feature
@@ -141,7 +141,8 @@ Feature: Create a lookup table
       "initial_ui_recipes": {
         "_default_": null
       },
-      "extends": {}
+      "extends": {},
+      "paths": ["test-DS/root_package/recipe_links"]
     }
     """
     Given i access the resource url "/api/application/test-DS?recipe_package=test-DS/root_package/recipe_links&recipe_package=test-DS/root_package/more_recipe_links"
@@ -193,10 +194,10 @@ Feature: Create a lookup table
         "_default_": null,
         "dmss://system/SIMOS/NamedEntity": null
       },
-      "extends": {}
+      "extends": {},
+      "paths": ["test-DS/root_package/recipe_links", "test-DS/root_package/more_recipe_links"]
     }
     """
-
 
   Scenario: System admins want to replace an existing recipe lookup (test-DS/root_package/recipe_links) with a new one (test-DS/root_package/more_recipe_links)
     Given i access the resource url "/api/application/test-DS?recipe_package=test-DS/root_package/recipe_links"
@@ -231,7 +232,8 @@ Feature: Create a lookup table
       "initial_ui_recipes": {
         "_default_": null
       },
-      "extends": {}
+      "extends": {},
+      "paths": ["test-DS/root_package/recipe_links"]
     }
     """
     Given i access the resource url "/api/application/test-DS?recipe_package=test-DS/root_package/more_recipe_links"
@@ -266,7 +268,99 @@ Feature: Create a lookup table
       "initial_ui_recipes": {
         "dmss://system/SIMOS/NamedEntity": null
       },
-      "extends": {}
+      "extends": {},
+      "paths": ["test-DS/root_package/more_recipe_links"]
+    }
+    """
+
+  Scenario: System admins want to recreate an existing recipe lookup after updating the default ui_recipe
+    Given i access the resource url "/api/application/test-DS?recipe_package=test-DS/root_package/recipe_links"
+    When i make a "POST" request
+    Then the response status should be "No Content"
+    Given i access the resource url "/api/application/test-DS"
+    When i make a "GET" request
+    Then the response status should be "OK"
+    And the response should be
+    """
+    {
+      "ui_recipes": {
+        "_default_": [
+          {
+            "name": "Edit",
+            "type": "dmss://system/SIMOS/UiRecipe",
+            "attributes": [],
+            "description": "",
+            "plugin": "@development-framework/dm-core-plugins/form",
+            "category": "edit",
+            "roles": null,
+            "config": null,
+            "label": "",
+            "dimensions": "",
+            "showRefreshButton": false
+          }
+        ]
+      },
+      "storage_recipes": {
+        "_default_": []
+      },
+      "initial_ui_recipes": {
+        "_default_": null
+      },
+      "extends": {},
+      "paths": ["test-DS/root_package/recipe_links"]
+    }
+    """
+    Given i access the resource url "/api/documents/test-DS/$102"
+    When i make a form-data "PUT" request
+      """
+      {"data":       {
+        "type": "dmss://system/SIMOS/RecipeLink",
+        "_blueprintPath_": "_default_",
+        "uiRecipes": [
+          {
+            "name": "THIS CHANGED",
+            "type": "dmss://system/SIMOS/UiRecipe",
+            "plugin": "SOME OTHER PLUGIN",
+            "category": "edit"
+          }
+        ]
+      }}
+      """
+    Then the response status should be "OK"
+    Given i access the resource url "/api/application/test-DS/refresh"
+    When i make a "POST" request
+    Then the response status should be "OK"
+    Given i access the resource url "/api/application/test-DS"
+    When i make a "GET" request
+    Then the response status should be "OK"
+    And the response should be
+    """
+    {
+      "ui_recipes": {
+        "_default_": [
+          {
+            "name": "THIS CHANGED",
+            "type": "dmss://system/SIMOS/UiRecipe",
+            "attributes": [],
+            "description": "",
+            "plugin": "SOME OTHER PLUGIN",
+            "category": "edit",
+            "roles": null,
+            "config": null,
+            "label": "",
+            "dimensions": "",
+            "showRefreshButton": false
+          }
+        ]
+      },
+      "storage_recipes": {
+        "_default_": []
+      },
+      "initial_ui_recipes": {
+        "_default_": null
+      },
+      "extends": {},
+      "paths": ["test-DS/root_package/recipe_links"]
     }
     """
 


### PR DESCRIPTION
## What does this pull request change?
- Adds endpoint to refresh existing "application recipe lookup"

## Issues related to this change:
needed for https://github.com/equinor/dm-core-packages/issues/1410