### PR TITLE
refactor: use poetery v2

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -33,7 +33,7 @@ jobs:
         run: |
           pip install poetry
           poetry config virtualenvs.in-project true
-          poetry install
+          poetry install --no-root
           pre-commit install --install-hooks
 
       - name: Run pre-commit

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,10 +23,10 @@ USER 1000
 RUN poetry config virtualenvs.in-project true
 
 FROM base AS development
-RUN poetry install
+RUN poetry install --no-root
 COPY /src/.behaverc ./src/.behaverc
 COPY src ./src
 
 FROM base AS prod
-RUN poetry install --no-dev
+RUN poetry install --no-root --without dev
 COPY src ./src

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,12 @@
-[tool.poetry]
-name = "Data Modeling Storage Service"
+[project]
+name = "data-modeling-storage-service"
 version = "1.28.0" # x-release-please-version
 description = "A model based storage service"
-authors = ["Stig Ofstad <stoo@equinor.com>","Christoffer","Eirik"]
-license = "MIT"
+authors = [ { name = "Stig Ofstad", email = "stoo@equinor.com" }, { name = "Christopher Collin Løkken", email = "chcl@equinor.com" }, { name = "Eirik Ola Aksnes", email = "eaks@equinor.com" }]
+license = { text = "MIT" }
+
+[tool.poetry]
+requires-poetry = ">=2.0"
 
 [tool.poetry.dependencies]
 python = "^3.12"
@@ -85,5 +88,5 @@ check_untyped_defs = true
 allow_redefinition = true
 
 [build-system]
-requires = ["poetry-core>=1.0.0"]
+requires = ["poetry-core>=2.0.0"]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
## What does this pull request change?
Tries to update pyproject.toml to use poetry v2 format

## Why is this pull request needed?
Broken build
```
Error: The current project could not be installed: No file/folder found for package data-modeling-storage-service
If you do not want to install the current project use --no-root.
If you want to use Poetry only for dependency management but not for packaging, you can disable package mode by setting package-mode = false in your pyproject.toml file.
If you did intend to install the current project, you may need to set `packages` in your pyproject.toml file.
```
