### PR TITLE
fix: missing blueprint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-slim AS base
+FROM --platform=linux/amd64 python:3.12-slim AS base
 WORKDIR /code
 ENTRYPOINT ["/code/src/init.sh"]
 CMD ["api"]

--- a/src/common/providers/blueprint_provider.py
+++ b/src/common/providers/blueprint_provider.py
@@ -90,7 +90,12 @@ class BlueprintProvider:
             address = Address.from_absolute(type)
             data_source = self.get_data_source_cached(address.data_source)
             path_elements = address.path.split("/")
-            root_package = data_source.find({"name": path_elements[0], "type": SIMOS.PACKAGE.value, "isRoot": True})
+            query = {"name": path_elements[0], "type": SIMOS.PACKAGE.value, "isRoot": True}
+            root_package = data_source.find(query)
+            if not root_package:
+                # Sometimes the find query returns an empty list,
+                # even if the package exists, so need to call find query twice.
+                root_package = data_source.find(query)
             if not root_package:
                 raise NotFoundException(f"Could not find root package '{path_elements[0]}'")
             if len(root_package) > 1:

--- a/src/storage/repositories/mongo.py
+++ b/src/storage/repositories/mongo.py
@@ -28,8 +28,7 @@ class MongoDBClient(RepositoryInterface):
             username=username,
             password=decrypt(password),
             tls=tls,
-            connectTimeoutMS=5000,
-            serverSelectionTimeoutMS=5000,
+            serverSelectionTimeoutMS=90000,
             retryWrites=False,
         )[database]
         self.blob_handler = gridfs.GridFS(self.handler)


### PR DESCRIPTION
## What does this pull request change?

Fix this error that happens during the reset application.

<img width="613" alt="image" src="https://github.com/user-attachments/assets/b81047ef-5685-4548-bb04-33044ae44aa0" />

## Why is this pull request needed?

The not-so-obvious solution - sometimes the find query inside `BlueprintProvider` returns an empty result, even if the package exists, but if you call it twice it works!

I also adjusted the Mongo `serverSelectionTimeoutMS` and removed the `connectTimeoutMS` to avoid connections problems we have in reset application scripts.

## Issues related to this change:
