### PR TITLE
fix: invalidate BP cache on blueprint updates

### DIFF
--- a/src/common/providers/blueprint_provider.py
+++ b/src/common/providers/blueprint_provider.py
@@ -116,6 +116,7 @@ class BlueprintProvider:
     def invalidate_cache(self):
         try:
             logger.debug("invalidate cache")
+            self.prefetched_blueprints = {}
             self.get_blueprint.cache_clear()
             self.get_blueprint_with_extended_attributes.cache_clear()
         except Exception as error:

--- a/src/services/document_service/document_service.py
+++ b/src/services/document_service/document_service.py
@@ -74,7 +74,7 @@ class DocumentService:
         return create_default_storage_recipe()
 
     def invalidate_cache(self):
-        pass
+        self._blueprint_provider.invalidate_cache()
 
     def save_blob_data(self, node: Node, repository: DataSource) -> dict:
         """


### PR DESCRIPTION
## What does this pull request change?
Pop cache on blueprint updates 

## Why is this pull request needed?
- Blueprint cache should be reset on changes to blueprints

## Issues related to this change:
closes #858 